### PR TITLE
NXP-22989: moves dialog to nuxeo-document-edit-button

### DIFF
--- a/elements/document/nuxeo-document-edit.html
+++ b/elements/document/nuxeo-document-edit.html
@@ -17,9 +17,7 @@ limitations under the License.
 
 <link rel="import" href="../../bower_components/polymer/polymer.html">
 <link rel="import" href="../../bower_components/nuxeo-elements/nuxeo-document.html">
-<link rel="import" href="../../bower_components/nuxeo-ui-elements/widgets/nuxeo-dialog.html">
 <link rel="import" href="../../bower_components/paper-button/paper-button.html">
-<link rel="import" href="../../bower_components/paper-dialog-scrollable/paper-dialog-scrollable.html">
 <link rel="import" href="nuxeo-document-layout.html">
 
 <!--
@@ -30,6 +28,18 @@ limitations under the License.
 <dom-module id="nuxeo-document-edit">
   <template>
     <style>
+      .actions {
+        @apply(--buttons-bar);
+        @apply(--layout-horizontal);
+        @apply(--layout-flex);
+        @apply(--layout-justified);
+      }
+
+      .scrollable {
+        padding: 0 24px;
+        max-height: 60vh;
+        @apply(--layout-scroll);
+      }
 
       ::content nuxeo-directory-suggestion,
       ::content paper-input-container {
@@ -44,6 +54,18 @@ limitations under the License.
         width: 100%;
       }
 
+      ::content select {
+        background: none #fff;
+        border: 1px solid #c6c6c6;
+        border-radius: 3px;
+        box-shadow: 0 1px 1px rgba(0, 0, 0, 0.07) inset;
+        box-sizing: border-box;
+        display: block;
+        padding: 0.5em;
+        width: 100%;
+        margin-bottom: 8px;
+      }
+
       ::content *[role=widget] {
         @apply(--layout-vertical);
         box-sizing: border-box;
@@ -53,17 +75,15 @@ limitations under the License.
 
     <nuxeo-document id="doc" doc-id="[[document.uid]]" response="{{document}}" headers="[[headers]]"></nuxeo-document>
 
-    <nuxeo-dialog id="edit-dialog" no-auto-focus with-backdrop>
-      <paper-dialog-scrollable>
-        <form id="form" is="iron-form">
-          <nuxeo-document-layout id="document-edit" document="{{document}}" layout="edit"></nuxeo-document-layout>
-        </form>
-      </paper-dialog-scrollable>
-      <div class="buttons">
+    <form id="form" is="iron-form">
+      <div class="scrollable">
+        <nuxeo-document-layout id="document-edit" document="{{document}}" layout="edit"></nuxeo-document-layout>
+      </div>
+      <div class="actions">
         <paper-button on-tap="_cancel" noink>[[i18n('command.cancel')]]</paper-button>
         <paper-button id="save" on-tap="_save" noink class="primary">[[i18n('command.save')]]</paper-button>
       </div>
-    </nuxeo-dialog>
+    </form>
 
   </template>
   <script>
@@ -97,10 +117,6 @@ limitations under the License.
         };
       },
 
-      toggle: function() {
-        this.$['edit-dialog'].toggle();
-      },
-
       _validate: function() {
         // run our custom validation function first to allow setting custom native validity
         var valid = this.$['document-edit'].validate();
@@ -124,15 +140,11 @@ limitations under the License.
           properties: this._dirtyProperties
         };
 
-        this.$.doc.put().then(function() {
-          this._refresh();
-          this.toggle();
-        }.bind(this));
+        this.$.doc.put().then(this._refresh.bind(this));
       },
 
       _cancel: function() {
         this._refresh();
-        this.toggle();
       },
 
       _refresh: function() {

--- a/elements/elements.html
+++ b/elements/elements.html
@@ -256,7 +256,7 @@ limitations under the License.
 <link rel="import" href="../bower_components/nuxeo-ui-elements/actions/nuxeo-export-button.html">
 <link rel="import" href="../bower_components/nuxeo-ui-elements/actions/nuxeo-download-button.html">
 <link rel="import" href="nuxeo-document-actions/nuxeo-clipboard-toggle-button.html">
-<link rel="import" href="nuxeo-document-actions/nuxeo-document-edit-action.html">
+<link rel="import" href="nuxeo-document-actions/nuxeo-document-edit-button.html">
 
 <link rel="import" href="../bower_components/nuxeo-ui-elements/nuxeo-format-behavior.html">
 <link rel="import" href="../bower_components/nuxeo-ui-elements/actions/nuxeo-preview-button.html">

--- a/elements/nuxeo-document-actions/nuxeo-document-edit-button.html
+++ b/elements/nuxeo-document-actions/nuxeo-document-edit-button.html
@@ -18,34 +18,46 @@ limitations under the License.
 <link rel="import" href="../../bower_components/polymer/polymer.html">
 <link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../../bower_components/paper-tooltip/paper-tooltip.html">
+<link rel="import" href="../../bower_components/paper-dialog-scrollable/paper-dialog-scrollable.html">
 <link rel="import" href="../../bower_components/nuxeo-ui-elements/nuxeo-i18n-behavior.html">
 <link rel="import" href="../../bower_components/nuxeo-ui-elements/nuxeo-filters-behavior.html">
+<link rel="import" href="../../bower_components/nuxeo-ui-elements/widgets/nuxeo-dialog.html">
 <link rel="import" href="../document/nuxeo-document-edit.html">
 
 <!--
 `nuxeo-document-edit-action`
 @group Nuxeo UI
-@element nuxeo-document-edit-action
+@element nuxeo-document-edit-button
 -->
-<dom-module id="nuxeo-document-edit-action">
+<dom-module id="nuxeo-document-edit-button">
   <template>
     <style>
       :host {
         display: inline-block;
       }
+
+      .container {
+        margin: 0;
+        padding: 24px 0 0 0;
+      }
     </style>
 
     <template is="dom-if" if="[[_isAvailable(document)]]">
-      <paper-icon-button noink id="edit" icon="nuxeo:edit" on-tap="_showEdit"></paper-icon-button>
+      <paper-icon-button noink id="edit" icon="nuxeo:edit" on-tap="_openDialog"></paper-icon-button>
       <paper-tooltip>[[i18n('documentEditAction.tooltip')]]</paper-tooltip>
     </template>
 
-    <nuxeo-document-edit id="dialog" document="[[document]]"></nuxeo-document-edit>
+    <nuxeo-dialog id="edit-dialog" no-auto-focus with-backdrop modal>
+      <div class="container">
+        <nuxeo-document-edit id="dialog" document="[[document]]"
+                             on-document-updated="_closeDialog"></nuxeo-document-edit>
+      </div>
+    </nuxeo-dialog>
 
   </template>
   <script>
     Polymer({
-      is: 'nuxeo-document-edit-action',
+      is: 'nuxeo-document-edit-button',
       behaviors: [Nuxeo.I18nBehavior, Nuxeo.FiltersBehavior],
       properties: {
 
@@ -61,8 +73,12 @@ limitations under the License.
         return this.document;
       },
 
-      _showEdit: function() {
-        this.$.dialog.toggle();
+      _openDialog: function() {
+        this.$['edit-dialog'].open();
+      },
+
+      _closeDialog: function() {
+        this.$['edit-dialog'].close();
       }
     });
   </script>

--- a/elements/nuxeo-web-ui-bundle.html
+++ b/elements/nuxeo-web-ui-bundle.html
@@ -181,7 +181,7 @@
 
 <nuxeo-slot-content name="editDocumentAction" slot="DOCUMENT_ACTIONS" order="10">
   <template>
-    <nuxeo-document-edit-action document="[[document]]"></nuxeo-document-edit-action>
+    <nuxeo-document-edit-button document="[[document]]"></nuxeo-document-edit-button>
   </template>
 </nuxeo-slot-content>
 


### PR DESCRIPTION
restores the previous version of `nuxeo-document-edit`, just adding the div class="scrollable" .

renames `nuxeo-document-edit-action` to `nuxeo-document-edit-button`
