### PR TITLE
NXP-24711: fix create and import forms not submitting on enter press

### DIFF
--- a/elements/document/nuxeo-document-create.html
+++ b/elements/document/nuxeo-document-create.html
@@ -363,10 +363,8 @@ limitations under the License.
         });
       },
 
-      _submitKeyHandler: function(e) {
-        if (e.detail.keyboardEvent.target.tagName === 'INPUT') {
-          this._create();
-        }
+      _submitKeyHandler: function() {
+        this._create();
       },
 
       _canCreate: function() {

--- a/elements/document/nuxeo-document-import.html
+++ b/elements/document/nuxeo-document-import.html
@@ -1254,11 +1254,11 @@ limitations under the License.
         });
       },
 
-      _submitKeyHandler: function(e) {
+      _submitKeyHandler: function() {
         if (this.stage === 'upload' && this._canImport()) {
           this._import();
         }
-        if (this.stage === 'customize' && e.detail.keyboardEvent.target.tagName === 'INPUT') {
+        if (this.stage === 'customize') {
           if (this._hasNextFile()) {
             this._nextFile();
           } else if (this._canImportWithMetadata()) {


### PR DESCRIPTION
The check `e.detail.keyboardEvent.target.tagName === 'INPUT'` is removed as it doesn't work anymore. Currently the `tagName` returns `NUXEO-DOCUMENT-LAYOUT` instead of `INPUT`. The `_submitKeyHandler` method should only be triggered by pressing the enter key from an element inside the form, so it seems to be unnecessary to check for the tag name. Will backport to the `9.10` branch when (and if) this PR is approved.