### PR TITLE
NXP-24972: include cloud services and authorized apps on elements.html

### DIFF
--- a/elements/elements.html
+++ b/elements/elements.html
@@ -272,3 +272,7 @@ limitations under the License.
 
 <!-- Mobile redirection -->
 <link rel="import" href="nuxeo-mobile/nuxeo-mobile-banner.html">
+
+<!-- User Settings -->
+<link rel="import" href="nuxeo-user-authorized-apps.html">
+<link rel="import" href="nuxeo-user-cloud-services.html">


### PR DESCRIPTION
Please let me know if there's a more appropriate location other than at the end of `elements.html`.