### PR TITLE
NXP-25082: Add missing translated documentAttachments.empty key

### DIFF
--- a/i18n/messages-de.json
+++ b/i18n/messages-de.json
@@ -277,6 +277,7 @@
   "displayModeButton.display.grid": "Zu Rasteransicht wechseln",
   "displayModeButton.display.list": "Auf Listenansicht wechseln",
   "displayModeButton.display.table": "Zu Tabellenansicht wechseln",
+  "documentAttachments.empty": "Es sind keine Anhänge vorhanden",
   "documentAttachments.heading": "Anhänge",
   "documentAttachments.upload.uploaded": "Anlage(n) hochgeladen",
   "documentContentView.datatable.header.author": "Autor",

--- a/i18n/messages-es-ES.json
+++ b/i18n/messages-es-ES.json
@@ -277,6 +277,7 @@
   "displayModeButton.display.grid": "Cambiar a vista de cuadrícula",
   "displayModeButton.display.list": "Switch to List view",
   "displayModeButton.display.table": "Cambiar a la vista de tabla",
+  "documentAttachments.empty": "No hay archivos adjuntos",
   "documentAttachments.heading": "Ficheros adjuntos",
   "documentAttachments.upload.uploaded": "Anexo(s) subido(s)",
   "documentContentView.datatable.header.author": "Autor",

--- a/i18n/messages-eu.json
+++ b/i18n/messages-eu.json
@@ -265,6 +265,7 @@
   "displayModeButton.display.grid": "Switch to Grid View",
   "displayModeButton.display.list": "Switch to List view",
   "displayModeButton.display.table": "Switch to Table View",
+  "documentAttachments.empty": "Ez dago eranskinik",
   "documentAttachments.heading": "Attachments",
   "documentAttachments.upload.uploaded": "Attachment(s) uploaded",
   "documentContentView.datatable.header.author": "Author",

--- a/i18n/messages-fr.json
+++ b/i18n/messages-fr.json
@@ -277,6 +277,7 @@
   "displayModeButton.display.grid": "Passer en vue grille",
   "displayModeButton.display.list": "Passer en vue liste",
   "displayModeButton.display.table": "Passer en vue tableau",
+  "documentAttachments.empty": "Il n'y a pas de pièces jointes.",
   "documentAttachments.heading": "Fichiers complémentaires",
   "documentAttachments.upload.uploaded": "Fichier complémentaire ajouté",
   "documentContentView.datatable.header.author": "Contributeur",

--- a/i18n/messages-ja.json
+++ b/i18n/messages-ja.json
@@ -277,6 +277,7 @@
   "displayModeButton.display.grid": "グリッドビューに切り替える",
   "displayModeButton.display.list": "一覧表示に切り替え",
   "displayModeButton.display.table": "表ビューに切り替える",
+  "documentAttachments.empty": "添付ファイルがありません。",
   "documentAttachments.heading": "添付ファイル",
   "documentAttachments.upload.uploaded": "添付ファイルアップロード済み",
   "documentContentView.datatable.header.author": "作成者",

--- a/i18n/messages-pt-PT.json
+++ b/i18n/messages-pt-PT.json
@@ -265,6 +265,7 @@
   "displayModeButton.display.grid": "Alterne para modo de exibição de grade",
   "displayModeButton.display.list": "Switch to List view",
   "displayModeButton.display.table": "Alterne para modo de exibição de tabela",
+  "documentAttachments.empty": "Não existem anexos",
   "documentAttachments.heading": "Anexos",
   "documentAttachments.upload.uploaded": "Anexo(s) carregado(s)",
   "documentContentView.datatable.header.author": "Autor",

--- a/i18n/messages-sv-SE.json
+++ b/i18n/messages-sv-SE.json
@@ -277,6 +277,7 @@
   "displayModeButton.display.grid": "Växla till rutnätsvy",
   "displayModeButton.display.list": "Switch to List view",
   "displayModeButton.display.table": "Växla till tabellvy",
+  "documentAttachments.empty": "Det finns inga bilagor",
   "documentAttachments.heading": "Bilagor",
   "documentAttachments.upload.uploaded": "Bilaga/bilagor laddades upp",
   "documentContentView.datatable.header.author": "Författare",


### PR DESCRIPTION
Despite the i18n/messages-eu.json being totally in english, the key was backported in the correct language.