### PR TITLE
NXP-25700: add cache service worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bower_components
 node_modules
 npm-debug.log
 dist
+workbox
 .swp
 .tmp
 .publish

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,6 +105,10 @@ gulp.task('polymer-build', function() {
   });
 });
 
+gulp.task('workbox-sw', function() {
+  return gulp.src('workbox/**').pipe(gulp.dest(dist('workbox')));
+});
+
 // Move from 'elements' folder to root
 gulp.task('move-elements', function() {
   // copy user-group-management layouts
@@ -154,6 +158,7 @@ gulp.task('build', ['clean'], function(cb) {
       'merge-message-files',
       'polymer-build',
       'move-elements',
+      'workbox-sw',
       'strip',
       cb);
 });

--- a/index.html
+++ b/index.html
@@ -86,6 +86,16 @@ limitations under the License.
 
   <!-- Web UI default contributions -->
   <link rel="import" href="elements/nuxeo-web-ui-bundle.html">
+
+  <!--
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', function () {
+        navigator.serviceWorker.register('sw.js');
+      });
+    }
+  </script>
+  -->
 </body>
 
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -24,5 +24,6 @@
       }],
   "background_color": "#ffffff",
   "display": "standalone",
-  "theme_color": "#ffffff"
+  "theme_color": "#ffffff",
+  "start_url": "."
 }

--- a/package.json
+++ b/package.json
@@ -36,12 +36,14 @@
     "polymer-cli": "1.6.0",
     "polyserve": "^0.27.11",
     "run-sequence": "^1.1.5",
-    "through2": "^2.0.1"
+    "through2": "^2.0.1",
+    "workbox-cli": "^3.4.1"
   },
   "scripts": {
     "start": "gulp serve",
     "lint": "gulp lint && polymer lint -i elements/*/*.html",
-    "win-lint": "gulp lint && polymer lint -i elements\\*\\*.html"
+    "win-lint": "gulp lint && polymer lint -i elements\\*\\*.html",
+    "postinstall": "workbox copyLibraries . && mv workbox-v`npm view workbox-cli version` workbox"
   },
   "engines": {
     "node": ">=6.4.0"

--- a/polymer.json
+++ b/polymer.json
@@ -11,6 +11,7 @@
     "bower.json"
   ],
   "extraDependencies": [
+    "sw.js",
     "manifest.json",
     "index.css",
     "bower_components/webcomponentsjs/*",

--- a/src/main/resources/OSGI-INF/browser-cache-contrib.xml
+++ b/src/main/resources/OSGI-INF/browser-cache-contrib.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0"?>
 <component name="org.nuxeo.web.ui.request.contrib">
 
+  <require>org.nuxeo.ecm.platform.web.common.requestcontroller.service.RequestControllerService.defaultContrib</require>
+
   <extension target="org.nuxeo.ecm.platform.web.common.requestcontroller.service.RequestControllerService"
     point="filterConfig">
-    <!-- All Web UI resources cached for 24 hours -->
-    <!-- Trade off between agressive caching and HF applying within 24 hours -->
+    <filterConfig name="cached_ui_static" cached="true" cacheTime="31536000">
+      <!-- if url contains a timestamp param: approximately one year -->
+      <pattern>${org.nuxeo.ecm.contextPath}/ui/.*\\?.*ts=.+</pattern>
+    </filterConfig>
     <filterConfig name="ui_static" cached="true" cacheTime="86400">
-      <pattern>${org.nuxeo.ecm.contextPath}/ui/.+</pattern>
+      <!-- For other web ui resources: trade off between agressive caching and HF applying within 24 hours -->
+      <!-- Exclude JS and HTML files due to: https://jira.nuxeo.com/browse/NXP-25595 -->
+      <pattern>${org.nuxeo.ecm.contextPath}/ui/.*\.(?!(html|js)$).*</pattern>
     </filterConfig>
   </extension>
+
 </component>

--- a/src/main/resources/web/nuxeo.war/ui/index.jsp
+++ b/src/main/resources/web/nuxeo.war/ui/index.jsp
@@ -16,6 +16,7 @@ limitations under the License.
 -->
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.List"%>
+<%@ page import="java.lang.management.ManagementFactory"%>
 <%@ page import="org.nuxeo.common.Environment"%>
 <%@ page import="org.nuxeo.runtime.api.Framework"%>
 <%@ page import="org.nuxeo.ecm.web.resources.api.Resource"%>
@@ -27,7 +28,6 @@ limitations under the License.
 <% WebResourceManager wrm = Framework.getService(WebResourceManager.class); %>
 <% RepositoryManager rm = Framework.getService(RepositoryManager.class); %>
 <% String ua = request.getHeader("user-agent"); %>
-
 <!DOCTYPE html>
 <html lang="">
 
@@ -94,6 +94,16 @@ limitations under the License.
 
   <% for (Resource resource : wrm.getResources(new ResourceContextImpl(), "web-ui", "import")) { %>
   <link rel="import" href="<%= request.getContextPath() %><%= resource.getURI() %>">
+  <% } %>
+
+  <% if (!Framework.isDevModeSet()) { %>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', function () {
+        navigator.serviceWorker.register('sw.js?ts=<%= ManagementFactory.getRuntimeMXBean().getStartTime() %>');
+      });
+    }
+  </script>
   <% } %>
 </body>
 

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,17 @@
+importScripts('workbox/workbox-sw.js');
+
+workbox.setConfig({ modulePathPrefix: 'workbox/' });
+
+const params = new URL(self.location.href).searchParams;
+
+if (params.has('ts')) {
+  workbox.routing.registerRoute(/\.*\.(html|js)$/, async ({url, event}) => {
+    const strategy = workbox.strategies.networkFirst();
+    const request = new Request(`${url}?ts=${params.get('ts')}`, {credentials: 'same-origin'});
+    return await strategy.makeRequest({event, request});
+  });
+}
+
+self.addEventListener('install', event => {
+  self.skipWaiting();
+});


### PR DESCRIPTION
SW on dev mode only so no need for reload timestamp as hotreload is dev mode only.
SW matching js and html files for agressive caching of these. Other resources are not dynamically loaded so they rely on default static cache (which is disable for js and html files).
SW does network first so it hits browser cache (no stale responses unless offline).