### PR TITLE
NXP-25344: Use CSS variables and fix nuxeo-suggester display on mobile

### DIFF
--- a/elements/nuxeo-suggester/nuxeo-suggester.html
+++ b/elements/nuxeo-suggester/nuxeo-suggester.html
@@ -149,6 +149,10 @@ limitations under the License.
         @apply --layout-vertical;
       }
 
+      .item .details {
+        min-width: 1px;
+      }
+
       .item + .item {
         border-top: 1px solid var(--nuxeo-border);
       }
@@ -210,8 +214,8 @@ limitations under the License.
         }
 
         paper-input {
-          width: calc(100% - 90px);
-          margin-left: 1.2rem;
+          width: var(--nuxeo-suggester-media-width, calc(100% - 90px));
+          margin-left: var(--nuxeo-suggester-media-margin-left, 1.2rem);
         }
 
         #results {

--- a/themes/base.html
+++ b/themes/base.html
@@ -527,6 +527,12 @@ limitations under the License.
       position: relative;
       top: var(--nuxeo-app-top);
     };
+
+    --nuxeo-suggester-width: 65%;
+
+    --nuxeo-suggester-media-width: calc(100% - 90px);
+
+    --nuxeo-suggester-media-margin-left: 1.2rem;
   }
 
   @media (max-width: 1024px) {


### PR DESCRIPTION
Not really sure about the aim of this task, so I add 2 new variables in the default theme for the `paper-input` element, and I fixed a display bug on mobile when the result title is long. For that second point, you can find more informations here: https://css-tricks.com/flexbox-truncated-text/