### PR TITLE
NXP-25524: add missing label for easyshare dialog

### DIFF
--- a/i18n/messages.json
+++ b/i18n/messages.json
@@ -477,6 +477,7 @@
   "dropzone.progress": "Uploading...",
   "dropzone.uploaded": "File uploaded",
   "dublincoreEdit.directorySuggestion.placeholder": "Select a value.",
+  "easyshare.copy.label": "Copy the link and share the document {0}.",
   "easysharefolder.notification":"Active Notification",
   "easysharefolder.contactEmail":"Email",
   "easysharefolder.share":"Share public link to {0}",


### PR DESCRIPTION
Related to: https://github.com/nuxeo/nuxeo-easyshare/pull/36