### PR TITLE
NXP-25939: Reverse starting order on document diff

### DIFF
--- a/elements/diff/nuxeo-diff.js
+++ b/elements/diff/nuxeo-diff.js
@@ -408,9 +408,9 @@ Polymer({
         this._hasVersions = this.documents.some(function(doc) {
           return doc.isVersion;
         });
-        this.rightUid = null; // prevent accidental comparison with an old document
-        this.leftUid = this.documents[0].uid;
-        this.rightUid = this.documents[1].uid;
+        this.leftUid = null; // prevent accidental comparison with an old document
+        this.leftUid = this.documents[1].uid;
+        this.rightUid = this.documents[0].uid;
       }.bind(this));
     }
   },


### PR DESCRIPTION
The specifications of this task was not really clear, so I assumed that the diff page should always display the current version on the right screen, and the previous one on the left screen. So if the current version is not the last one, the versions following the current one will not be displayed.