### PR TITLE
NXP-26854: remove obsolete contribution.

### DIFF
--- a/elements/nuxeo-web-ui-bundle.html
+++ b/elements/nuxeo-web-ui-bundle.html
@@ -512,11 +512,6 @@
     <nuxeo-collections name="collections" id="collectionsForm"></nuxeo-collections>
   </template>
 </nuxeo-slot-content>
-<nuxeo-slot-content name="collectionsPage" slot="PAGES">
-  <template>
-    <nuxeo-collection-results name="collection" id="collectionResults" on-navigate="_navigateFromCollection"></nuxeo-collection-results>
-  </template>
-</nuxeo-slot-content>
 
 <nuxeo-slot-content name="personalWorkspaceDrawerItem" slot="DRAWER_ITEMS" order="80">
   <template>


### PR DESCRIPTION
The `nuxeo-collection-results` element does not exist since 0.10