### PR TITLE
NXP-26429: Improve error handling / permissions on CSV import

### DIFF
--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -565,7 +565,7 @@ Polymer({
             icon="nuxeo:admin"
             label="app.administration"
             class="admin-icon"
-            hidden$="[[!_hasAdministrationPermissions(currentUser)]]"
+            hidden$="[[!hasAdministrationPermissions(currentUser)]]"
           >
           </nuxeo-menu-icon>
           <nuxeo-menu-icon
@@ -589,7 +589,7 @@ Polymer({
           >
             <nuxeo-slot slot="DRAWER_PAGES" model="[[actionContext]]"></nuxeo-slot>
 
-            <template is="dom-if" if="[[_hasAdministrationPermissions(currentUser)]]">
+            <template is="dom-if" if="[[hasAdministrationPermissions(currentUser)]]">
               <div name="administration">
                 <div class="header">[[i18n('app.administration')]]</div>
                 <iron-selector selected="{{selectedAdminTab}}" attr-for-selected="name">
@@ -1344,10 +1344,6 @@ Polymer({
         this.i18n(documents.length === 1 ? 'app.document.addedToCollection' : 'app.documents.addedToCollection'),
       );
     });
-  },
-
-  _hasAdministrationPermissions(user) {
-    return user.isAdministrator || this.isMember(user, 'powerusers');
   },
 
   _errorUrl() {

--- a/elements/nuxeo-document-create-popup/nuxeo-document-create-popup.js
+++ b/elements/nuxeo-document-create-popup/nuxeo-document-create-popup.js
@@ -219,8 +219,10 @@ Polymer({
   _parentPathChanged(e) {
     if (
       e.detail.isValidTargetPath &&
-      (!this.parent || (this.parentPath && this.parent.path !== this.parentPath.replace(/(.+)\/$/, '$1')))
+      (!this.parent || (e.detail.parentPath && this.parent.path !== e.detail.parentPath.replace(/(.+)\/$/, '$1')))
     ) {
+      this.parentPath = e.detail.parentPath;
+      this.suggesterChildren = e.detail.suggesterChildren;
       this.$.defaultDoc.get();
     }
   },

--- a/elements/nuxeo-document-creation/nuxeo-document-creation-behavior.js
+++ b/elements/nuxeo-document-creation/nuxeo-document-creation-behavior.js
@@ -144,7 +144,11 @@ export const DocumentCreationBehavior = [
         (this.suggesterParent ? this.targetPath.replace(/(.+)\/$/, '$1') === this.suggesterParent.path : false) ||
         (this.suggesterChildren ? this.suggesterChildren.some((child) => this.targetPath === child.path) : false);
       this.set('isValidTargetPath', valid);
-      this.fire('nx-document-creation-suggester-parent-changed', { isValidTargetPath: valid });
+      this.fire('nx-document-creation-suggester-parent-changed', {
+        isValidTargetPath: valid,
+        parentPath: this.targetPath,
+        suggesterChildren: this.suggesterChildren,
+      });
     },
 
     _validateLocation() {


### PR DESCRIPTION
this fix is related to https://jira.nuxeo.com/browse/NXP-26429, and mainly on https://jira.nuxeo.com/browse/NXP-26429?focusedCommentId=386657&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-386657

_Error message on the path suggester should not appear if user has write permission_ : to solve this issue i duplicate some code in `nuxeo-document-import-csv.js` from `nuxeo-document-create-popup.js` to be able to update the parent property and the whole validation is ensured by the behaviour `nuxeo-document-creation-behavior.js`.

But unfortunately we end up with a duplicated code, to solve the problem caused by the two way binding when we add an extension to exiting slot.

with @guirenard we worked on a 2nd solution (https://github.com/nuxeo/nuxeo-web-ui/tree/fix-NXP-26429-csvPopup) avoiding the duplicated code,  we simulate the two way binding by setting manually the properties   
`this.parentPath = e.detail.parentPath;`
 `this.suggesterChildren = e.detail.suggesterChildren;`


_Apply Date, Author and Dublin Core properties should not be available to non-admins
disable the option_ : waiting for https://jira.nuxeo.com/browse/ELEMENTS-946