### PR TITLE
NXP-27037: ellipses and tooltip on document type create form

### DIFF
--- a/elements/document/nuxeo-document-create.js
+++ b/elements/document/nuxeo-document-create.js
@@ -27,6 +27,7 @@ import '@polymer/paper-spinner/paper-spinner-lite.js';
 import '@polymer/iron-icon/iron-icon.js';
 import '@polymer/iron-a11y-keys/iron-a11y-keys.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-path-suggestion/nuxeo-path-suggestion.js';
+import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-tooltip';
 import '@nuxeo/nuxeo-elements/nuxeo-document.js';
 import '../nuxeo-document-creation-stats/nuxeo-document-creation-stats.js';
 import './nuxeo-document-layout.js';
@@ -82,9 +83,31 @@ Polymer({
         box-shadow: 0 0 10px rgba(0, 0, 0, 0.3), 0 -3px 0 var(--nuxeo-link-hover-color) inset;
       }
 
-      .typeSelection iron-icon {
+      .typeIconWrapper {
+        display: flex;
+        flex: 1.5;
+        align-items: flex-end;
+      }
+
+      .typeIcon {
         width: var(--nuxeo-document-creation-form-icon-width, 42px);
         height: var(--nuxeo-document-creation-form-icon-height, 42px);
+      }
+
+      .typeLabelWrapper {
+        display: flex;
+        flex: 1;
+        align-items: flex-start;
+      }
+
+      .typeLabel {
+        width: 100%;
+        margin-top: 1em;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        word-break: break-word;
+        line-height: normal;
       }
 
       .container {
@@ -114,11 +137,6 @@ Polymer({
         width: 1.2rem;
         height: 1.2rem;
         margin-right: 8px;
-      }
-
-      .typeSelection div {
-        margin-top: 1em;
-        word-break: break-word;
       }
 
       .buttons {
@@ -188,8 +206,13 @@ Polymer({
                   on-tap="_selectType"
                   data-args$="[[type]]"
                 >
-                  <iron-icon src="[[_getTypeIcon(type)]]"></iron-icon>
-                  <div>[[_getTypeLabel(type)]]</div>
+                  <div class="typeIconWrapper">
+                    <iron-icon class="typeIcon" src="[[_getTypeIcon(type)]]"></iron-icon>
+                  </div>
+                  <div class="typeLabelWrapper">
+                    <div class="typeLabel">[[_getTypeLabel(type)]]</div>
+                    <nuxeo-tooltip>[[_getTypeLabel(type)]]</nuxeo-tooltip>
+                  </div>
                 </paper-button>
               </template>
             </div>

--- a/elements/document/nuxeo-document-create.js
+++ b/elements/document/nuxeo-document-create.js
@@ -70,10 +70,13 @@ Polymer({
         max-width: 128px;
         height: 128px;
         margin: 4px;
+        padding: 4px;
         border: none;
         text-align: center;
         box-shadow: none;
         background-color: var(--nuxeo-dialog-buttons-bar);
+        @apply --layout-vertical;
+        @apply --nuxeo-document-create-selection-button;
       }
 
       .typeSelection paper-button:hover {
@@ -83,31 +86,23 @@ Polymer({
         box-shadow: 0 0 10px rgba(0, 0, 0, 0.3), 0 -3px 0 var(--nuxeo-link-hover-color) inset;
       }
 
-      .typeIconWrapper {
-        display: flex;
-        flex: 1.5;
-        align-items: flex-end;
-      }
-
       .typeIcon {
+        /* These variables are deprecated. Instead, use the mixin bellow */
         width: var(--nuxeo-document-creation-form-icon-width, 42px);
         height: var(--nuxeo-document-creation-form-icon-height, 42px);
-      }
-
-      .typeLabelWrapper {
-        display: flex;
-        flex: 1;
-        align-items: flex-start;
+        @apply --nuxeo-document-create-selection-icon;
       }
 
       .typeLabel {
         width: 100%;
         margin-top: 1em;
         overflow: hidden;
+        line-height: normal;
         text-overflow: ellipsis;
+        text-align: center;
         white-space: nowrap;
         word-break: break-word;
-        line-height: normal;
+        @apply --nuxeo-document-create-selection-label;
       }
 
       .container {
@@ -202,17 +197,13 @@ Polymer({
                 <paper-button
                   noink
                   name$="[[type.type]]"
-                  class="docTypeButton vertical layout"
+                  class="docTypeButton"
                   on-tap="_selectType"
                   data-args$="[[type]]"
                 >
-                  <div class="typeIconWrapper">
-                    <iron-icon class="typeIcon" src="[[_getTypeIcon(type)]]"></iron-icon>
-                  </div>
-                  <div class="typeLabelWrapper">
-                    <div class="typeLabel">[[_getTypeLabel(type)]]</div>
-                    <nuxeo-tooltip>[[_getTypeLabel(type)]]</nuxeo-tooltip>
-                  </div>
+                  <iron-icon class="typeIcon" src="[[_getTypeIcon(type)]]"></iron-icon>
+                  <div class="typeLabel">[[_getTypeLabel(type)]]</div>
+                  <nuxeo-tooltip>[[_getTypeLabel(type)]]</nuxeo-tooltip>
                 </paper-button>
               </template>
             </div>


### PR DESCRIPTION
This branch has 3 commits but it is the second one that I want to discuss with you.

In [NXP-27037](https://jira.nuxeo.com/browse/NXP-27037) we are asked to maintain two lines with ellipsis. I'm proposing `-webkit-line-clamp` to solve this question. The only place where it isn't supported now is Firefox 67, but it is already working on Firefox Nightly [(check it out here)](https://caniuse.com/#search=webkit-line-clamp). 

Today, the expected behaviour on Firefox 67 is simply the omission of the rest of the text. Do you think this could be a good solution?