### PR TITLE
NXP-27264: add nuxeo-web-ui/dev builder image

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,17 @@
+FROM node:lts
+
+RUN npm config set @nuxeo:registry=https://mavenin.nuxeo.com/nexus/repository/npmjs-nuxeo
+
+WORKDIR /ui
+
+# Copy package.json and install dependencies
+COPY package*.json ./
+
+RUN npm install
+
+# Copy application source code
+COPY . .
+
+EXPOSE 5000
+
+CMD ["npm", "start"]

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -19,6 +19,18 @@ build:
           - --insecure
           - --insecure-pull
           - --insecure-registry=${DOCKER_REGISTRY}
+    - image: nuxeo-web-ui/dev
+      context: .
+      kaniko:
+        dockerfile: Dockerfile.dev
+        buildArgs:
+          DOCKER_REGISTRY: ${DOCKER_REGISTRY}
+        buildContext:
+          localDir: {}
+        flags:
+          - --insecure
+          - --insecure-pull
+          - --insecure-registry=${DOCKER_REGISTRY}
     - image: nuxeo-web-ui
       context: .
       kaniko:


### PR DESCRIPTION
Goal of this image is to allow usage when developing. ie for a custom addon:
```
version: "3"
services:
  webui:
    image: nuxeo-web-ui/dev
    environment:
      - NUXEO_PACKAGES=nuxeo-dam mine
    volumes:
      - .:/ui/addons/mine:ro
  nuxeo:
    image: nuxeo/nuxeo:10.10
    environment:
      - NUXEO_PACKAGES=nuxeo-dam
```
Here's a sample use case for usage as a builder image https://github.com/nelsonsilva/nuxeo-nightly

