### PR TITLE
NXP-28785: compare audit comment using regex

### DIFF
--- a/elements/nuxeo-document-history/nuxeo-document-history.js
+++ b/elements/nuxeo-document-history/nuxeo-document-history.js
@@ -81,7 +81,7 @@ Polymer({
         </nuxeo-data-table-column>
         <nuxeo-data-table-column name="[[i18n('documentHistory.comment')]]">
           <template>
-            <a href$="[[_parseComment(item.comment)]]">[[item.comment]]</a>
+            <a href$="[[_parseComment(item.comment)]]">[[_formatComment(item.comment)]]</a>
           </template>
         </nuxeo-data-table-column>
         <nuxeo-data-table-column name="[[i18n('documentHistory.state')]]">
@@ -163,11 +163,19 @@ Polymer({
     return this.i18n(`activity.${key}`);
   },
 
+  // XXX: Both parse and format methods shouldn't be needed after NXP-28820
   _parseComment(comment) {
-    if (comment && /^(\w+):(\S+)$/.test(comment)) {
+    if (comment && /^\w+:(?:\w+-){2,}(?:\w+)$/.test(comment)) {
       // repoName:docId
       return this.urlFor('document', comment.split(':')[1]);
     }
     return null;
+  },
+
+  _formatComment(comment) {
+    if (moment(comment, moment.ISO_8601).isValid()) {
+      return this.formatDateTime(comment);
+    }
+    return comment;
   },
 });

--- a/elements/nuxeo-document-history/nuxeo-document-history.js
+++ b/elements/nuxeo-document-history/nuxeo-document-history.js
@@ -164,13 +164,9 @@ Polymer({
   },
 
   _parseComment(comment) {
-    if (comment) {
-      const split = comment.split(':');
-      if (split.length >= 2) {
-        // split[0] is repo name, split[1] is doc id
-        return this.urlFor('document', split[1]);
-      }
-      return null;
+    if (comment && /^(\w+):(\S+)$/.test(comment)) {
+      // repoName:docId
+      return this.urlFor('document', comment.split(':')[1]);
     }
     return null;
   },


### PR DESCRIPTION
The second commit is, in fact, a workaround for some limitations that we have on our event system.
Ideally, we would have information provided by the server to know which is the type of event's comment. Then we could have a formatter approach as we have for Diff.