### PR TITLE
NXP-28787: add missing translation label for Nuxeo Drive

### DIFF
--- a/addons/nuxeo-drive/elements/nuxeo-drive-sync-roots-management.js
+++ b/addons/nuxeo-drive/elements/nuxeo-drive-sync-roots-management.js
@@ -84,15 +84,15 @@ Polymer({
 
     <template is="dom-if" if="[[_empty(roots)]]">
       <div class="emptyResult">
-        [[i18n('driveSyncRootsManagement.roots.empty',"You currently don't have any synchronization root.")]]
+        [[i18n('driveSyncRootsManagement.roots.empty')]]
       </div>
     </template>
 
     <template is="dom-if" if="[[!_empty(roots)]]">
       <div class="table">
         <div class="header">
-          <div class="cell flex-1">[[i18n('driveSyncRootsManagement.root.name', 'Name')]]</div>
-          <div class="cell flex-3">[[i18n('driveSyncRootsManagement.root.path', 'Path')]]</div>
+          <div class="cell flex-1">[[i18n('driveSyncRootsManagement.root.name')]]</div>
+          <div class="cell flex-3">[[i18n('driveSyncRootsManagement.root.path')]]</div>
           <div class="cell"></div>
         </div>
         <template is="dom-repeat" items="[[roots]]" as="doc">
@@ -102,7 +102,7 @@ Polymer({
             <div class="cell actions">
               <paper-icon-button
                 icon="icons:clear"
-                title="[[i18n('driveSyncRootsManagement.root.disable', 'Disable)]]"
+                title="[[i18n('driveSyncRootsManagement.root.disable')]]"
                 on-tap="_disable"
               >
               </paper-icon-button>
@@ -113,7 +113,7 @@ Polymer({
     </template>
 
     <paper-toast id="toast"
-      >[[i18n('driveSyncRootsManagement.roots.disabled', 'Synchronization root disabled')]]</paper-toast
+      >[[i18n('driveSyncRootsManagement.roots.disabled')]]</paper-toast
     >
   `,
 

--- a/i18n/messages.json
+++ b/i18n/messages.json
@@ -524,6 +524,7 @@
   "drivePage.packages": "Packages",
   "drivePage.roots": "Synchronization Roots",
   "drivePage.tokens": "Tokens",
+  "driveSyncRootsManagement.root.disable": "Disable",
   "driveSyncRootsManagement.root.name": "Title",
   "driveSyncRootsManagement.root.path": "Path",
   "driveSyncRootsManagement.roots.disabled": "Synchronization root disabled",


### PR DESCRIPTION
The `driveSyncRootsManagement.root.disable` label was lost at some point.
Reintroducing it to solve the tooltip display on the delete button of a synchronized root.

It is used here: https://github.com/nuxeo/nuxeo-web-ui/blob/c7e67299e9c35803d8c25104324ba37e54787f4d/addons/nuxeo-drive/elements/nuxeo-drive-sync-roots-management.js#L103-L107

Signed-off-by: Mickaël Schoentgen <mschoentgen@nuxeo.com>