### PR TITLE
[10.10] NXP-28787: add missing translation label for Nuxeo Drive

### DIFF
--- a/i18n/messages.json
+++ b/i18n/messages.json
@@ -483,6 +483,7 @@
   "drivePage.packages": "Packages",
   "drivePage.roots": "Synchronization Roots",
   "drivePage.tokens": "Tokens",
+  "driveSyncRootsManagement.root.disable": "Disable",
   "driveSyncRootsManagement.root.name": "Title",
   "driveSyncRootsManagement.root.path": "Path",
   "driveSyncRootsManagement.roots.disabled": "Synchronization root disabled",


### PR DESCRIPTION
The `driveSyncRootsManagement.root.disable` label was lost at some point.
Reintroducing it to solve the tooltip display on the delete button of a synchronized root.

The JS code cleanup (+fix) is here: https://github.com/nuxeo/nuxeo/pull/3945