### PR TITLE
(WIP) NXP-28820: implement document history formater to display extended info

### DIFF
--- a/elements/nuxeo-audit/formatters/nuxeo-audit-extended-default-formatter.js
+++ b/elements/nuxeo-audit/formatters/nuxeo-audit-extended-default-formatter.js
@@ -1,0 +1,36 @@
+/**
+@license
+(C) Copyright Nuxeo Corp. (http://nuxeo.com/)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+
+class NuxeoAuditExtendedDefaultFormatter extends mixinBehaviors([], Nuxeo.Element) {
+  static get template() {
+    return html`
+      <span>[[_parseExtended(item)]]</span>
+    `;
+  }
+
+  static get is() {
+    return 'nuxeo-document-history-extended-default-formatter';
+  }
+
+  _parseExtended(item) {
+    return JSON.stringify(item.extended, null, '\t');
+  }
+}
+customElements.define(NuxeoAuditExtendedDefaultFormatter.is, NuxeoAuditExtendedDefaultFormatter);
+export default NuxeoAuditExtendedDefaultFormatter;

--- a/elements/nuxeo-audit/formatters/nuxeo-audit-extended-download-formatter.js
+++ b/elements/nuxeo-audit/formatters/nuxeo-audit-extended-download-formatter.js
@@ -1,0 +1,41 @@
+/**
+@license
+(C) Copyright Nuxeo Corp. (http://nuxeo.com/)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+
+class NuxeoAuditExtendedDownloadFormatter extends mixinBehaviors([], Nuxeo.Element) {
+  static get template() {
+    return html`
+      <p>[[_getDownloadType(item)]] by user</p>
+    `;
+  }
+
+  static get is() {
+    return 'nuxeo-audit-extended-download-formatter';
+  }
+
+  _getDownloadType(item) {
+    // obs: nuxeo default - may be different by user
+    // if blobXPath starts by file: then it's an explicit user download
+    // else, it's a view
+    return item.extended && item.extended.blobXPath && item.extended.blobXPath.split(':')[0] === 'file'
+      ? 'Downloaded'
+      : 'Viewed';
+  }
+}
+customElements.define(NuxeoAuditExtendedDownloadFormatter.is, NuxeoAuditExtendedDownloadFormatter);
+export default NuxeoAuditExtendedDownloadFormatter;

--- a/elements/nuxeo-audit/nuxeo-audit-extended-formatters.js
+++ b/elements/nuxeo-audit/nuxeo-audit-extended-formatters.js
@@ -1,0 +1,35 @@
+/**
+@license
+(C) Copyright Nuxeo Corp. (http://nuxeo.com/)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import DefaultAuditExtendedFormatter from './formatters/nuxeo-audit-extended-default-formatter.js';
+import DownloadAuditExtendedFormatter from './formatters/nuxeo-audit-extended-download-formatter.js';
+
+const FORMATTERS = {
+  default: DefaultAuditExtendedFormatter.is,
+  types: {
+    download: DownloadAuditExtendedFormatter.is,
+  },
+};
+
+const NuxeoAuditExtendedFormatters = {
+  register: (formatter, eventType) => {
+    FORMATTERS.types[eventType] = formatter;
+  },
+
+  get: (eventType) => FORMATTERS.types[eventType] || FORMATTERS.default,
+};
+
+export default NuxeoAuditExtendedFormatters;

--- a/elements/nuxeo-audit/nuxeo-audit-extended-info.js
+++ b/elements/nuxeo-audit/nuxeo-audit-extended-info.js
@@ -1,0 +1,45 @@
+/**
+@license
+(C) Copyright Nuxeo Corp. (http://nuxeo.com/)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import DocHistoryExtendedFormatters from './nuxeo-audit-extended-formatters.js';
+
+class NuxeoAuditExtendedInfo extends mixinBehaviors([], Nuxeo.Element) {
+  static get template() {
+    return html`
+      <style></style>
+      <div id="container"></div>
+    `;
+  }
+
+  static get is() {
+    return 'nuxeo-audit-extended-info';
+  }
+
+  static get observers() {
+    return ['_updateContainer(item)'];
+  }
+
+  _updateContainer(item) {
+    const formatter = DocHistoryExtendedFormatters.get(item.eventId);
+    this._instance = document.createElement(formatter);
+    this.$.container.appendChild(this._instance);
+    this._instance.item = this.item;
+  }
+}
+
+customElements.define(NuxeoAuditExtendedInfo.is, NuxeoAuditExtendedInfo);

--- a/elements/nuxeo-audit/nuxeo-audit-search.js
+++ b/elements/nuxeo-audit/nuxeo-audit-search.js
@@ -21,6 +21,7 @@ import { FormatBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-format-behavior.j
 import { RoutingBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-routing-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/actions/nuxeo-action-button-styles.js';
 import moment from '@nuxeo/moment';
+import './nuxeo-audit-extended-info.js';
 
 /**
 `nuxeo-audit-search`
@@ -85,7 +86,13 @@ class AuditSearch extends mixinBehaviors([FormatBehavior, RoutingBehavior], Nuxe
         </div>
       </nuxeo-card>
       <nuxeo-card>
-        <nuxeo-data-table id="table" paginable nx-provider="provider" empty-label="[[i18n('documentHistory.empty')]]">
+        <nuxeo-data-table
+          id="table"
+          details-enabled
+          paginable
+          nx-provider="provider"
+          empty-label="[[i18n('documentHistory.empty')]]"
+        >
           <nuxeo-data-table-column name="[[i18n('audit.performedAction')]]" sort-by="eventId">
             <template>[[_formati18n('eventType.', item.eventId)]]</template>
           </nuxeo-data-table-column>
@@ -114,6 +121,9 @@ class AuditSearch extends mixinBehaviors([FormatBehavior, RoutingBehavior], Nuxe
             <nuxeo-data-table-column name="[[i18n('audit.state')]]">
               <template><nuxeo-tag uppercase>[[formatLifecycleState(item.docLifeCycle)]]</nuxeo-tag></template>
             </nuxeo-data-table-column>
+          </template>
+          <template is="row-detail">
+            <nuxeo-audit-extended-info item="[[item]]"></nuxeo-audit-extended-info>
           </template>
         </nuxeo-data-table>
       </nuxeo-card>


### PR DESCRIPTION
PR open for feedback - the idea is to get each document history event, and depending on its event type, display extended info property accordingly - in practice this applies to download, cold storage, transfer, etc.