### PR TITLE
NXP-28338: show translated taskName instead of action in workflow analytics

### DIFF
--- a/elements/nuxeo-admin/nuxeo-workflow-analytics.js
+++ b/elements/nuxeo-admin/nuxeo-workflow-analytics.js
@@ -154,7 +154,7 @@ Polymer({
       <nuxeo-workflow-data
         workflow="[[workflow]]"
         event="afterWorkflowTaskEnded"
-        grouped-by="taskActor, action"
+        grouped-by="taskActor, taskName"
         start-date="[[startDate]]"
         end-date="[[_extendEndDate(endDate)]]"
         data="{{numberOfActionsPerUser}}"
@@ -226,7 +226,7 @@ Polymer({
       return [];
     }
     if (data.value) {
-      return data.value.map((obj) => obj.key);
+      return data.value.map((obj) => this.i18n(obj.key));
     }
     return this._labels(data[0]);
   },


### PR DESCRIPTION
Note: the `_labels` method is only used for this chart in particular, so we won't be translating labels elsewhere.
Will post a pipeline status ASAP.