### PR TITLE
NXP-29221: lock jsplumb version to 2.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "extend": "^3.0.2",
     "jquery": "^3.3.1",
     "jsondiffpatch": "^0.3.11",
-    "jsplumb": "^2.9.0",
+    "jsplumb": "2.13.0",
     "nuxeo": "^3.2.1",
     "select2": "~3.5.1",
     "three": "~0.81.0",


### PR DESCRIPTION
This issue is visible for the following `jsplumb` versions:
- `2.13.3` (latest)
- `2.13.2`
- `2.13.1`

On `2.13.0` (released 3 months ago) the connectors are properly drawn.