### PR TITLE
NXP-29241: fix the Direct Edit icon tooltip position

### DIFF
--- a/addons/nuxeo-drive/elements/nuxeo-drive-edit-button.js
+++ b/addons/nuxeo-drive/elements/nuxeo-drive-edit-button.js
@@ -36,7 +36,7 @@ Polymer({
       <div class="action" on-tap="_go">
         <paper-icon-button noink icon="icons:open-in-new" id="driveBtn"></paper-icon-button>
         <span class="label" hidden$="[[!showLabel]]">[[i18n('driveEditButton.tooltip')]]</span>
-        <paper-tooltip>[[i18n('driveEditButton.tooltip')]]</paper-tooltip>
+        <nuxeo-tooltip>[[i18n('driveEditButton.tooltip')]]</nuxeo-tooltip>
       </div>
     </template>
 

--- a/addons/nuxeo-drive/elements/nuxeo-drive-sync-toggle-button.js
+++ b/addons/nuxeo-drive/elements/nuxeo-drive-sync-toggle-button.js
@@ -48,7 +48,7 @@ Polymer({
       <div class="action" on-tap="toggle">
         <paper-icon-button id="syncBut" icon="[[_icon(synchronized)]]"></paper-icon-button>
         <span class="label" hidden$="[[!showLabel]]">[[_label]]</span>
-        <paper-tooltip>[[_label]]</paper-tooltip>
+        <nuxeo-tooltip>[[_label]]</nuxeo-tooltip>
       </div>
     </template>
   `,


### PR DESCRIPTION
Applies the same code change to the sync root icon to conform with other icons.

Before:
![0  before](https://user-images.githubusercontent.com/2033598/85299020-100b4900-b4a5-11ea-9c88-94989f7cb61f.png)

After:
![1  after](https://user-images.githubusercontent.com/2033598/85299030-113c7600-b4a5-11ea-9303-08e097d3a501.png)
