### PR TITLE
NXP-29305: force packages as npm registry

### DIFF
--- a/Jenkinsfiles/web-ui-pipeline.groovy
+++ b/Jenkinsfiles/web-ui-pipeline.groovy
@@ -112,7 +112,7 @@ timestamps {
                         if (webui || el || uiel || datavizel) {
                             echo 'Need to build nuxeo-web-ui'
                             dir('nuxeo-web-ui') {
-                                sh 'npm install --no-package-lock'
+                                sh 'npm install --no-package-lock --@nuxeo:registry="https://packages.nuxeo.com/repository/npm-public"'
                                 if (el) {
                                     sh "npm install --no-package-lock ../nuxeo-elements/core/${el}"
                                 }

--- a/plugin/web-ui/addon/build.xml
+++ b/plugin/web-ui/addon/build.xml
@@ -33,6 +33,8 @@ limitations under the License.
   <target name="install" description="Install npm depedencies" unless="skipInstall">
     <exec executable="${cmd.npm}" failonerror="true">
       <arg value="install" />
+      <!-- remove next line once NXBT-3340 is closed -->
+      <arg value="--@nuxeo:registry=&quot;https://packages.nuxeo.com/repository/npm-public&quot;" />
     </exec>
   </target>
 


### PR DESCRIPTION
This is a temporary measure to allow nightly build to go through. We would undo this as soon as we have continuous releases on Web UI and could move the nightly build to JX.