### PR TITLE
NXP-29347: nuxeo-document-task-assignment-popup outputs comment

### DIFF
--- a/elements/workflow/nuxeo-document-task-assignment-popup.js
+++ b/elements/workflow/nuxeo-document-task-assignment-popup.js
@@ -61,7 +61,7 @@ Polymer({
               id="commentText"
               label="[[i18n('tasks.assignment.comment')]]"
               placeholder="[[i18n('tasks.assignment.placeholder')]]"
-              value="[[comment]]"
+              value="{{comment}}"
               max-rows="4"
             >
             </nuxeo-textarea>


### PR DESCRIPTION
Changed value="[[comment]]" to value="{{comment}}" in nuxeo-textarea arguments, as this is an output rather than an input in this "screen".
Tested manually and successfully the change in LTS 2019