### PR TITLE
NXP-29210: rely on the current document id if available

### DIFF
--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -630,7 +630,8 @@ Polymer({
     if (this.page === 'search') {
       this._refreshSearch();
     } else if ((this.docPath && this.docPath.length > 0) || (this.docId && this.docId.length > 0)) {
-      this.load('browse', this.docId, this.docPath, this.docAction);
+      const id = this.docId || (this.currentDocument && this.currentDocument.uid);
+      this.load('browse', id, this.docPath, this.docAction);
     } else {
       this.navigateTo('home');
     }


### PR DESCRIPTION
The goal is to navigate to the document referenced by the action response. Additionally, we no longer rely on the `document-updated` event to close the dialog, so we now have two new (and more specific) events: `save` and `cancel`.