### PR TITLE
NXP-28889: fix navigation when document url contains newline characters

### DIFF
--- a/elements/routing.js
+++ b/elements/routing.js
@@ -45,7 +45,7 @@ customElements.whenDefined('nuxeo-app').then(() => {
   });
 
   // /browse/<path>@<action>
-  page(/\/browse\/(.*)?/, (data) => {
+  page(/\/browse\/(.*)?/s, (data) => {
     if (!data.state.contentView) {
       app.currentContentView = null;
     }


### PR DESCRIPTION
We need the `/.../s` flag for `.` to match with `\n` characters.