### PR TITLE
NXP-28889: fix navigation when document url contains newline characters (10.10)

### DIFF
--- a/elements/routing.html
+++ b/elements/routing.html
@@ -47,7 +47,7 @@ limitations under the License.
     });
 
     // /browse/<path>@<action>
-    page(/^\/browse\/(.*)?/, function(data) {
+    page(new RegExp(/^\/browse\/(.*)?/, 's'), function(data) {
       if (!data.state.contentView) {
         app.currentContentView = null;
       }


### PR DESCRIPTION
Backport of #977.