### PR TITLE
WEBUI-28: fix icon misalignment in create dialog

### DIFF
--- a/themes/base.js
+++ b/themes/base.js
@@ -557,7 +557,6 @@ const template = html`
         }
 
         --nx-button-icon: {
-          margin-inline-end: var(--nuxeo-button-icon-margin-end, 4px);
           width: 16px;
           height: 16px;
         }


### PR DESCRIPTION
Still to be discussed. The best solution should be to define the `--nuxeo-button-icon-margin-end` [instead ](https://github.com/nuxeo/nuxeo-web-ui/blob/0cab8027de899ec0bc1344136d40801daa5fed5f/themes/base.js#L560)