### PR TITLE
WEBUI-30: use npm-public as the default repo for nuxeo scoped packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@nuxeo:registry=https://packages.nuxeo.com/repository/npm-public/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -329,7 +329,7 @@ pipeline {
             def token = sh(script: 'jx step credential -s public-npm-token -k token', returnStdout: true).trim()
             sh "echo '//packages.nuxeo.com/repository/:_authToken=${token}' >> ~/.npmrc"
             dir('packages/nuxeo-web-ui-ftest') {
-              sh 'npm --registry=https://packages.nuxeo.com/repository/npm-public publish --tag SNAPSHOT'
+              sh 'npm publish --tag SNAPSHOT'
             }
           }
         }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Nuxeo Web UI is a standard base web application for Nuxeo Platform. It is highly
 ### Install dependencies
 
 ```sh
-npm config set @nuxeo:registry https://packages.nuxeo.com/repository/npm-public
 npm install
 ```
 


### PR DESCRIPTION
Depends on https://github.com/nuxeo/jx-webui-env/pull/21.