### PR TITLE
WEBUI-41: refresh clipboard based on content update

### DIFF
--- a/elements/nuxeo-clipboard/nuxeo-clipboard.js
+++ b/elements/nuxeo-clipboard/nuxeo-clipboard.js
@@ -172,7 +172,7 @@ Polymer({
             id="paste"
             on-tap="execute"
             data-op="Document.Copy"
-            disabled="[[!canPaste(documents, targetDocument)]]"
+            disabled="[[!canPaste(documents, targetDocument, documents.splices)]]"
             noink
             class="primary clear"
           >
@@ -184,7 +184,7 @@ Polymer({
             id="move"
             on-tap="execute"
             data-op="Document.Move"
-            disabled="[[!canPaste(documents, targetDocument)]]"
+            disabled="[[!canPaste(documents, targetDocument, documents.splices)]]"
             noink
             class="primary clear"
           >


### PR DESCRIPTION
Ok, I'm opening the PR for further discussion on the topic.
- `nuxeo-clipboard` is using the `nuxeo-document-storage` to store the documents in the clipboard. 
- `nuxeo-document-storage` is [updating](https://github.com/nuxeo/nuxeo-web-ui/blob/master/elements/nuxeo-document-storage/nuxeo-document-storage.js#L85) the `documents` array and [notifying](https://github.com/nuxeo/nuxeo-web-ui/blob/master/elements/nuxeo-document-storage/nuxeo-document-storage.js#L95) the `nuxeo-clipboard`
- However, `nuxeo-clipboard` is not listening to array splices or any update inside the `documents` property (`!canPaste(documents, targetDocument)` is only triggered when the `documents` changes).

What do you think would be a good approach to handle this? 
I thought about listening to splices (`documents.splices`) or even all updates (`documents.*`), but I am wondering what you usually do in similar cases.