### PR TITLE
WEBUI-44: enqueue debounce to prevent request cancelling.

### DIFF
--- a/elements/nuxeo-results/nuxeo-results.js
+++ b/elements/nuxeo-results/nuxeo-results.js
@@ -30,6 +30,8 @@ import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-sort-select.js';
 import '../nuxeo-selection/nuxeo-selection-toolbar.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { timeOut } from '@polymer/polymer/lib/utils/async.js';
+import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 
 /**
 An element to display results from a page provider.
@@ -395,20 +397,16 @@ Polymer({
 
   fetch() {
     return new Promise((resolve, error) => {
-      this.debounce(
-        'fetch',
-        () => {
-          if (this.view) {
-            this.view
-              .fetch()
-              .then(resolve)
-              .catch(error);
-          } else {
-            resolve();
-          }
-        },
-        100,
-      );
+      this._fetchDebouncer = Debouncer.debounce(this._fetchDebouncer, timeOut.after(100), () => {
+        if (this.view) {
+          this.view
+            .fetch()
+            .then(resolve)
+            .catch(error);
+        } else {
+          resolve();
+        }
+      });
     });
   },
 


### PR DESCRIPTION
Don't see an easy option for this one. The problem is caused by two elements ([nuxeo-search-form](https://github.com/nuxeo/nuxeo-web-ui/blob/master/elements/search/nuxeo-search-form.js#L922) and [nuxeo-results](https://github.com/nuxeo/nuxeo-web-ui/blob/master/elements/nuxeo-results/nuxeo-results.js#L454)) performing a `fetch` in the page provider which debounces requests. 

The debounce itself is not bad, but if the request made by the `nuxeo-search-form` is canceled because the `nuxeo-results` performs another request due to a `view change`, then we get this issue. The `nuxeo-search-form` expects the request to resolve to [remove the loading state](https://github.com/nuxeo/nuxeo-web-ui/blob/master/elements/search/nuxeo-search-form.js#L925).

Feedback is very welcome 😄 