### PR TITLE
WEBUI-102: validate comment's text type (10.10)

### DIFF
--- a/elements/nuxeo-document-comments/nuxeo-document-comment.html
+++ b/elements/nuxeo-document-comments/nuxeo-document-comment.html
@@ -326,7 +326,7 @@ limitations under the License.
       },
 
       _computeTruncatedFlag: function(showFull, text, limit) {
-        return !showFull && text.length > limit;
+        return !showFull && typeof text === 'string' && text.length > limit;
       },
 
       /** Visibility Methods **/


### PR DESCRIPTION
Backporting a fix already on master done under comment's migration to elements.

Pipeline ran multiple times with random/different errors each time 🤦🏼‍♂️ 