### PR TITLE
WEBUI-137: update gulp-imagemin to fix minification of pdfjs viewer from elements (10.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "gulp-html-extract": "^0.0.3",
     "gulp-html-minifier": "^0.1.8",
     "gulp-if": "^2.0.0",
-    "gulp-imagemin": "^2.4.0",
+    "gulp-imagemin": "^7.1.0",
     "gulp-load-plugins": "^1.1.0",
     "gulp-merge-json": "^0.6.0",
     "gulp-minify-html": "^1.0.4",


### PR DESCRIPTION
Required for ELEMENTS-1248.