### PR TITLE
WEBUI-189: handle a password on easyshare

### DIFF
--- a/addons/easyshare/document/easysharefolder/nuxeo-easysharefolder-create-layout.html
+++ b/addons/easyshare/document/easysharefolder/nuxeo-easysharefolder-create-layout.html
@@ -49,7 +49,10 @@ limitations under the License.
     >
     </nuxeo-date-picker>
 
-    <paper-checkbox noink name="notification" checked$="{{document.properties.eshare:hasNotification}}">
+    <paper-checkbox
+      noink
+      name="notification"
+      checked$="{{document.properties.eshare:hasNotification}}">
       [[i18n('easysharefolder.notification')]]
     </paper-checkbox>
 
@@ -61,6 +64,24 @@ limitations under the License.
       value="{{document.properties.eshare:contactEmail}}"
     >
     </nuxeo-input>
+
+    <paper-checkbox
+      noink
+      name="accessCodeRequired"
+      checked="{{document.properties.eshare:accessCodeRequired}}"
+      id="accessCodeRequired">
+      [[i18n('easysharefolder.accessCodeRequired')]]
+    </paper-checkbox>
+
+    <nuxeo-input
+      role="widget"
+      label="[[i18n('easysharefolder.accessCode')]]"
+      id="accessCode"
+      name="accessCode"
+      value="{{document.properties.eshare:accessCode}}"
+      required="[[document.properties.eshare:accessCodeRequired]]">
+    </nuxeo-input>
+
   </template>
   <script>
     Polymer({

--- a/addons/easyshare/document/easysharefolder/nuxeo-easysharefolder-edit-layout.html
+++ b/addons/easyshare/document/easysharefolder/nuxeo-easysharefolder-edit-layout.html
@@ -49,7 +49,10 @@ limitations under the License.
     >
     </nuxeo-date-picker>
 
-    <paper-checkbox noink name="notification" checked="{{document.properties.eshare:hasNotification}}">
+    <paper-checkbox
+      noink
+      name="notification"
+      checked="{{document.properties.eshare:hasNotification}}">
       [[i18n('easysharefolder.notification')]]
     </paper-checkbox>
 
@@ -61,6 +64,24 @@ limitations under the License.
       value="{{document.properties.eshare:contactEmail}}"
     >
     </nuxeo-input>
+
+    <paper-checkbox
+      noink
+      name="accessCodeRequired"
+      checked="{{document.properties.eshare:accessCodeRequired}}"
+      id="accessCodeRequired">
+      [[i18n('easysharefolder.accessCodeRequired')]]
+    </paper-checkbox>
+
+    <nuxeo-input
+      role="widget"
+      label="[[i18n('easysharefolder.accessCode')]]"
+      id="accessCode"
+      name="accessCode"
+      value="{{document.properties.eshare:accessCode}}"
+      required="{{document.properties.eshare:accessCodeRequired}}">
+    </nuxeo-input>
+
   </template>
   <script>
     Polymer({

--- a/addons/easyshare/document/easysharefolder/nuxeo-easysharefolder-metadata-layout.html
+++ b/addons/easyshare/document/easysharefolder/nuxeo-easysharefolder-metadata-layout.html
@@ -71,6 +71,18 @@ limitations under the License.
       <label>[[i18n('easysharefolder.contactEmail')]]</label>
       <div name="email">[[document.properties.eshare:contactEmail]]</div>
     </div>
+
+   <div role="widget" hidden$="[[!document.properties.eshare:accessCodeRequired]]">
+      <paper-checkbox name="accessCodeRequired" checked$="[[document.properties.eshare:accessCodeRequired]]"
+        noink disabled>
+        [[i18n('easysharefolder.accessCodeRequired')]]
+      </paper-checkbox>
+    </div>
+
+    <div role="widget" hidden$="[[!document.properties.eshare:accessCode]]">
+      <label>[[i18n('easysharefolder.accessCode')]]</label>
+      <div name="accessCode">[[document.properties.eshare:accessCode]]</div>
+    </div>    
   </template>
   <script>
     Polymer({

--- a/i18n/messages.json
+++ b/i18n/messages.json
@@ -533,6 +533,8 @@
   "easyshare.copy.label": "Internal Access link to {0}.",
   "easysharefolder.notification": "Active Notification",
   "easysharefolder.contactEmail": "Email",
+  "easysharefolder.accessCodeRequired": "Access code required ?",
+  "easysharefolder.accessCode": "Access code",
   "easysharefolder.share": "Public EasyShare link to {0}",
   "eventCategory.document_review_approbation": "Relation",
   "eventCategory.eventDocumentCategory": "Document",


### PR DESCRIPTION
Features :
- Secure Easyshare shared folder with a password from Web-UI available on creation or edit layouts

- On a secured Easyshare shared folder, when a « public » end-user is accessing a secured Easyshare shared folder, it will be prompt the accessCode

- If the « public » end-user entered the defined accessCode, he will have access to the shared folder content from the current browser. 
=> Some extra informations will be added the your browser URL
=> These extra informations are mandatory once connected and cannot be removed or shared to other « public » end-users (these informations are dynamically changed on each call with a matching based on browser JSESSIONID so using another browser will imply to re-enter accessCode or share it, notice it’s not working with Incognito session on Browsers)

- AccessCode is controled on each call that means if you change your accessCode in the EasyShare folder, previously connected users will be disconnected and prompted a new AccessCode

1.	Core/WebUI update

Two new metadatas as accessCodeRequired (Boolean) and accessCode (String) value added to existing easyshare schema (updated XSD)

WebUI Layouts (creation /edit) and JSF layout (creation/edit)
- Checkbox for accessCodeRequired metadata to activate password requirement on public EasyShare access
- Input text for accessCode to provide a password

Translation available in English/US, French, German and Spanish to check

2. Easyshare "public" access is not changing with no password

If EasyShare folder has no password set, access to public Easyshare remains available (no access code required so public access will remain as current version of EasyShare).

3. Capacity of checking checkbox "Access code required ?" and setting password to secure access to an Easyshare collection

If checkbox is checked, password is mandatory

4. Easyshare "public" access will ask for a password (access code) if the collection has password protected access (checkbox checked).
In that case, the user is prompted to enter the password. 

5. If the right password is entered, the user will be able to navigate in the collection. Otherwise, he must re-enter the password.
Notice all links are available for end-users include 3 new dynamic url parameters (a, s and j). They are calculated on the fly, encrypted with default and generated salt and only available on the current browser.