### PR TITLE
WEBUI-132: enable remove from collection button when user has WriteProperties

### DIFF
--- a/elements/nuxeo-collections/nuxeo-collection-remove-action.js
+++ b/elements/nuxeo-collections/nuxeo-collection-remove-action.js
@@ -91,7 +91,7 @@ Polymer({
     if (collection && collection.contextParameters && collection.contextParameters.permissions) {
       // NXP-21408: prior to 8.10-HF01 the permissions enricher wouldn't return ReadCanCollect
       // Action will therefore not be available
-      return collection.contextParameters.permissions.indexOf('ReadCanCollect') > -1;
+      return collection.contextParameters.permissions.indexOf('WriteProperties') > -1;
     }
     return false;
   },


### PR DESCRIPTION
JSF UI is relying in the platform CollectionManager to assert if the user [can add/remove](https://github.com/nuxeo/nuxeo/blob/master/modules/platform/nuxeo-collections/src/main/java/org/nuxeo/ecm/collections/core/CollectionManagerImpl.java#L132) items from a collection. This checks if the user has the WriteProperties permission on the collection, and on Web UI we are only do the assertion for the [ReadCanCollect](https://github.com/nuxeo/nuxeo/blob/8ce732309dc35ebe6c53aa8e0dd52757e8faf74a/modules/platform/nuxeo-collections/src/main/resources/OSGI-INF/collection-security-contrib.xml#L9) permission (that includes both the Read and WriteProperties permissions). 
To make this consistent, we should check for the `WriteProperties` permission too.