### PR TITLE
WEBUI-265: automate a11y checks with axe-core

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,6 +146,9 @@ pipeline {
           dir('packages/nuxeo-web-ui-ftest') {
             sh 'npm install'
           }
+          dir('plugin/a11y') {
+            sh 'npm install'
+          }
           sh 'npm run lint'
         }
       }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "win-lint": "npm run win-lint:polymer && npm run lint:eslint && npm run lint:prettier",
     "format": "npm run format:polymer && npm run format:prettier && npm run format:eslint",
     "win-format": "npm run win-format:polymer && npm run format:prettier && npm run format:eslint",
-    "preinstall": "cd packages/nuxeo-web-ui-ftest && npm install",
+    "preinstall": "cd ./packages/nuxeo-web-ui-ftest && npm install && cd ../../plugin/a11y && npm install",
     "ftest": "node scripts/test-runner.js --report --screenshots --headless --tags='not @ignore'",
     "ftest:dev": "node scripts/test-runner.js --nuxeoUrl=http://localhost:8080/nuxeo --url=http://localhost:5000/",
     "ftest:watch": "node scripts/test-runner.js --nuxeoUrl=http://localhost:8080/nuxeo  --url=http://localhost:5000/ --tags='@watch' --debug",

--- a/plugin/a11y/.eslintrc
+++ b/plugin/a11y/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "globals": {
+    "$": true,
+    "browser": true,
+    "expect": true
+  }
+}

--- a/plugin/a11y/a11y.xml
+++ b/plugin/a11y/a11y.xml
@@ -1,0 +1,31 @@
+<project name="web-ui-webdriver-a11y" xmlns:nx="urn:nuxeo-build" xmlns:artifact="urn:nuxeo-artifact">
+  <taskdef resource="org/nuxeo/build/antlib.xml" uri="urn:nuxeo-build" />
+  <taskdef resource="org/nuxeo/build/artifact/antlib.xml" uri="urn:nuxeo-artifact" />
+  <taskdef resource="net/sf/antcontrib/antlib.xml" />
+
+  <property name="out.dir" value="${maven.project.build.directory}" />
+  <unzip dest="${out.dir}/" overwrite="false">
+    <artifact:resolveFile key="org.nuxeo:nuxeo-ftest::zip" />
+  </unzip>
+  <import file="${out.dir}/nuxeo-ftest.xml" />
+
+  <property name="mp.install" value="file:${out.dir}/nuxeo-web-ui-marketplace-${maven.project.version}.zip" />
+  <target name="prepare-environment" depends="_init,prepare-db,prepare-tomcat">
+    <copy todir="${out.dir}">
+      <artifact:file key="org.nuxeo.web.ui:nuxeo-web-ui-marketplace::zip" />
+    </copy>
+  </target>
+
+  <target name="run-bench" depends="_init">
+    <condition property="cmd.npm" value="npm.cmd" else="npm">
+      <os family="windows"/>
+    </condition>
+    <delete dir="node_modules" failonerror="true" />
+    <exec executable="${cmd.npm}" failonerror="true">
+      <arg value="install" />
+    </exec>
+    <exec executable="${cmd.npm}" failonerror="true">
+      <arg value="start" />
+    </exec>
+  </target>
+</project>

--- a/plugin/a11y/babel.config.js
+++ b/plugin/a11y/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          node: 'current',
+        },
+      },
+    ],
+  ],
+};

--- a/plugin/a11y/package.json
+++ b/plugin/a11y/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@nuxeo/nuxeo-web-ui-a11y",
+  "version": "1.0.0",
+  "engines": {
+    "node": ">=10.23.0"
+  },
+  "scripts": {
+    "start": "npm run test",
+    "test": "wdio wdio.conf.js",
+    "test:dev": "NUXEO_WEB_UI_URL=http://localhost:5000/ NUXEO_URL=http://localhost:8080/nuxeo/ wdio wdio.conf.js"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@nuxeo/nuxeo-web-ui-ftest": "file:../../packages/nuxeo-web-ui-ftest",
+    "axe-core": "^4.1.2"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.13.10",
+    "@babel/core": "^7.13.10",
+    "@babel/preset-env": "^7.13.10",
+    "@babel/register": "^7.13.8",
+    "@wdio/cli": "^7.0.7",
+    "@wdio/local-runner": "^7.0.7",
+    "@wdio/mocha-framework": "^7.0.7",
+    "@wdio/spec-reporter": "^7.0.7",
+    "@wdio/sync": "^7.0.7",
+    "chromedriver": "^88.0.0",
+    "wdio-chromedriver-service": "^7.0.0"
+  }
+}

--- a/plugin/a11y/pom.xml
+++ b/plugin/a11y/pom.xml
@@ -1,0 +1,101 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.nuxeo.web.ui</groupId>
+    <artifactId>nuxeo-web-ui-parent</artifactId>
+    <version>3.1.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>a11y</artifactId>
+  <packaging>pom</packaging>
+  <name>Nuxeo Web UI - a11y</name>
+  <description>Nuxeo Web UI - Accessibility</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.nuxeo.ecm.distribution</groupId>
+      <artifactId>nuxeo-server-tomcat</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.nuxeo.web.ui</groupId>
+      <artifactId>nuxeo-web-ui-marketplace</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.nuxeo.build</groupId>
+        <artifactId>ant-assembly-maven-plugin</artifactId>
+        <configuration>
+          <buildFile>${basedir}/a11y.xml</buildFile>
+        </configuration>
+        <executions>
+          <execution>
+            <id>start-nuxeo</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <targets>
+                <target>prepare-environment</target>
+                <target>start</target>
+              </targets>
+            </configuration>
+          </execution>
+          <execution>
+            <id>run-tests</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <target>run-bench</target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>stop-nuxeo</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <targets>
+                <target>stop</target>
+                <target>cleanup-environment</target>
+              </targets>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/report</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>report</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/plugin/a11y/test/a11y-reporter.js
+++ b/plugin/a11y/test/a11y-reporter.js
@@ -1,0 +1,61 @@
+import { runAxeCore } from './axe-reporter.js';
+
+export function reportA11y(expectedViolations, expectedIncompleteViolations, setup) {
+  let _report;
+
+  const getReport = () => {
+    if (_report) {
+      return _report;
+    }
+    browser.setTimeout({ script: 120000 });
+
+    setup();
+
+    browser.pause(3000);
+    _report = runAxeCore();
+
+    return _report;
+  };
+
+  context('Violations', () => {
+    let report;
+
+    before(() => {
+      report = getReport();
+    });
+
+    Object.entries(expectedViolations).forEach(([violation, issues]) => {
+      it(`${violation}: ${issues} issue(s)`, () => {
+        expect(report.violations).toEqual(
+          expect.arrayContaining([
+            {
+              id: violation,
+              issues,
+            },
+          ]),
+        );
+      });
+    });
+  });
+
+  context('Incomplete violations', () => {
+    let report;
+
+    before(() => {
+      report = getReport();
+    });
+
+    Object.entries(expectedIncompleteViolations).forEach(([violation, issues]) => {
+      it(`${violation}: ${issues} issue(s)`, () => {
+        expect(report.incomplete).toEqual(
+          expect.arrayContaining([
+            {
+              id: violation,
+              issues,
+            },
+          ]),
+        );
+      });
+    });
+  });
+}

--- a/plugin/a11y/test/axe-reporter.js
+++ b/plugin/a11y/test/axe-reporter.js
@@ -1,0 +1,34 @@
+import { source } from 'axe-core';
+
+export function runAxeCore() {
+  // inject the axe-core lib
+  browser.execute(source);
+
+  // https://github.com/dequelabs/axe-core/blob/develop/doc/API.md
+  const options = {
+    runOnly: {
+      type: 'tag',
+      values: ['ACT', 'best-practice', 'wcag2a', 'wcag2aa'],
+    },
+  };
+  // run inside browser and get results
+  const results = browser.executeAsync((opts, done) => {
+    // eslint-disable-next-line no-undef
+    axe
+      .run(opts)
+      .then((res) => done(res))
+      .catch((err) => {
+        throw err;
+      });
+  }, options);
+
+  return {
+    results,
+    incomplete: results.incomplete.map((a) => {
+      return { id: a.id, issues: a.nodes.length };
+    }),
+    violations: results.violations.map((a) => {
+      return { id: a.id, issues: a.nodes.length };
+    }),
+  };
+}

--- a/plugin/a11y/test/pageobjects/home.page.js
+++ b/plugin/a11y/test/pageobjects/home.page.js
@@ -1,0 +1,19 @@
+import Page from './page.js';
+
+class HomePage extends Page {
+  open() {
+    return browser.url('#!/home');
+  }
+
+  get el() {
+    $('nuxeo-app').waitForDisplayed();
+    return $('nuxeo-app').shadow$('nuxeo-home');
+  }
+
+  recentlyEdited() {
+    this.el.waitForDisplayed();
+    return this.el.shadow$('nuxeo-card[icon="nuxeo:edit"]');
+  }
+}
+
+export default new HomePage();

--- a/plugin/a11y/test/pageobjects/login.page.js
+++ b/plugin/a11y/test/pageobjects/login.page.js
@@ -1,0 +1,25 @@
+class LoginPage {
+  get inputUsername() {
+    return $('#username');
+  }
+
+  get inputPassword() {
+    return $('#password');
+  }
+
+  get btnSubmit() {
+    return $('input[name="Submit"]');
+  }
+
+  login(username, password) {
+    this.inputUsername.setValue(username);
+    this.inputPassword.setValue(password);
+    this.btnSubmit.click();
+  }
+
+  open() {
+    return browser.url(process.env.NUXEO_URL ? `${process.env.NUXEO_URL}logout` : 'logout');
+  }
+}
+
+export default new LoginPage();

--- a/plugin/a11y/test/pageobjects/page.js
+++ b/plugin/a11y/test/pageobjects/page.js
@@ -1,0 +1,9 @@
+export default class Page {
+  /**
+   * Opens a sub page of the page
+   * @param path path of the sub page (e.g. /path/to/page.html)
+   */
+  open(path) {
+    return browser.url(`#!/${path}`);
+  }
+}

--- a/plugin/a11y/test/specs/home.js
+++ b/plugin/a11y/test/specs/home.js
@@ -1,0 +1,39 @@
+import LoginPage from '../pageobjects/login.page.js';
+import HomePage from '../pageobjects/home.page.js';
+/* import Login from '@nuxeo/nuxeo-web-ui-ftest/pages/login';
+import UI from '@nuxeo/nuxeo-web-ui-ftest/pages/ui'; */
+import { reportA11y } from '../a11y-reporter.js';
+
+const EXPECTED_VIOLATIONS = {
+  'aria-command-name': 15,
+  'aria-input-field-name': 1,
+  'aria-required-children': 1,
+  'aria-tooltip-name': 1,
+  'duplicate-id-active': 28,
+  'landmark-one-main': 1,
+  'meta-viewport': 1,
+  'page-has-heading-one': 1,
+  region: 19,
+  'scrollable-region-focusable': 1,
+};
+
+const EXPECTED_INCOMPLETE_VIOLATIONS = {
+  'aria-allowed-role': 5,
+  'color-contrast': 0,
+};
+
+describe('Home Page', () => {
+  reportA11y(EXPECTED_VIOLATIONS, EXPECTED_INCOMPLETE_VIOLATIONS, () => {
+    LoginPage.open();
+    LoginPage.login('Administrator', 'Administrator');
+    HomePage.open();
+    HomePage.recentlyEdited().waitForDisplayed();
+    // we should be able to leverage these once WEBUI-278 lands
+    /* const login = Login.get();
+    login.username = 'Administrator';
+    login.password = 'Administrator';
+    login.submit();
+    const ui = UI.get();
+    ui.home.el.$('nuxeo-card[icon="nuxeo:edit"]').waitForDisplayed(); */
+  });
+});

--- a/plugin/a11y/wdio.conf.js
+++ b/plugin/a11y/wdio.conf.js
@@ -1,0 +1,277 @@
+const debug = process.env.DEBUG;
+const debugTimeout = 24 * 60 * 60 * 1000;
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+require('@babel/register')({
+  ignore: [/node_modules\/(?!@nuxeo\/nuxeo-web-ui-ftest)/],
+});
+
+exports.config = {
+  execArgv: debug ? ['--inspect'] : [],
+  //
+  // ====================
+  // Runner Configuration
+  // ====================
+  //
+  // WebdriverIO allows it to run your tests in arbitrary locations (e.g. locally or
+  // on a remote machine).
+  runner: 'local',
+  //
+  // ==================
+  // Specify Test Files
+  // ==================
+  // Define which test specs should run. The pattern is relative to the directory
+  // from which `wdio` was called. Notice that, if you are calling `wdio` from an
+  // NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
+  // directory is where your package.json resides, so `wdio` will be called from there.
+  //
+  specs: ['./test/specs/**/*.js'],
+  // Patterns to exclude.
+  exclude: [
+    // 'path/to/excluded/files'
+  ],
+  //
+  // ============
+  // Capabilities
+  // ============
+  // Define your capabilities here. WebdriverIO can run multiple capabilities at the same
+  // time. Depending on the number of capabilities, WebdriverIO launches several test
+  // sessions. Within your capabilities you can overwrite the spec and exclude options in
+  // order to group specific specs to a specific capability.
+  //
+  // First, you can define how many instances should be started at the same time. Let's
+  // say you have 3 different capabilities (Chrome, Firefox, and Safari) and you have
+  // set maxInstances to 1; wdio will spawn 3 processes. Therefore, if you have 10 spec
+  // files and you set maxInstances to 10, all spec files will get tested at the same time
+  // and 30 processes will get spawned. The property handles how many capabilities
+  // from the same test should run tests.
+  //
+  maxInstances: 10,
+  //
+  // If you have trouble getting all important capabilities together, check out the
+  // Sauce Labs platform configurator - a great tool to configure your capabilities:
+  // https://docs.saucelabs.com/reference/platforms-configurator
+  //
+  capabilities: [
+    {
+      // maxInstances can get overwritten per capability. So if you have an in-house Selenium
+      // grid with only 5 firefox instances available you can make sure that not more than
+      // 5 instances get started at a time.
+      maxInstances: debug ? 1 : 5,
+      //
+      browserName: 'chrome',
+      acceptInsecureCerts: true,
+      // If outputDir is provided WebdriverIO can capture driver session logs
+      // it is possible to configure which logTypes to include/exclude.
+      // excludeDriverLogs: ['*'], // pass '*' to exclude all driver session logs
+      // excludeDriverLogs: ['bugreport', 'server'],
+    },
+  ],
+  //
+  // ===================
+  // Test Configurations
+  // ===================
+  // Define all options that are relevant for the WebdriverIO instance here
+  //
+  // Level of logging verbosity: trace | debug | info | warn | error | silent
+  logLevel: 'info',
+  //
+  // Set specific log levels per logger
+  // loggers:
+  // - webdriver, webdriverio
+  // - @wdio/applitools-service, @wdio/browserstack-service, @wdio/devtools-service, @wdio/sauce-service
+  // - @wdio/mocha-framework, @wdio/jasmine-framework
+  // - @wdio/local-runner
+  // - @wdio/sumologic-reporter
+  // - @wdio/cli, @wdio/config, @wdio/sync, @wdio/utils
+  // Level of logging verbosity: trace | debug | info | warn | error | silent
+  // logLevels: {
+  //     webdriver: 'info',
+  //     '@wdio/applitools-service': 'info'
+  // },
+  //
+  // If you only want to run your tests until a specific amount of tests have failed use
+  // bail (default is 0 - don't bail, run all tests).
+  bail: 0,
+  //
+  // Set a base URL in order to shorten url command calls. If your `url` parameter starts
+  // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
+  // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
+  // gets prepended directly.
+  baseUrl: process.env.NUXEO_WEB_UI_URL || process.env.NUXEO_URL || 'http://localhost:8080/nuxeo/',
+  //
+  // Default timeout for all waitFor* commands.
+  waitforTimeout: debug ? debugTimeout : 20000,
+  //
+  // Default timeout in milliseconds for request
+  // if browser driver or grid doesn't send response
+  connectionRetryTimeout: debug ? debugTimeout : 120000,
+  //
+  // Default request retries count
+  connectionRetryCount: 3,
+  //
+  // Test runner services
+  // Services take over a specific job you don't want to take care of. They enhance
+  // your test setup with almost no effort. Unlike plugins, they don't add new
+  // commands. Instead, they hook themselves up into the test process.
+  services: ['chromedriver'],
+
+  // Framework you want to run your specs with.
+  // The following are supported: Mocha, Jasmine, and Cucumber
+  // see also: https://webdriver.io/docs/frameworks
+  //
+  // Make sure you have the wdio adapter package for the specific framework installed
+  // before running any tests.
+  framework: 'mocha',
+  //
+  // The number of times to retry the entire specfile when it fails as a whole
+  // specFileRetries: 1,
+  //
+  // Delay in seconds between the spec file retry attempts
+  // specFileRetriesDelay: 0,
+  //
+  // Whether or not retried specfiles should be retried immediately or deferred to the end of the queue
+  // specFileRetriesDeferred: false,
+  //
+  // Test reporter for stdout.
+  // The only one supported by default is 'dot'
+  // see also: https://webdriver.io/docs/dot-reporter
+  reporters: ['spec'],
+
+  //
+  // Options to be passed to Mocha.
+  // See the full list at http://mochajs.org/
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: debug ? debugTimeout : 120000,
+  },
+  //
+  // =====
+  // Hooks
+  // =====
+  // WebdriverIO provides several hooks you can use to interfere with the test process in order to enhance
+  // it and to build services around it. You can either apply a single function or an array of
+  // methods to it. If one of them returns with a promise, WebdriverIO will wait until that promise got
+  // resolved to continue.
+  /**
+   * Gets executed once before all workers get launched.
+   * @param {Object} config wdio configuration object
+   * @param {Array.<Object>} capabilities list of capabilities details
+   */
+  // onPrepare: function (config, capabilities) {
+  // },
+  /**
+   * Gets executed before a worker process is spawned and can be used to initialise specific service
+   * for that worker as well as modify runtime environments in an async fashion.
+   * @param  {String} cid      capability id (e.g 0-0)
+   * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
+   * @param  {[type]} specs    specs to be run in the worker process
+   * @param  {[type]} args     object that will be merged with the main configuration once worker is initialised
+   * @param  {[type]} execArgv list of string arguments passed to the worker process
+   */
+  // onWorkerStart: function (cid, caps, specs, args, execArgv) {
+  // },
+  /**
+   * Gets executed just before initialising the webdriver session and test framework. It allows you
+   * to manipulate configurations depending on the capability or spec.
+   * @param {Object} config wdio configuration object
+   * @param {Array.<Object>} capabilities list of capabilities details
+   * @param {Array.<String>} specs List of spec file paths that are to be run
+   */
+  // beforeSession: function (config, capabilities, specs) {
+  // },
+  /**
+   * Gets executed before test execution begins. At this point you can access to all global
+   * variables like `browser`. It is the perfect place to define custom commands.
+   * @param {Array.<Object>} capabilities list of capabilities details
+   * @param {Array.<String>} specs        List of spec file paths that are to be run
+   * @param {Object}         browser      instance of created browser/device session
+   */
+  // before: function (capabilities, specs) {
+  // },
+  /**
+   * Runs before a WebdriverIO command gets executed.
+   * @param {String} commandName hook command name
+   * @param {Array} args arguments that command would receive
+   */
+  // beforeCommand: function (commandName, args) {
+  // },
+  /**
+   * Hook that gets executed before the suite starts
+   * @param {Object} suite suite details
+   */
+  // beforeSuite: function (suite) {
+  // },
+  /**
+   * Function to be executed before a test (in Mocha/Jasmine) starts.
+   */
+  // beforeTest: function (test, context) {
+  // },
+  /**
+   * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
+   * beforeEach in Mocha)
+   */
+  // beforeHook: function (test, context) {
+  // },
+  /**
+   * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+   * afterEach in Mocha)
+   */
+  // afterHook: function (test, context, { error, result, duration, passed, retries }) {
+  // },
+  /**
+   * Function to be executed after a test (in Mocha/Jasmine).
+   */
+  // afterTest: function(test, context, { error, result, duration, passed, retries }) {
+  // },
+
+  /**
+   * Hook that gets executed after the suite has ended
+   * @param {Object} suite suite details
+   */
+  // afterSuite: function (suite) {
+  // },
+  /**
+   * Runs after a WebdriverIO command gets executed
+   * @param {String} commandName hook command name
+   * @param {Array} args arguments that command would receive
+   * @param {Number} result 0 - command success, 1 - command error
+   * @param {Object} error error object if any
+   */
+  // afterCommand: function (commandName, args, result, error) {
+  // },
+  /**
+   * Gets executed after all tests are done. You still have access to all global variables from
+   * the test.
+   * @param {Number} result 0 - test pass, 1 - test fail
+   * @param {Array.<Object>} capabilities list of capabilities details
+   * @param {Array.<String>} specs List of spec file paths that ran
+   */
+  // after: function (result, capabilities, specs) {
+  // },
+  /**
+   * Gets executed right after terminating the webdriver session.
+   * @param {Object} config wdio configuration object
+   * @param {Array.<Object>} capabilities list of capabilities details
+   * @param {Array.<String>} specs List of spec file paths that ran
+   */
+  // afterSession: function (config, capabilities, specs) {
+  // },
+  /**
+   * Gets executed after all workers got shut down and the process is about to exit. An error
+   * thrown in the onComplete hook will result in the test run failing.
+   * @param {Object} exitCode 0 - success, 1 - fail
+   * @param {Object} config wdio configuration object
+   * @param {Array.<Object>} capabilities list of capabilities details
+   * @param {<Object>} results object containing test results
+   */
+  // onComplete: function(exitCode, config, capabilities, results) {
+  // },
+  /**
+   * Gets executed when a refresh happens.
+   * @param {String} oldSessionId session ID of the old session
+   * @param {String} newSessionId session ID of the new session
+   */
+  // onReload: function(oldSessionId, newSessionId) {
+  // }
+};

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,12 @@
         <module>plugin/metrics</module>
       </modules>
     </profile>
+    <profile>
+      <id>a11y</id>
+      <modules>
+        <module>plugin/a11y</module>
+      </modules>
+    </profile>
   </profiles>
 
   <dependencyManagement>


### PR DESCRIPTION
This is a POC of how we could integrate axe-core with our pipeline. For now, the goal would be for it to provide us control over  the type of violations we are expecting as well as the number of issues.

The DX is not ideal: we get a different amount of issues when running in dev mode. This is caused, in part, by the fact the server / local storage content differs. There might be other factors, which I am not currently aware of.

The fact that we do not have dummy content renders the home page testing somewhat limited, as we are certainly missing issues in the data tables, for example. I believe we should populate the server with a few documents so we could at least have data in the Recently edited. What is the best way to populate the server with some data? I would like to avoid using the rest API if possible.