### PR TITLE
WEBUI-333: set ui config from functional tests

### DIFF
--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -19,6 +19,7 @@ import '@polymer/polymer/polymer-legacy.js';
 import '@nuxeo/nuxeo-elements/nuxeo-document.js';
 import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
 import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
+import { config } from '@nuxeo/nuxeo-elements';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-layout.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-slots.js';
 import { FiltersBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-filters-behavior.js';
@@ -1339,7 +1340,7 @@ Polymer({
   },
 
   _computeEnrichers() {
-    return Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.enrichers;
+    return config.get('enrichers');
   },
 
   _computeHeaders() {
@@ -1347,7 +1348,7 @@ Polymer({
       'translate-directoryEntry': 'label',
     };
 
-    const fetch = (Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.fetch) || {};
+    const fetch = config.get('fetch', {});
 
     // add required fetchers
     const required = { document: ['lock'], directoryEntry: ['parent'], task: ['actors'] };

--- a/elements/nuxeo-document-creation/nuxeo-document-creation-behavior.js
+++ b/elements/nuxeo-document-creation/nuxeo-document-creation-behavior.js
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { FormatBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-format-behavior.js';
 
+import { config } from '@nuxeo/nuxeo-elements';
+import { FormatBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-format-behavior.js';
 import { RoutingBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-routing-behavior.js';
 
 let schemaFetcher = null;
@@ -92,7 +93,7 @@ export const DocumentCreationBehavior = [
         'fetch-document': 'properties',
         'translate-directoryEntry': 'label',
       };
-      schemaFetcher.enrichers = (Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.enrichers) || {};
+      schemaFetcher.enrichers = config.get('enrichers', {});
       return schemaFetcher.get().then((doc) => {
         if (properties) {
           Object.keys(properties).forEach((prop) => {

--- a/elements/nuxeo-document-versions/nuxeo-document-versions.js
+++ b/elements/nuxeo-document-versions/nuxeo-document-versions.js
@@ -21,6 +21,7 @@ import '@polymer/iron-icon/iron-icon.js';
 import '@polymer/iron-scroll-threshold/iron-scroll-threshold.js';
 import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
 import '@nuxeo/nuxeo-elements/nuxeo-page-provider.js';
+import { config } from '@nuxeo/nuxeo-elements';
 import { RoutingBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-routing-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
 import { FiltersBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-filters-behavior.js';
@@ -244,14 +245,7 @@ Polymer({
     this._hideList();
     this.navigateTo(
       'document',
-      (Nuxeo &&
-        Nuxeo.UI &&
-        Nuxeo.UI.config &&
-        Nuxeo.UI.config.router &&
-        Nuxeo.UI.config.router.key &&
-        Nuxeo.UI.config.router.key.document === 'uid' &&
-        this.document.versionableId) ||
-        this.document.path,
+      (config.get('router.key.document') === 'uid' && this.document.versionableId) || this.document.path,
     );
   },
 

--- a/elements/nuxeo-dropzone/nuxeo-dropzone.js
+++ b/elements/nuxeo-dropzone/nuxeo-dropzone.js
@@ -24,6 +24,7 @@ import '@nuxeo/nuxeo-elements/nuxeo-document.js';
 import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
 import { createNestedObject } from '@nuxeo/nuxeo-elements/utils.js';
 import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
+import { config } from '@nuxeo/nuxeo-elements';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-icons.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-slots.js';
 import { FormatBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-format-behavior.js';
@@ -370,9 +371,7 @@ Polymer({
       value() {
         return {
           document: ['preview'],
-          blob: (Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.enrichers && Nuxeo.UI.config.enrichers.blob) || [
-            'appLinks',
-          ],
+          blob: config.get('enrichers.blob', ['appLinks']),
         };
       },
     },

--- a/elements/nuxeo-publication/nuxeo-publication-info-bar.js
+++ b/elements/nuxeo-publication/nuxeo-publication-info-bar.js
@@ -20,6 +20,7 @@ import '@polymer/iron-icon/iron-icon.js';
 import '@polymer/iron-icons/iron-icons.js';
 import '@polymer/iron-icons/social-icons.js';
 import '@nuxeo/nuxeo-elements/nuxeo-document.js';
+import { config } from '@nuxeo/nuxeo-elements';
 import { FiltersBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-filters-behavior.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
 import { RoutingBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-routing-behavior.js';
@@ -118,14 +119,7 @@ Polymer({
     return this._src
       ? this.urlFor(
           'document',
-          (Nuxeo &&
-            Nuxeo.UI &&
-            Nuxeo.UI.config &&
-            Nuxeo.UI.config.router &&
-            Nuxeo.UI.config.router.key &&
-            Nuxeo.UI.config.router.key.document === 'uid' &&
-            this._src.versionableId) ||
-            this._src.path,
+          (config.get('router.key.document') === 'uid' && this._src.versionableId) || this._src.path,
         )
       : null;
   },

--- a/elements/nuxeo-restore-version-button/nuxeo-restore-version-button.js
+++ b/elements/nuxeo-restore-version-button/nuxeo-restore-version-button.js
@@ -17,6 +17,7 @@ limitations under the License.
 import '@polymer/polymer/polymer-legacy.js';
 
 import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
+import { config } from '@nuxeo/nuxeo-elements';
 import { FiltersBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-filters-behavior.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
 import { RoutingBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-routing-behavior.js';
@@ -101,14 +102,7 @@ Polymer({
       this.$.opRestoreVersion.execute().then(() => {
         this.navigateTo(
           'document',
-          (Nuxeo &&
-            Nuxeo.UI &&
-            Nuxeo.UI.config &&
-            Nuxeo.UI.config.router &&
-            Nuxeo.UI.config.router.key &&
-            Nuxeo.UI.config.router.key.document === 'uid' &&
-            this.document.versionableId) ||
-            this.document.path,
+          (config.get('router.key.document') === 'uid' && this.document.versionableId) || this.document.path,
         );
       });
     }

--- a/ftest/features/versions.feature
+++ b/ftest/features/versions.feature
@@ -67,3 +67,26 @@ Feature: Versioning
     And I can restore version
     And The document version is 1.0+
     And Versions count is 2
+
+  @config('router.key.document','uid')
+  Scenario: Restore and list versions (navigation by UID)
+    Given I have a File document
+    And I have permission ReadWrite for this document
+    And This document has a minor version
+    And I browse to the document
+    And The document version is 0.1
+    Then I can edit the Note metadata
+    And The document version is 0.1+
+    Then I click the versions list
+    And I click the Create Version button in versions list
+    Then The create version dialog appears
+    And Version options 0.2 and 1.0 are presented
+    Then I create a major version
+    And The document version is 1.0
+    Then I click the versions list
+    And Versions item index at 0 is 1.0
+    And Versions item index at 1 is 0.1
+    Then I click the versions list at index 1
+    And I can restore version
+    And The document version is 1.0+
+    And Versions count is 2

--- a/index.js
+++ b/index.js
@@ -1,102 +1,56 @@
-// load app
-import './elements/nuxeo-app.js';
-
-// expose moment for compat
-import moment from '@nuxeo/moment';
-// expose page for compat
-import page from '@nuxeo/page/page.mjs';
-
-// expose Polymer and PolymerElement for 1.x and 2.x compat
-import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
-import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
-import { html } from '@polymer/polymer/lib/utils/html-tag.js';
-import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import * as Async from '@polymer/polymer/lib/utils/async.js';
-import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
+import { config } from '@nuxeo/nuxeo-elements';
 import { importHTML, importHref } from '@nuxeo/nuxeo-ui-elements/import-href.js';
-import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
-import * as RenderStatus from '@polymer/polymer/lib/utils/render-status.js';
+import { setFallbackNotificationTarget } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 
-// expose Polymer behaviors for compat
-import { IronOverlayBehavior } from '@polymer/iron-overlay-behavior/iron-overlay-behavior.js';
-import { IronResizableBehavior } from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
-import { IronValidatableBehavior } from '@polymer/iron-validatable-behavior/iron-validatable-behavior.js';
-import { IronValidatorBehavior } from '@polymer/iron-validator-behavior/iron-validator-behavior.js';
-import { Templatizer } from '@polymer/polymer/lib/legacy/templatizer-behavior.js';
-
-// expose behaviors for compat
-import { NotifyBehavior, setFallbackNotificationTarget } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
-import { AggregationBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-aggregation/nuxeo-aggregation-behavior.js';
-import { FiltersBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-filters-behavior.js';
-import { FormatBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-format-behavior.js';
-import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
-import { LayoutBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-layout-behavior.js';
-import { PageProviderDisplayBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-page-provider-display-behavior.js';
-import { RoutingBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-routing-behavior.js';
-import { UploaderBehavior } from '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-uploader-behavior.js';
-import { DocumentContentBehavior } from './elements/nuxeo-results/nuxeo-document-content-behavior.js';
-import { ChartDataBehavior } from './elements/nuxeo-admin/nuxeo-chart-data-behavior.js';
-
-// load Web UI bundle
-import bundleHtml from './elements/nuxeo-web-ui-bundle.html';
-
-window.moment = moment;
-window.page = page;
-
-// expose commonly used legacy helpers for compat
-Object.assign(Polymer, { dom, html, importHref, mixinBehaviors, Debouncer, Async, RenderStatus });
-window.Polymer = Polymer;
-window.PolymerElement = PolymerElement;
-window.importHref = importHref;
-Polymer.IronOverlayBehavior = IronOverlayBehavior;
-Polymer.IronResizableBehavior = IronResizableBehavior;
-Polymer.IronValidatableBehavior = IronValidatableBehavior;
-Polymer.IronValidatorBehavior = IronValidatorBehavior;
-Polymer.Templatizer = Templatizer;
-Nuxeo.NotifyBehavior = NotifyBehavior;
-Nuxeo.AggregationBehavior = AggregationBehavior;
-Nuxeo.ChartDataBehavior = ChartDataBehavior;
-Nuxeo.DocumentContentBehavior = DocumentContentBehavior;
-Nuxeo.FiltersBehavior = FiltersBehavior;
-Nuxeo.FormatBehavior = FormatBehavior;
-Nuxeo.I18nBehavior = I18nBehavior;
-Nuxeo.LayoutBehavior = LayoutBehavior;
-Nuxeo.PageProviderDisplayBehavior = PageProviderDisplayBehavior;
-Nuxeo.RoutingBehavior = RoutingBehavior;
-Nuxeo.UploaderBehavior = UploaderBehavior;
-
-// import the main bundle
-importHTML(bundleHtml);
-
-const bundles = [...Nuxeo.UI.bundles, 'nuxeo-spreadsheet'];
-
-// load addons / bundles
-// NXP-26977: await loading of addons
-Promise.all(
-  bundles.map((url) => {
-    if (url.endsWith('.html')) {
-      return new Promise((resolve, reject) => importHref(url, resolve, reject));
-    }
-    return import(
-      /* webpackChunkName: "[request]" */
-      /* webpackInclude: /addons\/[^\/]+\/index.js$/ */
-      // eslint-disable-next-line comma-dangle
-      `./addons/${url}`
-    ).catch(() => import(/* webpackIgnore: true */ `./${url}.bundle.js`));
-  }),
-)
-  .then(() => customElements.whenDefined('nuxeo-app'))
-  .then(() => {
+const loadApp = () => import(/* webpackMode: "eager" */ './elements/nuxeo-app.js');
+const loadLegacy = () => import(/* webpackMode: "eager" */ './legacy.js');
+const loadBundle = () =>
+  import('./elements/nuxeo-web-ui-bundle.html').then(({ default: bundleHtml }) => importHTML(bundleHtml));
+const loadAddons = () => {
+  const bundles = [...Nuxeo.UI.bundles, 'nuxeo-spreadsheet'];
+  // load addons / bundles
+  // NXP-26977: await loading of addons
+  Promise.all(
+    bundles.map((url) => {
+      if (url.endsWith('.html')) {
+        return new Promise((resolve, reject) => importHref(url, resolve, reject));
+      }
+      return import(
+        /* webpackChunkName: "[request]" */
+        /* webpackInclude: /addons\/[^\/]+\/index.js$/ */
+        // eslint-disable-next-line comma-dangle
+        `./addons/${url}`
+      ).catch(() => import(/* webpackIgnore: true */ `./${url}.bundle.js`));
+    }),
+  );
+};
+const setupApp = () =>
+  customElements.whenDefined('nuxeo-app').then(() => {
     Nuxeo.UI.app = document.querySelector('nuxeo-app');
     if (!Nuxeo.UI.app) {
       console.error('could not find nuxeo-app');
     }
     setFallbackNotificationTarget(Nuxeo.UI.app);
-  })
-  .then(async () => {
-    if (Nuxeo.UI.config.router && Nuxeo.UI.config.router.htmlImport) {
-      importHref(Nuxeo.UI.app.resolveUrl('routing.html'));
-    } else {
-      return import(/* webpackMode: "eager" */ './elements/routing.js');
-    }
   });
+const loadRouting = async () => {
+  if (config.get('router.htmlImport')) {
+    importHref(Nuxeo.UI.app.resolveUrl('routing.html'));
+  } else {
+    return import(/* webpackMode: "eager" */ './elements/routing.js');
+  }
+};
+
+const ready =
+  !navigator.webdriver || window.automationReady
+    ? Promise.resolve()
+    : new Promise((resolve) => {
+        document.addEventListener('automation-ready', resolve);
+      });
+
+ready
+  .then(loadApp)
+  .then(loadLegacy)
+  .then(loadBundle)
+  .then(loadAddons)
+  .then(setupApp)
+  .then(loadRouting);

--- a/legacy.js
+++ b/legacy.js
@@ -1,0 +1,60 @@
+// expose moment for compat
+import moment from '@nuxeo/moment';
+// expose page for compat
+import page from '@nuxeo/page/page.mjs';
+
+// expose Polymer and PolymerElement for 1.x and 2.x compat
+import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
+import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import * as Async from '@polymer/polymer/lib/utils/async.js';
+import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
+import { importHref } from '@nuxeo/nuxeo-ui-elements/import-href.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import * as RenderStatus from '@polymer/polymer/lib/utils/render-status.js';
+
+// expose Polymer behaviors for compat
+import { IronOverlayBehavior } from '@polymer/iron-overlay-behavior/iron-overlay-behavior.js';
+import { IronResizableBehavior } from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
+import { IronValidatableBehavior } from '@polymer/iron-validatable-behavior/iron-validatable-behavior.js';
+import { IronValidatorBehavior } from '@polymer/iron-validator-behavior/iron-validator-behavior.js';
+import { Templatizer } from '@polymer/polymer/lib/legacy/templatizer-behavior.js';
+
+// expose behaviors for compat
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
+import { AggregationBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-aggregation/nuxeo-aggregation-behavior.js';
+import { FiltersBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-filters-behavior.js';
+import { FormatBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-format-behavior.js';
+import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
+import { LayoutBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-layout-behavior.js';
+import { PageProviderDisplayBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-page-provider-display-behavior.js';
+import { RoutingBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-routing-behavior.js';
+import { UploaderBehavior } from '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-uploader-behavior.js';
+import { DocumentContentBehavior } from './elements/nuxeo-results/nuxeo-document-content-behavior.js';
+import { ChartDataBehavior } from './elements/nuxeo-admin/nuxeo-chart-data-behavior.js';
+
+window.moment = moment;
+window.page = page;
+
+// expose commonly used legacy helpers for compat
+Object.assign(Polymer, { dom, html, importHref, mixinBehaviors, Debouncer, Async, RenderStatus });
+window.Polymer = Polymer;
+window.PolymerElement = PolymerElement;
+window.importHref = importHref;
+Polymer.IronOverlayBehavior = IronOverlayBehavior;
+Polymer.IronResizableBehavior = IronResizableBehavior;
+Polymer.IronValidatableBehavior = IronValidatableBehavior;
+Polymer.IronValidatorBehavior = IronValidatorBehavior;
+Polymer.Templatizer = Templatizer;
+Nuxeo.NotifyBehavior = NotifyBehavior;
+Nuxeo.AggregationBehavior = AggregationBehavior;
+Nuxeo.ChartDataBehavior = ChartDataBehavior;
+Nuxeo.DocumentContentBehavior = DocumentContentBehavior;
+Nuxeo.FiltersBehavior = FiltersBehavior;
+Nuxeo.FormatBehavior = FormatBehavior;
+Nuxeo.I18nBehavior = I18nBehavior;
+Nuxeo.LayoutBehavior = LayoutBehavior;
+Nuxeo.PageProviderDisplayBehavior = PageProviderDisplayBehavior;
+Nuxeo.RoutingBehavior = RoutingBehavior;
+Nuxeo.UploaderBehavior = UploaderBehavior;

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/browser.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/browser.js
@@ -98,7 +98,8 @@ Then('I can see {int} document(s)', function(numberOfResults) {
   const { results } = this.ui.browser;
   results.waitForVisible();
   // XXX temporary fix for visual issue while importing more than 1 document; will be fixed when NXP-28642 is tackled
-  driver.refresh();
+  this.ui.reload();
+
   const { displayMode } = results;
   results.getResults(displayMode).waitForVisible();
   results.resultsCount(displayMode).should.equal(numberOfResults);

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/document.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/document.js
@@ -1,4 +1,5 @@
 import { Given, When, Then } from 'cucumber';
+import { url } from '../../pages/helpers';
 
 Given('I have a {word} document', function(docType) {
   docType = docType || 'File';
@@ -126,7 +127,7 @@ When(/^I click the process button$/, function() {
 });
 
 Then(/^I can't view the document$/, function() {
-  driver.url(`#!/browse${this.doc.path}`);
+  url(`#!/browse${this.doc.path}`);
   this.ui.browser.breadcrumb.waitForVisible(browser.options.waitforTimeout, true).should.be.true;
 });
 

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/login.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/login.js
@@ -1,6 +1,7 @@
 import { Given, Then, When } from 'cucumber';
 import Login from '../../pages/login';
 import UI from '../../pages/ui';
+import { url } from '../../pages/helpers';
 
 Given('user {string} exists in group {string}', (username, group) =>
   fixtures.users.create({
@@ -37,7 +38,7 @@ When('I login as {string}', function(username) {
   driver.waitForVisible('nuxeo-page');
 });
 
-When(/^I visit (.*)$/, (url) => driver.url(url));
+When(/^I visit (.*)$/, (path) => url(path));
 
 When('I logout', () => Login.get());
 

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/search.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/search.js
@@ -1,4 +1,5 @@
 import { Given, Then, When } from 'cucumber';
+import { url } from '../../pages/helpers';
 
 Then('I can see the {string} search panel', function(name) {
   this.ui.drawer._search(name).waitForVisible();
@@ -107,7 +108,7 @@ Given('I have permission {word} for this saved search', function(permission) {
 });
 
 When('I browse to the saved search', function() {
-  driver.url(`#!/doc/${this.savedSearch.id}`);
+  url(`#!/doc/${this.savedSearch.id}`);
 });
 
 Then('I can see that my saved search "{word}" on "{word}" is selected', function(savedSearchName, searchName) {

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/support/ui_config.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/support/ui_config.js
@@ -1,0 +1,11 @@
+import { Before } from 'cucumber';
+
+Before((e) => {
+  const { tags } = e.pickle;
+  global.config = tags
+    .map((tag) => {
+      const res = tag.name.match(/@config\('(.*)','(.*)'\)/);
+      return res && { key: res[1], value: res[2] };
+    })
+    .filter(Boolean);
+});

--- a/packages/nuxeo-web-ui-ftest/pages/helpers.js
+++ b/packages/nuxeo-web-ui-ftest/pages/helpers.js
@@ -1,0 +1,18 @@
+const _flushProperties = () => {
+  driver.execute((conf) => {
+    conf.forEach(({ key, value }) => Nuxeo.UI.config.set(key, value));
+    document.dispatchEvent(new CustomEvent('automation-ready'));
+  }, global.config);
+};
+
+const refresh = () => {
+  driver.refresh();
+  _flushProperties();
+};
+
+const url = (...args) => {
+  driver.url(...args);
+  _flushProperties();
+};
+
+export { refresh, url };

--- a/packages/nuxeo-web-ui-ftest/pages/ui.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui.js
@@ -11,6 +11,7 @@ import Group from './ui/group';
 import Search from './ui/search';
 import UserAuthorizedApps from './ui/oauth2/user_authorized_apps';
 import UserCloudServices from './ui/oauth2/user_cloud_services';
+import { refresh, url } from './helpers';
 
 export default class UI extends BasePage {
   goHome() {
@@ -18,7 +19,7 @@ export default class UI extends BasePage {
   }
 
   reload() {
-    driver.refresh();
+    refresh();
   }
 
   get activityFeed() {
@@ -86,7 +87,7 @@ export default class UI extends BasePage {
   }
 
   static get() {
-    driver.url(process.env.NUXEO_URL ? '' : 'ui');
+    url(process.env.NUXEO_URL ? '' : 'ui');
     if (!global.locale) {
       browser.waitForVisible('nuxeo-app:not([unresolved])');
       /* global window */
@@ -129,7 +130,7 @@ export default class UI extends BasePage {
 
   goToUserCloudServices() {
     if (!browser.getUrl().endsWith('user-cloud-services')) {
-      driver.url(process.env.NUXEO_URL ? '#!/user-cloud-services' : 'ui/#!/user-cloud-services');
+      url(process.env.NUXEO_URL ? '#!/user-cloud-services' : 'ui/#!/user-cloud-services');
     }
     return this.userCloudServices;
   }
@@ -140,7 +141,7 @@ export default class UI extends BasePage {
 
   goToUserAuthorizedApps() {
     if (!browser.getUrl().endsWith('user-authorized-apps')) {
-      driver.url(process.env.NUXEO_URL ? '#!/user-authorized-apps' : 'ui/#!/user-authorized-apps');
+      url(process.env.NUXEO_URL ? '#!/user-authorized-apps' : 'ui/#!/user-authorized-apps');
     }
     return this.userAuthorizedApps;
   }

--- a/packages/nuxeo-web-ui-ftest/pages/ui/administration.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/administration.js
@@ -1,6 +1,7 @@
 import BasePage from '../base';
 import Vocabulary from './admin/vocabulary';
 import CloudServices from './admin/cloudServices';
+import { url } from '../helpers';
 
 export default class Administration extends BasePage {
   get analytics() {
@@ -21,14 +22,14 @@ export default class Administration extends BasePage {
 
   get vocabularyManagement() {
     if (!browser.getUrl().endsWith('vocabulary-management')) {
-      driver.url(process.env.NUXEO_URL ? '#!/admin/vocabulary-management' : 'ui/#!/admin/vocabulary-management');
+      url(process.env.NUXEO_URL ? '#!/admin/vocabulary-management' : 'ui/#!/admin/vocabulary-management');
     }
     return new Vocabulary('nuxeo-vocabulary-management');
   }
 
   goToVocabularyManagement() {
     if (!browser.getUrl().endsWith('vocabulary-management')) {
-      driver.url(process.env.NUXEO_URL ? '#!/admin/vocabulary-management' : 'ui/#!/admin/vocabulary-management');
+      url(process.env.NUXEO_URL ? '#!/admin/vocabulary-management' : 'ui/#!/admin/vocabulary-management');
     }
     return this.vocabularyManagement;
   }
@@ -43,7 +44,7 @@ export default class Administration extends BasePage {
 
   goToCloudServices() {
     if (!browser.getUrl().endsWith('cloud-services')) {
-      driver.url(process.env.NUXEO_URL ? '#!/admin/cloud-services' : 'ui/#!/admin/cloud-services');
+      url(process.env.NUXEO_URL ? '#!/admin/cloud-services' : 'ui/#!/admin/cloud-services');
     }
     return this.cloudServices;
   }

--- a/packages/nuxeo-web-ui-ftest/pages/ui/browser.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/browser.js
@@ -9,6 +9,7 @@ import DocumentTask from './browser/document_task';
 import DocumentFormLayout from './browser/document_form_layout';
 import Selection from './selection';
 import Results from './results';
+import { url } from '../helpers';
 
 export default class Browser extends BasePage {
   documentPage(docType) {
@@ -20,7 +21,7 @@ export default class Browser extends BasePage {
   }
 
   browseTo(path) {
-    driver.url(`#!/browse${path}`);
+    url(`#!/browse${path}`);
     this.waitForVisible();
     this.breadcrumb.waitForVisible();
     this.currentPage.waitForVisible();

--- a/packages/nuxeo-web-ui-ftest/pages/ui/browser/collapsible_document_page.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/browser/collapsible_document_page.js
@@ -22,7 +22,8 @@ export default class CollapsibleDocumentPage extends DocumentPage {
 
   expandDetailsCard() {
     this.detailsCard.waitForVisible();
-    if (this.detailsCard.getAttribute('opened') === null) {
+    // XXX: getAttribute('opened') returns 'false' instead of null when the attribute is set to false, not sure why
+    if (this.detailsCard.getAttribute('opened') === 'false') {
       this.detailsCard.waitForVisible('h5.header');
       this.detailsCard.click('h5.header');
     }
@@ -30,7 +31,8 @@ export default class CollapsibleDocumentPage extends DocumentPage {
 
   collapseDetailsCard() {
     this.detailsCard.waitForVisible();
-    if (this.detailsCard.getAttribute('opened') !== null) {
+    // XXX: getAttribute('opened') returns 'false' instead of null when the attribute is set to false, not sure why
+    if (this.detailsCard.getAttribute('opened') !== 'false') {
       this.detailsCard.waitForVisible('h5.header');
       this.detailsCard.click('h5.header');
     }


### PR DESCRIPTION
Depends on https://github.com/nuxeo/nuxeo-elements/pull/407.

- Adds `@config(key, value)` cucumber tag to enable a given configuration property for a specific scenario or feature file.
- Adds a hook to the application where it waits for an event `automation-ready` to be fired before defining the `nuxeo-app` element, IF automation is enabled (i.e, the browser was launched by webdriver).
- Adds new helper methods `url` and `refresh`, which encapsulate the respective webdriver commands but also sends in the properties defined in the tests using the `@cofig` tag and then fire the `automation-ready` event. This means that the application will only load after the configuration has been loaded.

Note that the diff for nuxeo-app looks huge, but I just wrapped the nuxeo-app element definition with:
```
prom.then(() => {
  ...
});
```
### Experiments

Experiment A: Adding a fallback to the get helper, which tries to evaluate the result based on the fallback data type (see https://github.com/nuxeo/nuxeo-web-ui/pull/1218/commits/ec0d3f4ec7d8dc5ca2c3598efb1199b4911c32b7).
Experiment B: Moving the automation hook to index.js, which requires some refactoring (see https://github.com/nuxeo/nuxeo-web-ui/pull/1218/commits/cfa16025f54ae5cd4078c78619cfb37a92f337be).