### PR TITLE
WEBUI-345: make nuxeo-app the fallback notification target

### DIFF
--- a/addons/easyshare/elements/nuxeo-easyshare-share-link.js
+++ b/addons/easyshare/elements/nuxeo-easyshare-share-link.js
@@ -16,6 +16,7 @@ limitations under the License.
 */
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
@@ -104,7 +105,7 @@ Polymer({
   `,
 
   is: 'nuxeo-easyshare-share-link',
-  behaviors: [I18nBehavior],
+  behaviors: [NotifyBehavior, I18nBehavior],
 
   properties: {
     /**
@@ -192,6 +193,6 @@ Polymer({
 
     shareButton.set('icon', 'check');
     shareButton.classList.add('selected');
-    this.fire('notify', { message: this.i18n('shareButton.operation.copied'), duration: 2000 });
+    this.notify({ message: this.i18n('shareButton.operation.copied'), duration: 2000 });
   },
 });

--- a/addons/nuxeo-platform-3d/elements/nuxeo-3d-preview.js
+++ b/addons/nuxeo-platform-3d/elements/nuxeo-3d-preview.js
@@ -18,6 +18,7 @@ Contributors:
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import '@nuxeo/nuxeo-elements/nuxeo-document.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
 import './nuxeo-3d-viewer.js';
 
@@ -100,7 +101,7 @@ Polymer({
     },
   },
 
-  behaviors: [I18nBehavior],
+  behaviors: [NotifyBehavior, I18nBehavior],
 
   created() {
     this._createMethodObserver('_valueChanged(document.properties.file:content)', true);
@@ -121,7 +122,7 @@ Polymer({
 
     this.$.doc.put().then((response) => {
       this.document = response;
-      this.fire('notify', { message: this.i18n(this.uploadedMessage) });
+      this.notify({ message: this.i18n(this.uploadedMessage) });
       this.fire('document-updated');
     });
   },

--- a/addons/nuxeo-template-rendering/elements/nuxeo-render-template-button.js
+++ b/addons/nuxeo-template-rendering/elements/nuxeo-render-template-button.js
@@ -15,6 +15,7 @@ limitations under the License.
 */
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
 import './nuxeo-template-param-editor.js';
 
@@ -104,7 +105,7 @@ Polymer({
   `,
 
   is: 'nuxeo-render-template-button',
-  behaviors: [I18nBehavior],
+  behaviors: [NotifyBehavior, I18nBehavior],
 
   properties: {
     /**
@@ -255,7 +256,7 @@ Polymer({
   },
 
   _toast(msg, duration) {
-    this.fire('notify', {
+    this.notify({
       message: msg,
       close: true,
       duration,

--- a/elements/diff/nuxeo-versions-diff-button.js
+++ b/elements/diff/nuxeo-versions-diff-button.js
@@ -18,6 +18,7 @@ import '@polymer/polymer/polymer-legacy.js';
 
 import '@polymer/paper-icon-button/paper-icon-button.js';
 import '@nuxeo/nuxeo-ui-elements/actions/nuxeo-action-button-styles.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
 import { FiltersBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-filters-behavior.js';
 import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
@@ -45,7 +46,7 @@ Polymer({
   `,
 
   is: 'nuxeo-versions-diff-button',
-  behaviors: [I18nBehavior, FiltersBehavior],
+  behaviors: [NotifyBehavior, I18nBehavior, FiltersBehavior],
 
   properties: {
     document: {
@@ -91,7 +92,7 @@ Polymer({
         }
         // check if there is at least two versions to be compared
         if (versions.length < 2) {
-          this.fire('notify', { message: this.i18n('versionsDiffButton.nothingToCompare') });
+          this.notify({ message: this.i18n('versionsDiffButton.nothingToCompare') });
           return;
         }
         this.fire('nuxeo-diff-documents', {

--- a/elements/directory/nuxeo-vocabulary-management.js
+++ b/elements/directory/nuxeo-vocabulary-management.js
@@ -19,6 +19,7 @@ import '@polymer/polymer/polymer-legacy.js';
 import '@polymer/iron-flex-layout/iron-flex-layout.js';
 import '@polymer/iron-form/iron-form.js';
 import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-layout.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-card.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-select.js';
@@ -164,7 +165,7 @@ Polymer({
   `,
 
   is: 'nuxeo-vocabulary-management',
-  behaviors: [I18nBehavior],
+  behaviors: [NotifyBehavior, I18nBehavior],
   importMeta: import.meta,
   properties: {
     vocabularies: Array,
@@ -310,17 +311,17 @@ Polymer({
       this.$.directory.remove().then(
         () => {
           this._refresh();
-          this.fire('notify', { message: this.i18n('vocabularyManagement.successfullyDeleted') });
+          this.notify({ message: this.i18n('vocabularyManagement.successfullyDeleted') });
         },
         (err) => {
           if (err.status === 409) {
-            this.fire('notify', {
+            this.notify({
               message: `${this.i18n('label.error').toUpperCase()}: ${this.i18n(
                 'vocabularyManagement.cannotDelete.referencedEntry',
               )}`,
             });
           } else {
-            this.fire('notify', {
+            this.notify({
               message: `${this.i18n('label.error').toUpperCase()}: ${this.i18n(
                 'vocabularyManagement.cannotDelete.error',
               )}`,
@@ -353,11 +354,11 @@ Polymer({
       this.$.directory.post().then(
         () => {
           this.$.vocabularyEditDialog.toggle();
-          this.fire('notify', { message: this.i18n('vocabularyManagement.successfullyCreated') });
+          this.notify({ message: this.i18n('vocabularyManagement.successfullyCreated') });
           this._refresh();
         },
         (err) => {
-          this.fire('notify', {
+          this.notify({
             message: `${this.i18n('label.error').toUpperCase()}: ${
               err.message && err.message.length > 0 ? err.message : this.i18n('vocabularyManagement.cannotCreate')
             }`,
@@ -369,11 +370,11 @@ Polymer({
       this.$.directory.put().then(
         () => {
           this.$.vocabularyEditDialog.toggle();
-          this.fire('notify', { message: this.i18n('vocabularyManagement.successfullyEdited') });
+          this.notify({ message: this.i18n('vocabularyManagement.successfullyEdited') });
           this._refresh();
         },
         (err) => {
-          this.fire('notify', {
+          this.notify({
             message: `${this.i18n('label.error').toUpperCase()}: ${
               err.message && err.message.length > 0 ? err.message : this.i18n('vocabularyManagement.cannotEdit')
             }`,
@@ -423,7 +424,7 @@ Polymer({
         return fields;
       })
       .catch(function(error) {
-        this.fire('notify', { message: this.i18n('vocabularyManagement.cannotGetSchema') });
+        this.notify({ message: this.i18n('vocabularyManagement.cannotGetSchema') });
         if (error.status !== 404) {
           throw error;
         }

--- a/elements/document/nuxeo-document-create.js
+++ b/elements/document/nuxeo-document-create.js
@@ -29,6 +29,7 @@ import '@polymer/iron-a11y-keys/iron-a11y-keys.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-path-suggestion/nuxeo-path-suggestion.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-tooltip';
 import '@nuxeo/nuxeo-elements/nuxeo-document.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-document-layout.js';
 import '../nuxeo-document-creation-stats/nuxeo-document-creation-stats.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
@@ -284,7 +285,7 @@ Polymer({
   `,
 
   is: 'nuxeo-document-create',
-  behaviors: [IronResizableBehavior, DocumentCreationBehavior],
+  behaviors: [NotifyBehavior, IronResizableBehavior, DocumentCreationBehavior],
   importMeta: import.meta,
 
   properties: {
@@ -372,7 +373,7 @@ Polymer({
         if (err && err['entity-type'] === 'validation_report') {
           this.$['document-create'].reportValidation(err);
         } else {
-          this.fire('notify', { message: this.i18n('documentCreationForm.createError') });
+          this.notify({ message: this.i18n('documentCreationForm.createError') });
           console.error(err);
         }
       })

--- a/elements/document/nuxeo-document-form-layout.js
+++ b/elements/document/nuxeo-document-form-layout.js
@@ -19,6 +19,7 @@ import '@polymer/polymer/polymer-legacy.js';
 import '@polymer/iron-form/iron-form.js';
 import '@polymer/paper-button/paper-button.js';
 import '@nuxeo/nuxeo-elements/nuxeo-document.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-document-layout.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
@@ -99,7 +100,7 @@ Polymer({
   `,
 
   is: 'nuxeo-document-form-layout',
-  behaviors: [IronResizableBehavior, I18nBehavior],
+  behaviors: [NotifyBehavior, IronResizableBehavior, I18nBehavior],
   importMeta: import.meta,
 
   properties: {
@@ -162,7 +163,7 @@ Polymer({
         if (err && err['entity-type'] === 'validation_report') {
           this.$.layout.reportValidation(err);
         } else {
-          this.fire('notify', { message: this.i18n('documentEdit.saveError') });
+          this.notify({ message: this.i18n('documentEdit.saveError') });
           console.error(err);
         }
       })

--- a/elements/document/nuxeo-document-import.js
+++ b/elements/document/nuxeo-document-import.js
@@ -31,6 +31,7 @@ import '@nuxeo/nuxeo-elements/nuxeo-connection.js';
 import '@nuxeo/nuxeo-elements/nuxeo-document.js';
 import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
 import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-select.js';
 import { UploaderBehavior } from '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-uploader-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-path-suggestion/nuxeo-path-suggestion.js';
@@ -688,7 +689,7 @@ Polymer({
   `,
 
   is: 'nuxeo-document-import',
-  behaviors: [IronResizableBehavior, UploaderBehavior, DocumentCreationBehavior],
+  behaviors: [NotifyBehavior, IronResizableBehavior, UploaderBehavior, DocumentCreationBehavior],
   importMeta: import.meta,
 
   properties: {
@@ -1178,7 +1179,7 @@ Polymer({
     this.set('_creating', false);
     this.set('_importErrorMessage', this.i18n('documentImport.error.importFailed'));
     const message = error.message || (error.detail && error.detail.error);
-    this.fire('notify', { message: `${this.i18n('label.error').toUpperCase()}: ${message}` });
+    this.notify({ message: `${this.i18n('label.error').toUpperCase()}: ${message}` });
   },
 
   _mergeResponses(...args) {

--- a/elements/nuxeo-cloud-services/nuxeo-cloud-consumers.js
+++ b/elements/nuxeo-cloud-services/nuxeo-cloud-consumers.js
@@ -20,6 +20,7 @@ import '@polymer/paper-button/paper-button.js';
 import '@polymer/paper-checkbox/paper-checkbox.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
 import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { FormatBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-format-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-data-table/iron-data-table.js';
@@ -38,7 +39,7 @@ const OAUTH2_CONSUMERS_BASE_PATH = '/oauth2/client/';
  *
  * @memberof Nuxeo
  */
-class CloudConsumers extends mixinBehaviors([FormatBehavior], Nuxeo.Element) {
+class CloudConsumers extends mixinBehaviors([NotifyBehavior, FormatBehavior], Nuxeo.Element) {
   static get template() {
     return html`
       <style include="nuxeo-styles iron-flex iron-flex-alignment">
@@ -239,10 +240,10 @@ class CloudConsumers extends mixinBehaviors([FormatBehavior], Nuxeo.Element) {
       () => {
         this.refresh();
         this.$.dialog.toggle();
-        this.fire('notify', { message: this.i18n('cloudConsumers.successfullyCreated') });
+        this.notify({ message: this.i18n('cloudConsumers.successfullyCreated') });
       },
       (err) => {
-        this.fire('notify', {
+        this.notify({
           message: `${this.i18n('label.error').toUpperCase()}: ${
             err.message && err.message.length > 0 ? err.message : this.i18n('cloudConsumers.errorCreating')
           }`,
@@ -257,11 +258,11 @@ class CloudConsumers extends mixinBehaviors([FormatBehavior], Nuxeo.Element) {
     this.$.oauth.put().then(
       () => {
         this.$.dialog.toggle();
-        this.fire('notify', { message: this.i18n('cloudConsumers.successfullyEdited') });
+        this.notify({ message: this.i18n('cloudConsumers.successfullyEdited') });
         this.refresh();
       },
       (err) => {
-        this.fire('notify', {
+        this.notify({
           message: `${this.i18n('label.error').toUpperCase()}: ${
             err.message && err.message.length > 0 ? err.message : this.i18n('cloudConsumers.errorEditing')
           }`,
@@ -277,10 +278,10 @@ class CloudConsumers extends mixinBehaviors([FormatBehavior], Nuxeo.Element) {
       this.$.oauth.remove().then(
         () => {
           this.refresh();
-          this.fire('notify', { message: this.i18n('cloudConsumers.successfullyDeleted') });
+          this.notify({ message: this.i18n('cloudConsumers.successfullyDeleted') });
         },
         () => {
-          this.fire('notify', {
+          this.notify({
             message: `${this.i18n('label.error').toUpperCase()}: ${this.i18n('cloudConsumers.errorDeleting')}`,
           });
         },

--- a/elements/nuxeo-cloud-services/nuxeo-cloud-providers.js
+++ b/elements/nuxeo-cloud-services/nuxeo-cloud-providers.js
@@ -21,6 +21,7 @@ import '@polymer/paper-button/paper-button.js';
 import '@polymer/paper-checkbox/paper-checkbox.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
 import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { FormatBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-format-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-data-table/iron-data-table.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-card.js';
@@ -172,7 +173,7 @@ Polymer({
   `,
 
   is: 'nuxeo-cloud-providers',
-  behaviors: [FormatBehavior],
+  behaviors: [NotifyBehavior, FormatBehavior],
 
   properties: {
     _selectedEntry: {
@@ -243,10 +244,10 @@ Polymer({
       () => {
         this.refresh();
         this.$.dialog.toggle();
-        this.fire('notify', { message: this.i18n('cloudProviders.successfullyCreated') });
+        this.notify({ message: this.i18n('cloudProviders.successfullyCreated') });
       },
       (err) => {
-        this.fire('notify', {
+        this.notify({
           message: `${this.i18n('label.error').toUpperCase()}: ${
             err.message && err.message.length > 0 ? err.message : this.i18n('cloudProviders.errorCreating')
           }`,
@@ -261,11 +262,11 @@ Polymer({
     this.$.oauth.put().then(
       () => {
         this.$.dialog.toggle();
-        this.fire('notify', { message: this.i18n('cloudProviders.successfullyEdited') });
+        this.notify({ message: this.i18n('cloudProviders.successfullyEdited') });
         this.refresh();
       },
       (err) => {
-        this.fire('notify', {
+        this.notify({
           message: `${this.i18n('label.error').toUpperCase()}: ${
             err.message && err.message.length > 0 ? err.message : this.i18n('cloudProviders.errorEditing')
           }`,
@@ -281,10 +282,10 @@ Polymer({
       this.$.oauth.remove().then(
         () => {
           this.refresh();
-          this.fire('notify', { message: this.i18n('cloudProviders.successfullyDeleted') });
+          this.notify({ message: this.i18n('cloudProviders.successfullyDeleted') });
         },
         () => {
-          this.fire('notify', {
+          this.notify({
             message: `${this.i18n('label.error').toUpperCase()}: ${this.i18n('cloudProviders.errorDeleting')}`,
           });
         },

--- a/elements/nuxeo-cloud-services/nuxeo-tokens-behavior.js
+++ b/elements/nuxeo-cloud-services/nuxeo-tokens-behavior.js
@@ -14,6 +14,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 
 /**
  * `Nuxeo.TokenBehavior` allows the management of oAuth2 token.
@@ -21,6 +22,7 @@
  * @polymerBehavior
  */
 export const TokenBehavior = [
+  NotifyBehavior,
   {
     properties: {
       tokens: {
@@ -76,10 +78,10 @@ export const TokenBehavior = [
         this.resource.remove().then(
           () => {
             this.refresh();
-            this.fire('notify', { message: this.i18n('cloudTokens.successfullyDeleted') });
+            this.notify({ message: this.i18n('cloudTokens.successfullyDeleted') });
           },
           () => {
-            this.fire('notify', {
+            this.notify({
               message: `${this.i18n('label.error').toUpperCase()}: ${this.i18n('cloudTokens.errorDeleting')}`,
             });
           },
@@ -97,10 +99,10 @@ export const TokenBehavior = [
           () => {
             this.$.dialog.toggle();
             this.refresh();
-            this.fire('notify', { message: this.i18n('cloudTokens.successfullyEdited') });
+            this.notify({ message: this.i18n('cloudTokens.successfullyEdited') });
           },
           (err) => {
-            this.fire('notify', {
+            this.notify({
               message: `${this.i18n('label.error').toUpperCase()}: ${
                 err.message && err.message.length > 0 ? err.message : this.i18n('cloudTokens.errorEditing')
               }`,

--- a/elements/nuxeo-csv-export/nuxeo-csv-export-button.js
+++ b/elements/nuxeo-csv-export/nuxeo-csv-export-button.js
@@ -16,6 +16,7 @@ limitations under the License.
 */
 import '@polymer/polymer/polymer-legacy.js';
 
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-operation-button.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
 import { FiltersBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-filters-behavior.js';
@@ -46,7 +47,7 @@ Polymer({
   `,
 
   is: 'nuxeo-csv-export-button',
-  behaviors: [I18nBehavior, FiltersBehavior],
+  behaviors: [NotifyBehavior, I18nBehavior, FiltersBehavior],
 
   properties: {
     /**
@@ -113,10 +114,10 @@ Polymer({
   },
 
   _onPollStart() {
-    this.fire('notify', { message: this.i18n('csvExportButton.action.poll') });
+    this.notify({ message: this.i18n('csvExportButton.action.poll') });
   },
 
   _onResponse() {
-    this.fire('notify', { message: this.i18n('csvExportButton.action.completed') });
+    this.notify({ message: this.i18n('csvExportButton.action.completed') });
   },
 });

--- a/elements/nuxeo-document-attachments/nuxeo-document-attachments.js
+++ b/elements/nuxeo-document-attachments/nuxeo-document-attachments.js
@@ -18,6 +18,7 @@ import '@polymer/polymer/polymer-legacy.js';
 
 import { createNestedObject } from '@nuxeo/nuxeo-elements/utils.js';
 import '@nuxeo/nuxeo-elements/nuxeo-document.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { FiltersBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-filters-behavior.js';
 import { FormatBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-format-behavior.js';
 import '../nuxeo-document-blob/nuxeo-document-blob.js';
@@ -84,7 +85,7 @@ Polymer({
   `,
 
   is: 'nuxeo-document-attachments',
-  behaviors: [FormatBehavior, FiltersBehavior],
+  behaviors: [NotifyBehavior, FormatBehavior, FiltersBehavior],
 
   properties: {
     document: Object,
@@ -125,7 +126,7 @@ Polymer({
 
     this.$.doc.put().then((response) => {
       this.document = response;
-      this.fire('notify', { message: this.i18n(this.uploadedMessage) });
+      this.notify({ message: this.i18n(this.uploadedMessage) });
       this.fire('document-updated');
     });
   },

--- a/elements/nuxeo-document-bulk-actions/nuxeo-download-documents-button.js
+++ b/elements/nuxeo-document-bulk-actions/nuxeo-download-documents-button.js
@@ -16,6 +16,7 @@ limitations under the License.
 */
 import '@polymer/polymer/polymer-legacy.js';
 
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-operation-button.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-icons.js';
 import { FiltersBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-filters-behavior.js';
@@ -45,7 +46,7 @@ Polymer({
   `,
 
   is: 'nuxeo-download-documents-button',
-  behaviors: [I18nBehavior, FiltersBehavior],
+  behaviors: [NotifyBehavior, I18nBehavior, FiltersBehavior],
 
   properties: {
     documents: {
@@ -87,10 +88,10 @@ Polymer({
   },
 
   _onPollStart() {
-    this.fire('notify', { message: this.i18n('bulkDownload.preparing'), duration: 0, dismissible: true });
+    this.notify({ message: this.i18n('bulkDownload.preparing'), duration: 0, dismissible: true });
   },
 
   _onResponse() {
-    this.fire('notify', { message: this.i18n('bulkDownload.completed'), close: true });
+    this.notify({ message: this.i18n('bulkDownload.completed'), close: true });
   },
 });

--- a/elements/nuxeo-document-create-popup/nuxeo-document-create-popup.js
+++ b/elements/nuxeo-document-create-popup/nuxeo-document-create-popup.js
@@ -22,6 +22,7 @@ import '@polymer/paper-tabs/paper-tabs.js';
 import '@polymer/iron-pages/iron-pages.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
 import '@nuxeo/nuxeo-elements/nuxeo-document.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-slots.js';
@@ -107,7 +108,7 @@ Polymer({
   `,
 
   is: 'nuxeo-document-create-popup',
-  behaviors: [I18nBehavior],
+  behaviors: [NotifyBehavior, I18nBehavior],
 
   properties: {
     parent: {
@@ -166,7 +167,7 @@ Polymer({
     this._showTabs = false;
     this._fetchParent().then(() => {
       if (this._noPermission) {
-        this.fire('notify', { message: this.i18n('documentCreationBehavior.error.noPermission') });
+        this.notify({ message: this.i18n('documentCreationBehavior.error.noPermission') });
       } else {
         this.$$('#simpleCreation').init(type);
         this.$$('#bulkCreation').init();
@@ -179,7 +180,7 @@ Polymer({
     this.selectedTab = 'import';
     this._fetchParent().then(() => {
       if (this._noPermission) {
-        this.fire('notify', { message: this.i18n('documentCreationBehavior.error.noPermission') });
+        this.notify({ message: this.i18n('documentCreationBehavior.error.noPermission') });
       } else {
         this.$$('#simpleCreation').init();
         this.$$('#bulkCreation').init(files);
@@ -191,7 +192,7 @@ Polymer({
   toggleDialog() {
     this._fetchParent().then(() => {
       if (this._noPermission) {
-        this.fire('notify', { message: this.i18n('documentCreationBehavior.error.noPermission') });
+        this.notify({ message: this.i18n('documentCreationBehavior.error.noPermission') });
       } else {
         this.$$('#simpleCreation').init();
         this.$$('#bulkCreation').init();

--- a/elements/nuxeo-document-viewer/nuxeo-document-viewer.js
+++ b/elements/nuxeo-document-viewer/nuxeo-document-viewer.js
@@ -17,6 +17,7 @@ limitations under the License.
 import '@polymer/polymer/polymer-legacy.js';
 
 import '@polymer/iron-image/iron-image.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
 import { FiltersBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-filters-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-document-preview.js';
@@ -64,7 +65,7 @@ Polymer({
   `,
 
   is: 'nuxeo-document-viewer',
-  behaviors: [I18nBehavior, FiltersBehavior],
+  behaviors: [NotifyBehavior, I18nBehavior, FiltersBehavior],
 
   properties: {
     document: Object,
@@ -89,7 +90,7 @@ Polymer({
 
     this.$.doc.put().then((response) => {
       this.document = response;
-      this.fire('notify', { message: this.i18n(this.uploadedMessage) });
+      this.notify({ message: this.i18n(this.uploadedMessage) });
       this.fire('document-updated');
     });
   },

--- a/elements/nuxeo-dropzone/nuxeo-dropzone.js
+++ b/elements/nuxeo-dropzone/nuxeo-dropzone.js
@@ -22,9 +22,10 @@ import '@polymer/paper-progress/paper-progress.js';
 import '@nuxeo/nuxeo-elements/nuxeo-connection.js';
 import '@nuxeo/nuxeo-elements/nuxeo-document.js';
 import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
+import { createNestedObject } from '@nuxeo/nuxeo-elements/utils.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-icons.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-slots.js';
-import { createNestedObject } from '@nuxeo/nuxeo-elements/utils.js';
 import { FormatBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-format-behavior.js';
 import { UploaderBehavior } from '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-uploader-behavior.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
@@ -225,7 +226,7 @@ Polymer({
   `,
 
   is: 'nuxeo-dropzone',
-  behaviors: [UploaderBehavior, FormatBehavior, IronValidatableBehavior],
+  behaviors: [NotifyBehavior, UploaderBehavior, FormatBehavior, IronValidatableBehavior],
 
   properties: {
     /**
@@ -423,7 +424,7 @@ Polymer({
       this._legacyImportBatch(value);
     }
     if (failed.length > 0) {
-      this.fire('notify', {
+      this.notify({
         message: this.i18n('dropzone.toast.error', failed.map((f) => f.name).join(', ')),
         duration: 0,
         dismissible: true,
@@ -432,7 +433,7 @@ Polymer({
       if (this.document && this.xpath) {
         await this._legacyUpdateDocument();
       }
-      this.fire('notify', { message: this.i18n(this.uploadedMessage), close: true });
+      this.notify({ message: this.i18n(this.uploadedMessage), close: true });
       this.invalid = false;
     }
     if (this.invalid) {

--- a/elements/nuxeo-note-editor/nuxeo-note-editor.js
+++ b/elements/nuxeo-note-editor/nuxeo-note-editor.js
@@ -20,6 +20,7 @@ import '@nuxeo/nuxeo-elements/nuxeo-document.js';
 import '@polymer/paper-button/paper-button.js';
 import '@polymer/paper-input/paper-textarea.js';
 import '@polymer/paper-tooltip/paper-tooltip.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-icons.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-document-preview.js';
 import { LayoutBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-layout-behavior.js';
@@ -147,7 +148,7 @@ Polymer({
   `,
 
   is: 'nuxeo-note-editor',
-  behaviors: [LayoutBehavior],
+  behaviors: [NotifyBehavior, LayoutBehavior],
 
   properties: {
     document: {
@@ -189,7 +190,7 @@ Polymer({
       },
     };
     this.$.note.put().then(() => {
-      this.fire('notify', { message: this.i18n('noteViewLayout.note.saved') });
+      this.notify({ message: this.i18n('noteViewLayout.note.saved') });
       this._viewMode = true;
       this.fire('document-updated');
     });

--- a/elements/nuxeo-publication/nuxeo-document-publications.js
+++ b/elements/nuxeo-publication/nuxeo-document-publications.js
@@ -18,6 +18,7 @@ import '@polymer/polymer/polymer-legacy.js';
 
 import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
 import '@nuxeo/nuxeo-elements/nuxeo-page-provider.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { LayoutBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-layout-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-card.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-date.js';
@@ -165,7 +166,7 @@ Polymer({
   `,
 
   is: 'nuxeo-document-publications',
-  behaviors: [LayoutBehavior],
+  behaviors: [NotifyBehavior, LayoutBehavior],
 
   properties: {
     document: Object,
@@ -224,11 +225,11 @@ Polymer({
       this.$.unpublishOp
         .execute()
         .then(() => {
-          this.fire('notify', { message: this.i18n('publication.unpublish.success') });
+          this.notify({ message: this.i18n('publication.unpublish.success') });
           this._fetchPublications();
         })
         .catch(() => {
-          this.fire('notify', { message: this.i18n('publication.unpublish.error') });
+          this.notify({ message: this.i18n('publication.unpublish.error') });
         });
     }
   },
@@ -248,14 +249,14 @@ Polymer({
       this.$.publishOp
         .execute()
         .then(() => {
-          this.fire('notify', {
+          this.notify({
             message: this.i18n('publication.internal.publish.success'),
           });
           this.fire('document-updated');
           this.fire('nx-publish-success');
         })
         .catch((err) => {
-          this.fire('notify', {
+          this.notify({
             message: this.i18n('publication.internal.publish.error'),
           });
           throw err;
@@ -294,11 +295,11 @@ Polymer({
     this.$.unpublishAllOp
       .execute()
       .then(() => {
-        this.fire('notify', { message: this.i18n('publication.unpublish.all.success') });
+        this.notify({ message: this.i18n('publication.unpublish.all.success') });
         this._fetchPublications();
       })
       .catch(function() {
-        this.fire('notify', { message: this.i18n('publication.unpublish.all.error') });
+        this.notify({ message: this.i18n('publication.unpublish.all.error') });
       });
   },
 

--- a/elements/nuxeo-publication/nuxeo-internal-publish.js
+++ b/elements/nuxeo-publication/nuxeo-internal-publish.js
@@ -25,6 +25,7 @@ import '@polymer/paper-checkbox/paper-checkbox.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
 import '@polymer/paper-input/paper-input.js';
 import '@polymer/polymer/lib/elements/dom-if.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
 import { LayoutBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-layout-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-icons.js';
@@ -138,7 +139,7 @@ Polymer({
   `,
 
   is: 'nuxeo-internal-publish',
-  behaviors: [I18nBehavior, LayoutBehavior],
+  behaviors: [NotifyBehavior, I18nBehavior, LayoutBehavior],
 
   properties: {
     /**
@@ -205,7 +206,7 @@ Polymer({
     this.$.op
       .execute()
       .then(() => {
-        this.fire('notify', {
+        this.notify({
           message: this.i18n(`publication.internal.publish.success${this._isMultiple ? '.multiple' : ''}`),
         });
         if (this._isMultiple) {
@@ -216,7 +217,7 @@ Polymer({
         this.fire('nx-publish-success');
       })
       .catch((err) => {
-        this.fire('notify', {
+        this.notify({
           message: this.i18n(`publication.internal.publish.error${this._isMultiple ? '.multiple' : ''}`),
         });
         throw err;

--- a/elements/nuxeo-publication/nuxeo-unpublish-button.js
+++ b/elements/nuxeo-publication/nuxeo-unpublish-button.js
@@ -17,6 +17,7 @@ limitations under the License.
 import '@polymer/polymer/polymer-legacy.js';
 
 import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { FiltersBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-filters-behavior.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
 import { RoutingBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-routing-behavior.js';
@@ -62,7 +63,7 @@ Polymer({
   `,
 
   is: 'nuxeo-unpublish-button',
-  behaviors: [I18nBehavior, RoutingBehavior, FiltersBehavior],
+  behaviors: [NotifyBehavior, I18nBehavior, RoutingBehavior, FiltersBehavior],
 
   properties: {
     document: Object,
@@ -76,11 +77,11 @@ Polymer({
     this.$.unpublishOp
       .execute()
       .then(() => {
-        this.fire('notify', { message: this.i18n('publication.unpublish.success') });
+        this.notify({ message: this.i18n('publication.unpublish.success') });
         this.fire('nx-unpublish-success');
       })
       .catch(() => {
-        this.fire('notify', { message: this.i18n('publication.unpublish.error') });
+        this.notify({ message: this.i18n('publication.unpublish.error') });
       });
   },
 });

--- a/elements/nuxeo-results/nuxeo-document-content-behavior.js
+++ b/elements/nuxeo-results/nuxeo-document-content-behavior.js
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import { IronResizableBehavior } from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
-
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { LayoutBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-layout-behavior.js';
 
 /**
@@ -23,6 +23,7 @@ import { LayoutBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-layout-behavior.j
  */
 export const DocumentContentBehavior = [
   IronResizableBehavior,
+  NotifyBehavior,
   LayoutBehavior,
   {
     properties: {
@@ -150,18 +151,18 @@ export const DocumentContentBehavior = [
 
     _dragoverImport(e) {
       e.preventDefault();
-      this.fire('notify', { message: this.i18n('documentContentView.drag.import'), duration: 0 });
+      this.notify({ message: this.i18n('documentContentView.drag.import'), duration: 0 });
       this._toggleDragging(true);
     },
 
     _dragleaveImport() {
-      this.fire('notify', { close: true });
+      this.notify({ close: true });
       this._toggleDragging(false);
     },
 
     _dropImport(e) {
       e.preventDefault();
-      this.fire('notify', { close: true });
+      this.notify({ close: true });
       this._toggleDragging(false);
       this.fire('create-document', { files: e.dataTransfer.files });
     },

--- a/elements/nuxeo-results/nuxeo-document-trash-content.js
+++ b/elements/nuxeo-results/nuxeo-document-trash-content.js
@@ -20,6 +20,7 @@ import '@polymer/paper-button/paper-button.js';
 import '@nuxeo/nuxeo-elements/nuxeo-connection.js';
 import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
 import '@nuxeo/nuxeo-elements/nuxeo-page-provider.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-date.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-tag.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-user-tag.js';
@@ -287,7 +288,7 @@ Polymer({
   `,
 
   is: 'nuxeo-document-trash-content',
-  behaviors: [DocumentContentBehavior],
+  behaviors: [NotifyBehavior, DocumentContentBehavior],
 
   properties: {
     /**
@@ -342,11 +343,11 @@ Polymer({
     this.$.opEmptyTrash
       .execute()
       .then(() => {
-        this.fire('notify', { message: this.i18n('documentTrashContent.emptyTrash.success') });
+        this.notify({ message: this.i18n('documentTrashContent.emptyTrash.success') });
         this._refresh();
       })
       .catch((error) => {
-        this.fire('notify', { message: this.i18n('documentTrashContent.emptyTrash.error') });
+        this.notify({ message: this.i18n('documentTrashContent.emptyTrash.error') });
         if (error.status !== 404) {
           throw error;
         }

--- a/elements/nuxeo-user-authorized-apps.html
+++ b/elements/nuxeo-user-authorized-apps.html
@@ -74,7 +74,7 @@ limitations under the License.
 
     Polymer({
       is: 'nuxeo-user-authorized-apps',
-      behaviors: [Nuxeo.I18nBehavior],
+      behaviors: [Nuxeo.NotifyBehavior, Nuxeo.I18nBehavior],
       properties: {
         visible: {
           type: Boolean,
@@ -131,13 +131,13 @@ limitations under the License.
             () => {
               this.refresh();
               this.fire('authorized-app-revoked');
-              this.fire('notify', {
+              this.notify({
                 message: this.i18n('authorizedApps.successfullyRevoked', client.name),
               });
             },
             () => {
               this.refresh();
-              this.fire('notify', {
+              this.notify({
                 message: `${this.i18n('label.error').toUpperCase()}: ${this.i18n(
                   'authorizedApps.errorRevoking',
                   client.name,

--- a/elements/nuxeo-workflow-graph/nuxeo-workflow-graph.js
+++ b/elements/nuxeo-workflow-graph/nuxeo-workflow-graph.js
@@ -20,6 +20,7 @@ import { IronResizableBehavior } from '@polymer/iron-resizable-behavior/iron-res
 import '@polymer/paper-button/paper-button.js';
 import '@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js';
 import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-dialog.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
@@ -179,7 +180,7 @@ Polymer({
   `,
 
   is: 'nuxeo-workflow-graph',
-  behaviors: [I18nBehavior, IronResizableBehavior],
+  behaviors: [NotifyBehavior, I18nBehavior, IronResizableBehavior],
 
   properties: {
     workflowId: {
@@ -251,7 +252,7 @@ Polymer({
         this.$.graphDialog.toggle();
       })
       .catch((error) => {
-        this.fire('notify', { message: this.i18n('documentPage.route.view.graph.error') });
+        this.notify({ message: this.i18n('documentPage.route.view.graph.error') });
         throw error;
       });
   },

--- a/elements/search/nuxeo-search-form.js
+++ b/elements/search/nuxeo-search-form.js
@@ -26,6 +26,7 @@ import '@polymer/paper-spinner/paper-spinner-lite.js';
 import '@polymer/paper-toggle-button/paper-toggle-button.js';
 import '@nuxeo/nuxeo-elements/nuxeo-page-provider.js';
 import '@nuxeo/nuxeo-elements/nuxeo-search.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-layout.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
 import { RoutingBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-routing-behavior.js';
@@ -418,7 +419,7 @@ Polymer({
   `,
 
   is: 'nuxeo-search-form',
-  behaviors: [I18nBehavior, RoutingBehavior, IronResizableBehavior],
+  behaviors: [NotifyBehavior, I18nBehavior, RoutingBehavior, IronResizableBehavior],
   importMeta: import.meta,
 
   properties: {
@@ -939,7 +940,7 @@ Polymer({
     if (e.detail.error && e.detail.error.name === 'AbortError') {
       return;
     }
-    this.fire('notify', e.detail.error);
+    this.notify(e.detail.error);
   },
 
   /**

--- a/elements/workflow/nuxeo-document-task.js
+++ b/elements/workflow/nuxeo-document-task.js
@@ -21,6 +21,7 @@ import '@polymer/iron-form/iron-form.js';
 import '@polymer/iron-pages/iron-pages.js';
 import '@polymer/paper-button/paper-button.js';
 import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { RoutingBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-routing-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-date.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-layout.js';
@@ -210,7 +211,7 @@ Polymer({
   `,
 
   is: 'nuxeo-document-task',
-  behaviors: [RoutingBehavior, FormatBehavior],
+  behaviors: [NotifyBehavior, RoutingBehavior, FormatBehavior],
   importMeta: import.meta,
   properties: {
     task: {
@@ -288,14 +289,14 @@ Polymer({
       })
       .catch((error) => {
         if (error.status === 409 || error.status === 403) {
-          this.fire('notify', {
+          this.notify({
             message: this.i18n(`tasks.submit.error.${error.status === 409 ? 'alreadyFinished' : 'noPermissions'}`),
             dismissible: true,
             duration: 30000,
           });
           this.fire('workflowTaskProcessed');
         } else {
-          this.fire('notify', { message: this.i18n('tasks.submit.error') });
+          this.notify({ message: this.i18n('tasks.submit.error') });
           throw error;
         }
       })

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ import { IronValidatorBehavior } from '@polymer/iron-validator-behavior/iron-val
 import { Templatizer } from '@polymer/polymer/lib/legacy/templatizer-behavior.js';
 
 // expose behaviors for compat
+import { NotifyBehavior, setFallbackNotificationTarget } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { AggregationBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-aggregation/nuxeo-aggregation-behavior.js';
 import { FiltersBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-filters-behavior.js';
 import { FormatBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-format-behavior.js';
@@ -52,6 +53,7 @@ Polymer.IronResizableBehavior = IronResizableBehavior;
 Polymer.IronValidatableBehavior = IronValidatableBehavior;
 Polymer.IronValidatorBehavior = IronValidatorBehavior;
 Polymer.Templatizer = Templatizer;
+Nuxeo.NotifyBehavior = NotifyBehavior;
 Nuxeo.AggregationBehavior = AggregationBehavior;
 Nuxeo.ChartDataBehavior = ChartDataBehavior;
 Nuxeo.DocumentContentBehavior = DocumentContentBehavior;
@@ -89,6 +91,7 @@ Promise.all(
     if (!Nuxeo.UI.app) {
       console.error('could not find nuxeo-app');
     }
+    setFallbackNotificationTarget(Nuxeo.UI.app);
   })
   .then(async () => {
     if (Nuxeo.UI.config.router && Nuxeo.UI.config.router.htmlImport) {


### PR DESCRIPTION
Depends on https://github.com/nuxeo/nuxeo-elements/pull/418.

As a POC, I modified `nuxeo-csv-export-button`, which is quite easy to test on the UI:
1. Navigate to a folder with several leaf documents
2. Switch network trotting to Fast or even Slot 3G.
3. Click the export button (you should still see the toast "CSV export is running")
4. Navigate to a leaf document
5. You will see the toast "CSV export is ready" (which would not show up before, because it is being fired from an element that is no longer stamped)