### PR TITLE
Fixing possible NPE when clipboard is disabled.

### DIFF
--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -1469,11 +1469,13 @@ Polymer({
   },
 
   _removeFromClipboard(docs) {
-    if (Array.isArray(docs)) {
-      docs.forEach((doc) => {
-        this.clipboard.remove(doc);
-      });
-    }
+    if (this.clipboard) {
+      if (Array.isArray(docs)) {
+        docs.forEach((doc) => {
+          this.clipboard.remove(doc);
+        });
+      }
+    }    
   },
 
   _removeFromRecentlyViewed(docs) {


### PR DESCRIPTION
When user disables clipboard document-deleted event handler no longer works because of an NPE.