### PR TITLE
WEBUI-465: use fulltext instead of title in document picker search form

### DIFF
--- a/elements/search/document_picker/nuxeo-document_picker-search-form.html
+++ b/elements/search/document_picker/nuxeo-document_picker-search-form.html
@@ -9,7 +9,7 @@
     <nuxeo-input
       role="widget"
       id="searchInput"
-      value="{{params.title}}"
+      value="{{params.fulltext_all}}"
       label="[[i18n('pickerSearch.title')]]"
       type="text"
       autofocus

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo</groupId>
     <artifactId>nuxeo-parent</artifactId>
-    <version>2021.8</version>
+    <version>2021.9</version>
   </parent>
 
   <groupId>org.nuxeo.web.ui</groupId>


### PR DESCRIPTION
Notice that this cannot be merged before the platform team promotes a new release that includes this https://github.com/nuxeo/nuxeo-lts/pull/238/files#diff-b8d9259ccea414353511fca16881e72d046a6d9806171a8f1cf35536efa9d912L11