### PR TITLE
WEBUI-488: update Safari to v15 in Saucelabs

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -38,7 +38,7 @@ if (process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY) {
     sl_latest_safari: {
       base: 'SauceLabs',
       browserName: 'safari',
-      platform: 'macOS 10.13',
+      platform: 'macOS 11.00',
       version: 'latest',
     },
   };


### PR DESCRIPTION
Notes: 
- Updated the MacOSx version to Big Sur (once Saucelabs update the Bigsur's Safari version, we will use it)