### PR TITLE
ELEMENTS-1348: compute hrefBase on nuxeo-search-page and nuxeo-note-editor

### DIFF
--- a/elements/nuxeo-note-editor/nuxeo-note-editor.js
+++ b/elements/nuxeo-note-editor/nuxeo-note-editor.js
@@ -100,7 +100,11 @@ Polymer({
             >[[_computeHtmlEditLabel(_viewMode, i18n)]]</paper-tooltip
           >
           <template is="dom-if" if="[[_viewMode]]">
-            <nuxeo-html-editor value="{{_value}}" read-only="[[!_canEdit(document)]]"></nuxeo-html-editor>
+            <nuxeo-html-editor
+              value="{{_value}}"
+              read-only="[[!_canEdit(document)]]"
+              href-base="[[_computeHrefBase()]]"
+            ></nuxeo-html-editor>
           </template>
           <template is="dom-if" if="[[!_viewMode]]">
             <paper-textarea
@@ -149,6 +153,7 @@ Polymer({
 
   is: 'nuxeo-note-editor',
   behaviors: [NotifyBehavior, LayoutBehavior],
+  importMeta: import.meta,
 
   properties: {
     document: {
@@ -216,5 +221,9 @@ Polymer({
 
   _toggleHtmlSource() {
     this._viewMode = !this._viewMode;
+  },
+
+  _computeHrefBase() {
+    return `${this.importPath}../search/`;
   },
 });

--- a/elements/nuxeo-search-page.js
+++ b/elements/nuxeo-search-page.js
@@ -66,6 +66,7 @@ Polymer({
           show-filters="[[showFilters]]"
           opened="[[opened]]"
           search-form="[[searchForm]]"
+          href-base="[[_computeHrefBase()]]"
         ></nuxeo-results-view>
       </div>
     </nuxeo-page>
@@ -73,6 +74,7 @@ Polymer({
 
   is: 'nuxeo-search-page',
   behaviors: [I18nBehavior],
+  importMeta: import.meta,
 
   properties: {
     showSavedSearchActions: {
@@ -165,5 +167,9 @@ Polymer({
      * `loading`, `aggregations`, `quickFilters` and `auto`.
      */
     searchForm: Object,
+  },
+
+  _computeHrefBase() {
+    return `${this.importPath}search/`;
   },
 });


### PR DESCRIPTION
This is another take on the problem described by ELEMENTS-1348 (see https://github.com/nuxeo/nuxeo-elements/pull/427). The goal is to redefined the hrefBase property of the nuxeo-results-view (even if nested inside the html editor) on Web UI, as this is the only place where we know where the default layouts live (the search/ folder).

Notes: I don't particularly like that we need to expose the hrefBase on the `nuxeo-html-editor` element. The alternative would be to pierce the shadow dom on the note editor element or use a different approach. Suggestions are more than welcome.

Note that I have used an ELEMENTS ticket but I will create a WEBUI one if we agree that doing a fix on both ends makes sense.