### PR TITLE
WEBUI-188: set user and email for git config in build workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - run: git config user.name "nuxeo-web-ui-jx-bot" && git config user.email "ui+jx-bot@nuxeo.com"
+
     - uses: actions/setup-node@v1
       with:
         registry-url: 'https://packages.nuxeo.com/repository/npm-public/'


### PR DESCRIPTION
Note: copied from the promote workflow (tag creation step failed because this information was not set)