### PR TITLE
WEBUI-188: update ftest framework and connect preprod with padded version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -123,7 +123,9 @@ jobs:
       env:
         CONNECT_PREPROD_URL: https://nos-preprod-connect.nuxeocloud.com/nuxeo
       run: |
-        PACKAGE="plugin/web-ui/marketplace/target/nuxeo-web-ui-marketplace-${VERSION}.zip"
+        PADDED=$(printf '%03d' $(echo $VERSION | sed -r s/[0-9]+\.[0-9]+\.[0-9]+-rc\.\([0-9]+\)/\\1/g))
+        PADDED_VERSION=$(echo $VERSION | sed -E "s/([0-9]+\.[0-9]+\.[0-9]+-rc\.)[0-9]+/\\1$PADDED/g")
+        PACKAGE="plugin/web-ui/marketplace/target/nuxeo-web-ui-marketplace-${PADDED_VERSION}.zip"
         curl -i -u "${{ secrets.CONNECT_PREPROD_AUTH }}" -F package=@$PACKAGE "$CONNECT_PREPROD_URL/site/marketplace/upload?batch=true"
 
     - name: Publish Web UI FTest framework

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -128,8 +128,9 @@ jobs:
 
     - name: Publish Web UI FTest framework
       if: github.event_name == 'push'
-      working-directory: packages/nuxeo-web-ui-ftest
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: |
-        npm publish --@nuxeo:registry=https://packages.nuxeo.com/repository/npm-public --tag SNAPSHOT
+        pushd packages/nuxeo-web-ui-ftest/
+        npm publish --@nuxeo:registry=https://packages.nuxeo.com/repository/npm-public/ --tag SNAPSHOT
+        popd


### PR DESCRIPTION
It seems that using the `working-directory` is making `npm publish` to fail, so we're now using the same strategy that we use in the promote workflow.

Added another commit to use the padded version when uploading to connect preprod.