### PR TITLE
WEBUI-569: cross-repo ondemand build

### DIFF
--- a/.github/workflows/ondemand-main.yaml
+++ b/.github/workflows/ondemand-main.yaml
@@ -9,17 +9,32 @@ on:
         required: true
       sauce_labs:
         description: 'Should unit tests be run on Sauce Labs?'
-        default: 'true'
+        default: true
+        type: boolean
         required: false
       skip_ftests:
         description: 'Should the functional tests be skipped?'
+        type: boolean
         required: false
       skip_unit_tests:
         description: 'Should the unit tests be skipped?'
+        type: boolean
         required: false
       generate_metrics:
         description: 'Should the metrics report be generated?'
+        type: boolean
         required: false
+      run_all:
+        description: 'Should fail fast premise be skipped?'
+        type: boolean
+        required: false
+      bail:
+        description: 'Number of failed features to stop test runner (default value 0 means not applicable).'
+        default: 0
+        required: false
+
+env:
+  REFERENCE_BRANCH: maintenance-3.0.x
 
 jobs:
   build:
@@ -37,7 +52,7 @@ jobs:
           if git ls-remote --exit-code --heads https://github.com/nuxeo/nuxeo-web-ui ${{ github.event.inputs.branch_name }}; then
             echo ::set-output name=branch::${{ github.event.inputs.branch_name }}
           else
-            echo ::set-output name=branch::maintenance-3.0.x
+            echo ::set-output name=branch::${{ env.REFERENCE_BRANCH }}
           fi
 
       - name: Checkout nuxeo-web-ui repo
@@ -51,7 +66,7 @@ jobs:
           if git ls-remote --exit-code --heads https://github.com/nuxeo/nuxeo-elements ${{ github.event.inputs.branch_name }}; then
             echo ::set-output name=branch::${{ github.event.inputs.branch_name }}
           else
-            echo ::set-output name=branch::maintenance-3.0.x
+            echo ::set-output name=branch::${{ env.REFERENCE_BRANCH }}
           fi
 
       - name: Checkout the nuxeo-elements repo
@@ -78,11 +93,11 @@ jobs:
         run: npm run lint
 
       - name: Unit tests
-        if: ${{ !github.event.inputs.skip_unit_tests && github.event.inputs.sauce_labs == 'false' }}
+        if: ${{ github.event.inputs.skip_unit_tests == 'false' && github.event.inputs.sauce_labs == 'false' }}
         run: npm run test
 
       - name: Unit tests (Sauce Labs)
-        if: ${{ !github.event.inputs.skip_unit_tests && github.event.inputs.sauce_labs == 'true' }}
+        if: ${{ github.event.inputs.skip_unit_tests == 'false' && github.event.inputs.sauce_labs == 'true' }}
         env:
           SAUCE_USERNAME: nuxeo-web-ui
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -101,13 +116,16 @@ jobs:
               </settings>' > ~/.m2/settings.xml
 
       - name: Nuxeo package build and Ftests
+        env:
+          RUN_ALL: ${{ github.event.inputs.run_all }}
+          BAIL: ${{ github.event.inputs.bail }}
         run: | 
           profiles=()
-          if [ "${{ github.event.inputs.skip_ftests }}" != 'true' ]
-          then
+          if [ ${{ github.event.inputs.skip_ftests }} = "false" ]
+          then 
             profiles+=('ftest') 
           fi
-          if [ ${{ github.event.inputs.generate_metrics }} ] 
+          if ${{ github.event.inputs.generate_metrics }}
           then 
             profiles+=('metrics') 
           fi

--- a/.github/workflows/ondemand-main.yaml
+++ b/.github/workflows/ondemand-main.yaml
@@ -1,0 +1,142 @@
+name: Ondemand build
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: 'The name of the branch to build.'
+        default: 'maintenance-3.0.x'
+        required: true
+      sauce_labs:
+        description: 'Should unit tests be run on Sauce Labs?'
+        default: 'true'
+        required: false
+      skip_ftests:
+        description: 'Should the functional tests be skipped?'
+        required: false
+      skip_unit_tests:
+        description: 'Should the unit tests be skipped?'
+        required: false
+      generate_metrics:
+        description: 'Should the metrics report be generated?'
+        required: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: [ self-hosted, master ]
+    steps:
+      - uses: actions/setup-node@v1
+        with:
+          registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
+          scope: '@nuxeo'
+
+      - name: Determine nuxeo-web-ui branch to use
+        id: pick_nuxeo_web_ui_branch
+        run: |
+          if git ls-remote --exit-code --heads https://github.com/nuxeo/nuxeo-web-ui ${{ github.event.inputs.branch_name }}; then
+            echo ::set-output name=branch::${{ github.event.inputs.branch_name }}
+          else
+            echo ::set-output name=branch::maintenance-3.0.x
+          fi
+
+      - name: Checkout nuxeo-web-ui repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.pick_nuxeo_web_ui_branch.outputs.branch }}
+
+      - name: Determine nuxeo-elements branch to use
+        id: pick_nuxeo_elements_branch
+        run: |
+          if git ls-remote --exit-code --heads https://github.com/nuxeo/nuxeo-elements ${{ github.event.inputs.branch_name }}; then
+            echo ::set-output name=branch::${{ github.event.inputs.branch_name }}
+          else
+            echo ::set-output name=branch::maintenance-3.0.x
+          fi
+
+      - name: Checkout the nuxeo-elements repo
+        uses: actions/checkout@v2
+        with:
+          repository: nuxeo/nuxeo-elements
+          path: nuxeo-elements
+          fetch-depth: 1
+          ref: ${{ steps.pick_nuxeo_elements_branch.outputs.branch }}
+
+      - name: Install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
+        run: |
+          npm install nuxeo-elements/core
+          npm install nuxeo-elements/ui
+          npm install nuxeo-elements/dataviz
+          npm install
+          pushd packages/nuxeo-web-ui-ftest
+          npm install
+          popd
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        if: ${{ !github.event.inputs.skip_unit_tests && github.event.inputs.sauce_labs == 'false' }}
+        run: npm run test
+
+      - name: Unit tests (Sauce Labs)
+        if: ${{ !github.event.inputs.skip_unit_tests && github.event.inputs.sauce_labs == 'true' }}
+        env:
+          SAUCE_USERNAME: nuxeo-web-ui
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+        run: npm run test
+
+      - name: 'Update settings.xml with server configuration'
+        run: |
+          echo '<settings>
+              <servers>
+                <server>
+                  <id>maven-internal</id>
+                  <username>${{ secrets.PACKAGES_AUTH_USER }}</username>
+                  <password>${{ secrets.PACKAGES_AUTH_TOKEN }}</password>
+                </server>
+              </servers>
+              </settings>' > ~/.m2/settings.xml
+
+      - name: Nuxeo package build and Ftests
+        run: | 
+          profiles=()
+          if [ "${{ github.event.inputs.skip_ftests }}" != 'true' ]
+          then
+            profiles+=('ftest') 
+          fi
+          if [ ${{ github.event.inputs.generate_metrics }} ] 
+          then 
+            profiles+=('metrics') 
+          fi
+          active_profiles=""
+          if [ ${#profiles[@]} -gt 0 ] 
+          then
+            active_profiles="-P$(printf -v active_profiles '%s,' "${profiles[@]}" && echo "${active_profiles%,}")"
+          fi
+          mvn install $active_profiles -DskipInstall
+
+      - name: Archive cucumber reports
+        uses: actions/upload-artifact@v2
+        with:
+          name: cucumber-reports
+          path: |
+            ftest/target/cucumber-reports/
+
+      - name: Archive logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: |
+            **/log/*.log
+            **/nxserver/config/distribution.properties
+
+      - name: Archive packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: packages
+          path: |
+            plugin/web-ui/marketplace/target/nuxeo-web-ui-marketplace-*.zip
+            plugin/itests/marketplace/target/nuxeo-web-ui-marketplace-itests-*.zip


### PR DESCRIPTION
This PR adds a workflow to manually trigger the build Nuxeo Web UI for a specific branch. If available, this branch name will be used for checking out Web UI and Elements.

Parameters that were removed:
- `CLEAN` (a new pod will be used, so no cache to clean)
- `BASE_BRANCH` (at least for now, until we do this for 10.10 as well)
- `SLAVE` (we have our custom runner in k8s)
- `BROWSER and BROWSER_BINARY` (removing them because as they don't make sense in the context of the new runner)

Yet to be decided:
- `CREATE PR` - This seems unnecessary effort, because 1) if we create a PR in Web UI this will trigger the build and the tests, 2) if we open the PR in Elements, we can just link the PR to the run triggered in Web UI.

Feedback is very welcome

Workflow dialog:

![Screenshot 2021-11-16 at 13 41 54](https://user-images.githubusercontent.com/738700/141996155-c2809104-34bb-488b-b822-8eb6112b15c8.png)
