### PR TITLE
WEBUI-633: allow cross repo navigation

### DIFF
--- a/elements/nuxeo-document-storage/nuxeo-document-storage.js
+++ b/elements/nuxeo-document-storage/nuxeo-document-storage.js
@@ -74,11 +74,12 @@ Polymer({
     }
     const document = {
       'entity-type': 'document',
-      uid: doc.uid,
+      lastViewed: new Date(),
+      path: doc.path,
+      repository: doc.repository,
       title: doc.title,
       type: doc.type,
-      path: doc.path,
-      lastViewed: new Date(),
+      uid: doc.uid,
     };
     if (doc.contextParameters && doc.contextParameters.thumbnail && doc.contextParameters.thumbnail.url) {
       document.contextParameters = { thumbnail: { url: doc.contextParameters.thumbnail.url } };

--- a/elements/routing.js
+++ b/elements/routing.js
@@ -183,5 +183,15 @@ app.router = {
     return `/${name}`;
   },
 
-  navigate: page,
+  navigate: (path) => {
+    if (path == null) {
+      return;
+    }
+    const isFullpath = /^http(s)?:\/\//.test(path);
+    if (isFullpath) {
+      window.location = path;
+    } else {
+      page(path);
+    }
+  },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -207,6 +207,7 @@ const assets = ['images', 'fonts', 'themes'].map((p) => {
 
 const production = merge([
   {
+    /* devtool: 'source-map', // enable this if you need sourcemaps on the production version */
     plugins: [
       new CleanWebpackPlugin(),
       new CopyWebpackPlugin({


### PR DESCRIPTION
This makes use of the new URL format passed to the `navigate` method, introduced by https://github.com/nuxeo/nuxeo-elements/pull/496.