### PR TITLE
WEBUI-620: display create document popup on top of selection toolbar

### DIFF
--- a/elements/nuxeo-document-create-popup/nuxeo-document-create-popup.js
+++ b/elements/nuxeo-document-create-popup/nuxeo-document-create-popup.js
@@ -49,6 +49,7 @@ Polymer({
         height: var(--nuxeo-document-create-popup-height, 80vh);
         width: var(--nuxeo-document-create-popup-width, 65vw);
         margin: 0;
+        z-index: 200;
       }
 
       paper-tabs {


### PR DESCRIPTION
`nuxeo-selection-toolbar` has a **z-index** value of 199. To display the create document popup on top of the selection toolbar, we need at least 200 as a z-index value for the nuxeo-dialog.