### PR TITLE
WEBUI-680: bump server version to 2021.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo</groupId>
     <artifactId>nuxeo-parent</artifactId>
-    <version>2021.13</version>
+    <version>2021.15</version>
   </parent>
 
   <groupId>org.nuxeo.web.ui</groupId>


### PR DESCRIPTION
@semisse and @Gabez0r I bumped the server version to 2021.15 and it seems that all the functional tests are up and running. Don't see any of the issues described https://github.com/nuxeo/nuxeo-web-ui/pull/1365 with the bump for 2021.14.