### PR TITLE
WEBUI-600: support cross repo check

### DIFF
--- a/.github/workflows/cross-repo.yaml
+++ b/.github/workflows/cross-repo.yaml
@@ -1,4 +1,6 @@
-name: Ondemand build
+# This workflow is not intended to be triggered manually from the Web UI repository,
+# but to be called from the Elements repository cross repo check instead.
+name: Cross repo check
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ondemand-main.yaml
+++ b/.github/workflows/ondemand-main.yaml
@@ -102,6 +102,9 @@ jobs:
           npm install
           popd
 
+      - name: Lint Web UI
+        run: npm run lint
+
       - name: Checkout the nuxeo-elements repo
         uses: actions/checkout@v2
         with:
@@ -136,6 +139,17 @@ jobs:
           npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" nuxeo-elements/ui/${ELEMENTS_UI}
           npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" nuxeo-elements/dataviz/${ELEMENTS_DATAVIZ}
           npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" nuxeo-elements/testing-helpers/${ELEMENTS_HELPERS}
+
+      - name: Web UI Unit tests
+        if: ${{ github.event.inputs.skip_unit_tests == 'false' && github.event.inputs.sauce_labs == 'false' }}
+        run: npm run test
+
+      - name: Web UI Unit tests (Sauce Labs)
+        if: ${{ github.event.inputs.skip_unit_tests == 'false' && github.event.inputs.sauce_labs == 'true' }}
+        env:
+          SAUCE_USERNAME: nuxeo-web-ui
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+        run: npm run test
 
       - name: 'Update settings.xml with server configuration'
         run: |

--- a/.github/workflows/ondemand-main.yaml
+++ b/.github/workflows/ondemand-main.yaml
@@ -72,22 +72,20 @@ jobs:
           java-version: '11'
 
       - name: Determine nuxeo-web-ui branch to use
+        uses: nuxeo/ui-team-gh-actions/get-branch@ca09d5c52a62e297502d3572c36d813be927982a
         id: pick_nuxeo_web_ui_branch
-        run: |
-          if git ls-remote --exit-code --heads https://github.com/nuxeo/nuxeo-web-ui ${{ github.event.inputs.branch_name }}; then
-            echo ::set-output name=branch::${{ github.event.inputs.branch_name }}
-          else
-            echo ::set-output name=branch::${{ env.REFERENCE_BRANCH }}
-          fi
+        with:
+          repository: nuxeo/nuxeo-web-ui
+          branch: ${{ github.event.inputs.branch_name }}
+          default-branch: ${{ env.REFERENCE_BRANCH }}
 
       - name: Determine nuxeo-elements branch to use
         id: pick_nuxeo_elements_branch
-        run: |
-          if git ls-remote --exit-code --heads https://github.com/nuxeo/nuxeo-elements ${{ github.event.inputs.branch_name }}; then
-            echo ::set-output name=branch::${{ github.event.inputs.branch_name }}
-          else
-            echo ::set-output name=branch::${{ env.REFERENCE_BRANCH }}
-          fi
+        uses: nuxeo/ui-team-gh-actions/get-branch@ca09d5c52a62e297502d3572c36d813be927982a
+        with:
+          repository: nuxeo/nuxeo-elements
+          branch: ${{ github.event.inputs.branch_name }}
+          default-branch: ${{ env.REFERENCE_BRANCH }}
 
       - name: Checkout nuxeo-web-ui repo
         uses: actions/checkout@v2

--- a/.github/workflows/ondemand-main.yaml
+++ b/.github/workflows/ondemand-main.yaml
@@ -36,14 +36,26 @@ on:
         description: 'Number of failed features to stop test runner (0 means not applicable).'
         default: 0
         required: false
+      caller_id:
+        description: 'run identifier'
+        default: 'maintenance-3.0.x'
+        type: string
+        required: false
 
 env:
   REFERENCE_BRANCH: maintenance-3.0.x
   NPM_REPOSITORY: https://packages.nuxeo.com/repository/npm-public/
 
 jobs:
+  id:
+    name: Remote Caller ID ${{ github.event.inputs.caller_id }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: ${{ github.event.inputs.id }}
+        run: echo run identifier ${{ github.event.inputs.id }}
   build:
     name: Build
+    needs: id
     runs-on: [ self-hosted, master ]
     steps:
       - name: Build parameters
@@ -53,6 +65,11 @@ jobs:
         with:
           registry-url: ${{ env.NPM_REPOSITORY }}
           scope: '@nuxeo'
+      
+      - uses: actions/setup-java@v2
+        with: 
+          distribution: 'zulu'
+          java-version: '11'
 
       - name: Determine nuxeo-web-ui branch to use
         id: pick_nuxeo_web_ui_branch
@@ -75,6 +92,7 @@ jobs:
       - name: Checkout nuxeo-web-ui repo
         uses: actions/checkout@v2
         with:
+          repository: nuxeo/nuxeo-web-ui
           ref: ${{ steps.pick_nuxeo_web_ui_branch.outputs.branch }}
 
       - name: Install Web UI
@@ -86,9 +104,6 @@ jobs:
           npm install
           popd
 
-      - name: Lint Web UI
-        run: npm run lint
-
       - name: Checkout the nuxeo-elements repo
         uses: actions/checkout@v2
         with:
@@ -97,38 +112,6 @@ jobs:
           fetch-depth: 1
           ref: ${{ steps.pick_nuxeo_elements_branch.outputs.branch }}
 
-      - name: Install Elements
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
-        run: |
-          pushd nuxeo-elements
-          npm install
-          npm run bootstrap
-          popd
-      
-      - name: Lint Elements
-        run: |
-          pushd nuxeo-elements
-          npm run lint
-          popd
-
-      - name: Elements Unit tests
-        if: ${{ github.event.inputs.skip_unit_tests == 'false' && github.event.inputs.sauce_labs == 'false' }}
-        run: |
-          pushd nuxeo-elements
-          npm run test
-          popd
-
-      - name: Elements Unit tests (Sauce Labs)
-        if: ${{ github.event.inputs.skip_unit_tests == 'false' && github.event.inputs.sauce_labs == 'true' }}
-        env:
-          SAUCE_USERNAME: nuxeo-elements
-          SAUCE_ACCESS_KEY: ${{ secrets.ELEMENTS_SAUCE_ACCESS_KEY }}
-        run: |
-          pushd nuxeo-elements
-          npm run test
-          popd
-      
       - name: Pack Elements modules
         run: |
           pushd nuxeo-elements
@@ -155,17 +138,6 @@ jobs:
           npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" nuxeo-elements/ui/${ELEMENTS_UI}
           npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" nuxeo-elements/dataviz/${ELEMENTS_DATAVIZ}
           npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" nuxeo-elements/testing-helpers/${ELEMENTS_HELPERS}
-
-      - name: Web UI Unit tests
-        if: ${{ github.event.inputs.skip_unit_tests == 'false' && github.event.inputs.sauce_labs == 'false' }}
-        run: npm run test
-
-      - name: Web UI Unit tests (Sauce Labs)
-        if: ${{ github.event.inputs.skip_unit_tests == 'false' && github.event.inputs.sauce_labs == 'true' }}
-        env:
-          SAUCE_USERNAME: nuxeo-web-ui
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        run: npm run test
 
       - name: 'Update settings.xml with server configuration'
         run: |

--- a/.github/workflows/ondemand-main.yaml
+++ b/.github/workflows/ondemand-main.yaml
@@ -168,12 +168,12 @@ jobs:
           then
             active_profiles="-P$(printf -v active_profiles '%s,' "${profiles[@]}" && echo "${active_profiles%,}")"
           fi
-          mvn install $active_profiles -DskipInstall
+          mvn install -ntp $active_profiles -DskipInstall
 
       - name: A11y checks
         if: ${{ !github.event.inputs.skip_a11y }}
         run: |
-          mvn -B -nsu -f plugin/a11y install
+          mvn -B -nsu -f plugin/a11y -ntp install
 
       - name: Archive cucumber reports
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This one pairs with https://github.com/nuxeo/nuxeo-elements/pull/510, but the improvements in Web UI should be merged first.
Main changes:
- rename of the ondemand wf to `cross-repo`
- adds id job for remote triggering from `nuxeo-elements` cross-repo check
- update reference to `get-branch` action