### PR TITLE
WEBUI-600: fix main workflow build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -99,9 +99,9 @@ jobs:
 
     - name: Nuxeo package build
       run: |
+        mvn -ntp install -DskipInstall
         mvn -B -nsu -ntp -f plugin/itests/addon install
         mvn -B -nsu -ntp -f plugin/itests/marketplace install
-        mvn -ntp install -DskipInstall
 
     - name: Archive packages
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
I removed the ftest step from the main workflow, and Web UI build should happen before we try to maven install the `addon` and the `marketplace` 😬 