### PR TITLE
WEBUI-218: manually update results view on browser

### DIFF
--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -679,6 +679,10 @@ Polymer({
       this._refreshSearch();
     } else if ((this.docPath && this.docPath.length > 0) || (this.docId && this.docId.length > 0)) {
       const id = this.docId || (this.currentDocument && this.currentDocument.uid);
+      // XXX make sure that if there are any nuxeo-results-view on the browser, that they will be updated
+      Array.from(this.$.browser.$.nxContent.querySelectorAll('nuxeo-results-view[visible]')).forEach((r) =>
+        r._search(),
+      );
       this.load('browse', id, this.docPath, this.docAction);
     } else {
       this.navigateTo('home');


### PR DESCRIPTION
It is a bit hacky, but the nuxeo browser only provides the document and the clipboard in the context, and the second doesn't make much sense to be used in the context of a `nuxeo-results-view`, so I'd say that there is no good reason no to update it if it is currently visible. It fixes the issue (apparently), it seems pretty harmless, but it's hacky...