### PR TITLE
WEBUI-581: prevent restore table settings from triggering a save

### DIFF
--- a/elements/nuxeo-results/nuxeo-results.js
+++ b/elements/nuxeo-results/nuxeo-results.js
@@ -630,6 +630,8 @@ Polymer({
   },
 
   restoreSettings() {
+    // XXX _isRestoring is a control flag to prevent restoring from triggering a save (see WEBUI-581)
+    this._isRestoring = true;
     if (this._settings && this.name) {
       if (this._settings.displayMode && this._settings.displayMode.length > 0) {
         this.displayMode = this._settings.displayMode;
@@ -638,6 +640,7 @@ Polymer({
         this.view.settings = this._settings[this.displayMode];
       }
     }
+    this._isRestoring = false;
   },
 
   saveSettings() {
@@ -694,7 +697,7 @@ Polymer({
   },
 
   _saveViewSettings() {
-    if (this.view.settings) {
+    if (this.view.settings && !this._isRestoring) {
       this.set(`_settings.${this.displayMode}`, this.view.settings);
       this.saveSettings();
     }


### PR DESCRIPTION
I could only reproduce this on Chrome, and only with multiple tabs open at the same time:
1) In tab 1, you add columns state and author
2) You open the same document on tab 2, and while restoring the settings (written by tab 1), it also triggers several saves while it iterates on the columns and sets them
3) The first save, on tab 2, which is only setting one of the two columns that change, updates local storage, and this triggers a refresh on tab 1.
4) Tab 1 restores, sets the value for just the State column, and saves, with then propagates to tab 2.

It doesn't seem fool proof, because the save is triggered by an event, which is async, but the propose fix prevented this from happening on all my tests. The issue is on `nuxeo-results`, because it is the entity that restores and saves, but it lacks context on the time of saving to know where all the changes are being triggered from. Alternatively, we could try to introduce more API on `iron-data-table` to try to get a cleaner way to do it. WDYT?