### PR TITLE
WEBUI-308: display tags for users and groups in document tasks

### DIFF
--- a/elements/workflow/nuxeo-document-task.js
+++ b/elements/workflow/nuxeo-document-task.js
@@ -163,12 +163,22 @@ Polymer({
           </div>
           <div id="assignedActors" class="vertical spaced">
             <span>[[i18n('tasks.actors.assigned')]]</span>
-            <nuxeo-tags type="user" items="[[task.actors]]"></nuxeo-tags>
+            <template is="dom-if" if="[[_hasActorType(task.actors, 'group')]]">
+              <nuxeo-tags type="group" items="[[_getActorsByType(task.actors, 'group')]]"></nuxeo-tags>  
+            </template>
+            <template is="dom-if" if="[[_hasActorType(task.actors, 'user')]]">
+              <nuxeo-tags type="user" items="[[_getActorsByType(task.actors, 'user')]]"></nuxeo-tags>
+            </template>
           </div>
           <template is="dom-if" if="[[_delegatedActorsExist(task.delegatedActors)]]">
             <div id="delegatedActors" class="vertical spaced">
               <span>[[i18n('tasks.actors.delegated')]]</span>
-              <nuxeo-tags type="user" items="[[task.delegatedActors]]"></nuxeo-tags>
+              <template is="dom-if" if="[[_hasActorType(task.delegatedActors, 'group')]]">
+                <nuxeo-tags type="user" items="[[_getActorsByType(task.delegatedActors, 'group')]]"></nuxeo-tags>
+              </template>
+              <template is="dom-if" if="[[_hasActorType(task.delegatedActors,'user')]]">
+                <nuxeo-tags type="user" items="[[_getActorsByType(task.delegatedActors, 'user')]]"></nuxeo-tags>
+              </template>
             </div>
           </template>
           <div class="vertical spaced">
@@ -322,5 +332,13 @@ Polymer({
 
   _isTaskInEndState(task) {
     return task && task.state === 'ended';
+  },
+
+  _hasActorType(actors, type) {
+    return actors && Array.isArray(actors) && actors.findIndex((actor) => actor['entity-type'] === type) >= 0;
+  },
+
+  _getActorsByType(actors, type) {
+    return actors && Array.isArray(actors) && actors.filter((actor) => actor['entity-type'] === type);
   },
 });

--- a/elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html
+++ b/elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html
@@ -23,9 +23,19 @@ limitations under the License.
 -->
 <dom-module id="nuxeo-task6d8-layout">
   <template>
-    <div role="widget">
+    <style>
+      .participants {
+        display: flex;
+      }
+    </style>
+    <div role="widget" class="participants">
       <label>[[i18n('wf.serialDocumentReview.participants')]]</label>
-      <nuxeo-tags type="user" items="[[task.variables.participants]]"></nuxeo-tags>
+      <template is="dom-if" if="[[_hasActorType(task.variables.participants, 'group')]]">
+        <nuxeo-tags type="group" items="[[_getActorsByType(task.variables.participants, 'group')]]"></nuxeo-tags>
+      </template>
+      <template is="dom-if" if="[[_hasActorType(task.variables.participants, 'user')]]">
+        <nuxeo-tags type="user" items="[[_getActorsByType(task.variables.participants, 'user')]]"></nuxeo-tags>
+      </template>
     </div>
 
     <div role="widget">
@@ -56,6 +66,14 @@ limitations under the License.
          * @task var_task6d8
          */
         task: Object,
+      },
+
+      _hasActorType(actors, type) {
+        return actors && Array.isArray(actors) && actors.findIndex((actor) => actor.startsWith(type)) >= 0;
+      },
+
+      _getActorsByType(actors, type) {
+        return actors && Array.isArray(actors) && actors.filter((actor) => actor.startsWith(type));
       },
     });
   </script>


### PR DESCRIPTION
This seems like a hacky solution for me.

I'd be ok with the purposed changes for `nuxeo-document-task` as it wouldn't mess any public API and it is an easy fix. However, having to change the `nuxeo-task6d8-layout` or any layout if necessary, should be a no go.

I thought about adding some logic to the `nuxeo-tags` instead, but since this is a dumb element without any logic, it means we would probably have to update (and break) its API.

Feedback of this is very welcome 👋  Thanks.