### PR TITLE
WEBUI-592: introduce property to config headers used in user management

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,13 @@ limitations under the License.
             /* selection: { // uncomment to enable select all items in listings
               selectAllEnabled: true
             }, */
+            /*user: {
+              management: {
+                fetch: {
+                  document: ['properties'],
+                },
+              },
+            },*/
           },
         },
       };

--- a/plugin/web-ui/addon/src/main/resources/OSGI-INF/web-ui-properties.xml
+++ b/plugin/web-ui/addon/src/main/resources/OSGI-INF/web-ui-properties.xml
@@ -44,5 +44,8 @@
 
     <!-- Control the enablement of select all -->
     <property name="org.nuxeo.web.ui.selection.selectAllEnabled">${nuxeo.selection.selectAllEnabled:=false}</property>
+
+    <!-- Properties to be fetched when loading the user object in user management, default is empty -->
+    <property name="org.nuxeo.web.ui.user.management.fetch.document" list="true"></property>
   </extension>
 </component>


### PR DESCRIPTION
This pairs with https://github.com/nuxeo/nuxeo-elements/pull/515 and exposes a configuration property to control the headers used to fetch user data in the `nuxeo-user-management`.

With this approach we keep the same behavior we have right now, without having to update any layout (this means that if someone wants to take advantage of this, they'll have to update the layouts).