### PR TITLE
WEBUI-351: add css variable to control html editor height

### DIFF
--- a/elements/nuxeo-note-editor/nuxeo-note-editor.js
+++ b/elements/nuxeo-note-editor/nuxeo-note-editor.js
@@ -67,10 +67,14 @@ Polymer({
       }
 
       paper-textarea,
-      nuxeo-document-preview,
-      nuxeo-html-editor {
+      nuxeo-document-preview {
         display: block;
         min-height: calc(80vh - 132px);
+      }
+
+      nuxeo-html-editor {
+        min-height: calc(80vh - 132px);
+        height: var(--nuxeo-note-editor-html-height);
       }
 
       paper-textarea {


### PR DESCRIPTION
The height of the `nuxeo-html-editor` inside `nuxeo-note-editor` can now be controlled using a new css variable:
`--nuxeo-note-editor-html-height`

For example, you can set the following on a theme:
```css
--nuxeo-note-editor-html-height: calc(80vh - 132px);
```

Depends on https://github.com/nuxeo/nuxeo-elements/pull/516.