### PR TITLE
WEBUI-436: reset ecm_fulltext when loading saved search

### DIFF
--- a/elements/search/nuxeo-search-form.js
+++ b/elements/search/nuxeo-search-form.js
@@ -752,10 +752,8 @@ Polymer({
   _selectedSearchChanged() {
     if (this.selectedSearch) {
       this.params = this._mutateParams(this.selectedSearch.params);
-      if (this.params && this.params.ecm_fulltext) {
-        this.searchTerm = this.params.ecm_fulltext.replace('*', '');
-        this.form.searchTerm = this.searchTerm;
-      }
+      this.searchTerm = this.params && this.params.ecm_fulltext ? this.params.ecm_fulltext.replace('*', '') : '';
+      this.form.searchTerm = this.searchTerm;
       this._fetch(this.$.provider);
     }
   },


### PR DESCRIPTION
When switching between saved searches we use the `paramMutator` to mutate the params of the saved search, however, because [we filter out null parameters](https://github.com/nuxeo/nuxeo-web-ui/blob/maintenance-3.0.x/elements/search/nuxeo-search-form.js#L545) and the `ecm_fulltext` is consider here a special case, the proposed solution is to reset the `searchTerm` used in the actual forms. 

Feedback is very welcome. 