### PR TITLE
WEBUI-706: prevent vocabulary creation with whitespaces only in id field

### DIFF
--- a/elements/directory/vocabulary/nuxeo-vocabulary-edit-layout.html
+++ b/elements/directory/vocabulary/nuxeo-vocabulary-edit-layout.html
@@ -31,6 +31,8 @@ limitations under the License.
       value="{{entry.properties.id::change}}"
       required
       readonly$="[[!new]]"
+      pattern=".*\S.*"
+      error-message="[[i18n('vocabularyManagement.edit.error')]]"
     >
     </nuxeo-input>
 

--- a/i18n/messages.json
+++ b/i18n/messages.json
@@ -1440,6 +1440,7 @@
   "vocabularyManagement.confirmDelete": "Delete vocabulary entry?",
   "vocabularyManagement.deleteEntry": "Delete Entry",
   "vocabularyManagement.edit.actions": "Actions",
+  "vocabularyManagement.edit.error": "ID cannot be empty",
   "vocabularyManagement.edit.id": "ID",
   "vocabularyManagement.edit.label_en": "English Label",
   "vocabularyManagement.edit.label_fr": "French Label",


### PR DESCRIPTION
The pattern ensures that we have at least a non whitespace character for the `id` field.

Current behavior: we can have ids made of whitespaces only
New behavior: we need at least a non whitespace character

Feedback is very welcome 🙂 