### PR TITLE
WEBUI-155: fix text overflow on vocabulary selection (10.10)

### DIFF
--- a/elements/directory/nuxeo-vocabulary-management.html
+++ b/elements/directory/nuxeo-vocabulary-management.html
@@ -54,10 +54,6 @@ limitations under the License.
         margin: 1em 0 1em 0;
       }
 
-      nuxeo-select {
-        max-width: 223px;
-      }
-
       nuxeo-dialog {
         min-width: 480px;
       }

--- a/elements/directory/nuxeo-vocabulary-management.html
+++ b/elements/directory/nuxeo-vocabulary-management.html
@@ -185,6 +185,12 @@ limitations under the License.
 
         _visibleChanged: function() {
           if (this.visible && !this.vocabularies) {
+            Polymer.RenderStatus.afterNextRender(this, function() {
+              // XXX workaround for ELEMENTS-1470
+              Array.from(this.shadowRoot.querySelectorAll('nuxeo-select')).forEach(function(s) {
+                s._resize();
+              });
+            }.bind(this));
             this.$.directory.get().then(function(response) {
               this.vocabularies = response.entries.sort(function(a, b) {
                 return a.name.localeCompare(b.name);

--- a/elements/directory/nuxeo-vocabulary-management.html
+++ b/elements/directory/nuxeo-vocabulary-management.html
@@ -75,6 +75,12 @@ limitations under the License.
         margin-top: 16px;
         background-color: var(--nuxeo-dialog-buttons-bar, white);
       }
+
+      paper-item span {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     </style>
 
     <nuxeo-resource id="directory" path="/directory" params='{"pageSize": 0}'></nuxeo-resource>
@@ -91,7 +97,9 @@ limitations under the License.
                         placeholder="[[i18n('vocabularyManagement.select')]]"
                         selected="{{selectedVocabulary}}" attr-for-selected="name">
             <template is="dom-repeat" items="[[vocabularies]]" as="vocabulary">
-              <paper-item name$="[[vocabulary.name]]">[[vocabulary.name]]</paper-item>
+              <paper-item name$="[[vocabulary.name]]">
+                <span title="[[vocabulary.name]]">[[vocabulary.name]]</span>
+              </paper-item>
             </template>
           </nuxeo-select>
         </nuxeo-card>


### PR DESCRIPTION
Backport of https://github.com/nuxeo/nuxeo-web-ui/pull/1413. Note that we did 5aeda754cc6c20a6d5b44976f3136a9c0eda0c95 instead of https://github.com/nuxeo/nuxeo-elements/pull/518, to prevent taking and risks of affecting customers using legacy browsers.