### PR TITLE
WEBUI-738: fix preview provisioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "prepare:workbox": "workbox copyLibraries .tmp && mv .tmp/workbox-v$npm_package_devDependencies_workbox_cli .tmp/workbox",
     "build": "webpack --env production",
     "postbuild": "npm-run-all fix:*",
+    "fix:preview": "replace 'elements/' '${window.location.pathname}/' dist/index.html",
     "fix:elements": "replace '/elements/' '${window.location.pathname}/' dist/*.js",
     "fix:ui_elements": "replace '/node_modules/@nuxeo/nuxeo-ui-elements/' '${window.location.pathname}/' dist/*.js",
     "fix:pdfjs": "replace 'pdfjs/web/viewer.html' '../vendor/pdfjs/web/viewer.html' dist/*.js",

--- a/server/nginx.conf
+++ b/server/nginx.conf
@@ -18,7 +18,7 @@ http {
         gzip_proxied no-cache no-store private expired auth;
 
         location / {
-            try_files $uri $uri/ /index.html;
+            try_files $uri $uri/ =404;
         }
     }
 }


### PR DESCRIPTION
Changes: 
- Prevent nginx from using index.html as 404 redirect
- Replace `elements/` in index.html on webpack build