### PR TITLE
WEBUI-741: fail step publish step if curl response is not ok

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -123,7 +123,14 @@ jobs:
         CONNECT_PREPROD_URL: https://nos-preprod-connect.nuxeocloud.com/nuxeo
       run: |
         PACKAGE="plugin/web-ui/marketplace/target/nuxeo-web-ui-marketplace-${PADDED_VERSION}.zip"
-        curl -i -u "${{ secrets.CONNECT_PREPROD_AUTH }}" -F package=@$PACKAGE "$CONNECT_PREPROD_URL/site/marketplace/upload?batch=true"
+        STATUS_CODE=`curl -i --silent --output publish-req.output -w "%{http_code}" -u "${{ secrets.CONNECT_PREPROD_AUTH }}" -F package=@$PACKAGE "$CONNECT_PREPROD_URL/site/marketplace/upload?batch=true"``
+        cat publish-req.output
+        if [[ "$STATUS_CODE" != "200" ]]
+        then
+          exit 1
+        else
+          exit 0
+        fi
 
     - name: Publish Web UI FTest framework
       env:


### PR DESCRIPTION
To discuss: 
- ~~This is a problem that could happen with every single use of cURL. Should we update all the requests to follow this structure?~~ Doing it just for this curl response (if necessary, we can backport it)
- ~~With this solution, we are hiding the output of the cURL request from `stdout`, we should probably find a way to output it to `stdout`, right?~~ Updated the PR to include this.