### PR TITLE
WEBUI-770: add file schema condition to display dropzone on nuxeo-document-viewer

### DIFF
--- a/elements/nuxeo-document-viewer/nuxeo-document-viewer.js
+++ b/elements/nuxeo-document-viewer/nuxeo-document-viewer.js
@@ -111,7 +111,8 @@ Polymer({
       this.hasPermission(doc, 'WriteProperties') &&
       !this.isImmutable(doc) &&
       !this.hasType(doc, 'Root') &&
-      !this.isTrashed(doc)
+      !this.isTrashed(doc) &&
+      this.hasSchema(doc, 'file')
     );
   },
 });


### PR DESCRIPTION
Up to discussion:
- check for the file schema, or
- check for the file schema and property

To fix the issue and for Compound Documents, the first approach is enough.
Feedback is welcome 🙂 