### PR TITLE
WEBUI-739: prevent bulk edit layout from loading on documents change

### DIFF
--- a/elements/bulk/nuxeo-edit-documents-button.js
+++ b/elements/bulk/nuxeo-edit-documents-button.js
@@ -202,7 +202,7 @@ class NuxeoEditDocumentsButton extends mixinBehaviors([I18nBehavior, FiltersBeha
   }
 
   static get observers() {
-    return ['_loadLayout(documents.splices, layout, hrefFunction, hrefBase)'];
+    return ['_loadLayout(layout, hrefFunction, hrefBase)'];
   }
 
   constructor() {
@@ -429,12 +429,15 @@ class NuxeoEditDocumentsButton extends mixinBehaviors([I18nBehavior, FiltersBeha
   /**
    * Loads the bulk edit layout.
    */
-  _loadLayout(documents, layout, hrefFunction, hrefBase) {
-    // force layout restamp
-    this._set_href(null);
+  _loadLayout(layout, hrefFunction, hrefBase) {
+    const { href } = this.$$('nuxeo-layout');
     const base = hrefBase || pathFromUrl(this.__dataHost.importPath || this.importPath);
     const path = [base, hrefFunction(layout)].join(base.slice(-1) !== '/' ? '/' : '');
-    this._set_href(path);
+    if (href !== path) {
+      // force layout restamp
+      this._set_href(null);
+      this._set_href(path);
+    }
   }
 
   /**


### PR DESCRIPTION
This PR proposes two changes to the edit documents button:
- prevent reloading the layout if the href is exactly the same that was previously used in `nuxeo-layout`
- prevent reloading the layout everytime a new document is selected (removing the `documents.splices` from the observer)