### PR TITLE
WEBUI-813: use node v14 to run a11y checks in cross-repo workflow

### DIFF
--- a/.github/workflows/cross-repo.yaml
+++ b/.github/workflows/cross-repo.yaml
@@ -63,9 +63,10 @@ jobs:
       - name: Build parameters
         run: echo '${{ toJSON(github.event.inputs) }}'
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           registry-url: ${{ env.NPM_REPOSITORY }}
+          node-version: 14
           scope: '@nuxeo'
       
       - uses: actions/setup-java@v2


### PR DESCRIPTION
Everything seems to be working with node `v14` (build, functional and a11y tests).
Cross-repo run here https://github.com/nuxeo/nuxeo-web-ui/actions/runs/2453328113 🔵 