### PR TITLE
WEBUI-811: fix first request for audit search for documents

### DIFF
--- a/elements/nuxeo-audit/nuxeo-audit-search.js
+++ b/elements/nuxeo-audit/nuxeo-audit-search.js
@@ -59,7 +59,7 @@ class AuditSearch extends mixinBehaviors([FormatBehavior, RoutingBehavior], Nuxe
         }
       </style>
 
-      <nuxeo-audit-page-provider id="provider" page-size="40"></nuxeo-audit-page-provider>
+      <nuxeo-audit-page-provider id="provider" doc-id="[[document.uid]]" page-size="40"></nuxeo-audit-page-provider>
 
       <nuxeo-card>
         <nuxeo-user-suggestion
@@ -220,7 +220,6 @@ class AuditSearch extends mixinBehaviors([FormatBehavior, RoutingBehavior], Nuxe
     if (!this.visible) {
       return;
     }
-    this.$.provider.docId = this.documentId;
     this.$.provider.params = this._buildParams();
     this.table.fetch();
   }


### PR DESCRIPTION
There's a weird behavior that is outside the scope of this ticket. In `paginable` mode, the data tables [`_threshold`](https://github.com/nuxeo/nuxeo-elements/blob/v3.0.13-rc.5/ui/nuxeo-data-table/iron-data-table.js#L990-L994) is being called, which forces a request on the provider. The provider, in this case is a `nuxeo-audit-page-provider`, which does not yet have a document id set. This results in it taking the [wrong code path](https://github.com/nuxeo/nuxeo-elements/blob/maintenance-3.0.x/core/nuxeo-audit-page-provider.js#L326-L328), assuming it is not dealing with the document. The solution sets the document id as soon as possible.