### PR TITLE
WEBUI-830: update actions/setup-version to v3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,10 +30,11 @@ jobs:
         with:
           ref: ${{ env.BRANCH_NAME }}
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
           scope: '@nuxeo'
+          node-version: 14
 
       - name: Install
         env:


### PR DESCRIPTION
It seems that v3 of the `setup-node` action doesn't fallback a [particular node version](https://github.com/nuxeo/nuxeo-web-ui/runs/7073497902?check_suite_focus=true#step:3:1) 🤔 So I'm updating the actions and node version (We'll clean it up later)