### PR TITLE
WEBUI-840: add missing node-version to 10.10 workflows

### DIFF
--- a/.github/workflows/cross-repo.yaml
+++ b/.github/workflows/cross-repo.yaml
@@ -123,9 +123,11 @@ jobs:
           path: nuxeo-web-ui
           ref: ${{ needs.setup.outputs.webui_branch }}
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '10'
+          registry-url: ${{ env.NPM_REPOSITORY }}
+          node-version: 10
+          scope: '@nuxeo'
 
       - run: npm install -g bower
 
@@ -234,6 +236,12 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '8'
+
+      - uses: actions/setup-node@v3
+        with:
+          registry-url: ${{ env.NPM_REPOSITORY }}
+          node-version: 10
+          scope: '@nuxeo'
 
       - name: 'Update settings.xml with server configuration'
         run: |

--- a/.github/workflows/ftest.yaml
+++ b/.github/workflows/ftest.yaml
@@ -94,9 +94,11 @@ jobs:
           path: nuxeo-web-ui
           ref: ${{ needs.setup.outputs.webui_branch }}
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '10'
+          registry-url: ${{ env.NPM_REPOSITORY }}
+          node-version: 10
+          scope: '@nuxeo'
 
       - run: npm install -g bower
 
@@ -205,6 +207,12 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '8'
+
+      - uses: actions/setup-node@v3
+        with:
+          registry-url: ${{ env.NPM_REPOSITORY }}
+          node-version: 10
+          scope: '@nuxeo'
 
       - name: 'Update settings.xml with server configuration'
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,6 +18,7 @@ jobs:
         with:
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
           scope: '@nuxeo'
+          node-version: 10
 
       - run: npm install -g bower
 


### PR DESCRIPTION
With the update of the default node version to v14, this needs to be explicitly set in the workflows (cross-repo and ftest).