### PR TITLE
WEBUI-786: Able to click 'Add' Button when no Collection selected

### DIFF
--- a/elements/nuxeo-document-bulk-actions/nuxeo-add-to-collection-documents-button.js
+++ b/elements/nuxeo-document-bulk-actions/nuxeo-add-to-collection-documents-button.js
@@ -231,7 +231,7 @@ class NuxeoAddToCollectionDocumentsButton extends mixinBehaviors(
   }
 
   _isValid() {
-    return this.collection !== '';
+    return this.collection;
   }
 
   _isNew() {


### PR DESCRIPTION
https://jira.nuxeo.com/browse/WEBUI-786

The Add button is disabled since no collection is selected

<img width="545" alt="Screenshot 2022-07-11 at 5 00 50 PM" src="https://user-images.githubusercontent.com/105918630/178255005-eaae422a-afca-4d61-9b48-f38aa8f72c3e.png">

