### PR TITLE
WEBUI-849: open PR for Crowdin translation updates

### DIFF
--- a/.github/workflows/crowdin.yaml
+++ b/.github/workflows/crowdin.yaml
@@ -37,7 +37,10 @@ jobs:
           auto_approve_imported: true
 
           # Name of the branch where to merge the translations
-          localization_branch_name: maintenance-3.0.x
+          localization_branch_name: crowdin-translations-update
+          create_pull_request: true
+          pull_request_title: 'New Crowdin translations'
+          pull_request_body: 'New Crowdin pull request with translations'
 
           # The commit message
           commit_message: 'Automatic update of translations from Crowdin'


### PR DESCRIPTION
Instead of merging directly the code into the head branch (which will be `maintenance-3.0.x`, currently [broken](https://github.com/nuxeo/nuxeo-web-ui/actions/runs/2701389646)), this will create a PR. For demonstration purposes, I have forced it to run against this branch instead (see 6192619b97abff6b2ae492677535d7787ab400ff, which was already deleted), which produced the following PR: https://github.com/nuxeo/nuxeo-web-ui/pull/1524.

The downside is that this will introduce an additional manual step to merge translations. I don't expect this to be a big issue, since we do validate labels before doing a release anyway, but this can certainly be improved.