### PR TITLE
WEBUI-450: fix isSavedSearch flag condition updated (Backport 10.10)

### DIFF
--- a/elements/search/nuxeo-saved-search-actions.html
+++ b/elements/search/nuxeo-saved-search-actions.html
@@ -103,9 +103,9 @@ limitations under the License.
             this._dirty = this.searchForm.dirty;
           }.bind(this));
           this.searchForm.addEventListener('selected-search-changed', function() {
+            this.isSavedSearch = this.searchForm.isSavedSearch;
             if (this.searchForm.selectedSearch) {
               this.searchId = this.searchForm.selectedSearch.id;
-              this.isSavedSearch = !!this.searchId;
             }
           }.bind(this));
 


### PR DESCRIPTION
https://jira.nuxeo.com/browse/WEBUI-450

In default search save button is hidden

<img width="1440" alt="Screenshot 2022-07-22 at 11 25 27 AM" src="https://user-images.githubusercontent.com/105918630/180383402-20cd7b27-5522-434d-b8f2-bbd12736d6d5.png">

