### PR TITLE
WEBUI-740: limit order input for new vocabulary entries(BackPort 10.10)

### DIFF
--- a/elements/directory/vocabulary/nuxeo-vocabulary-edit-layout.html
+++ b/elements/directory/vocabulary/nuxeo-vocabulary-edit-layout.html
@@ -60,6 +60,7 @@ limitations under the License.
                  label="[[i18n('vocabularyManagement.edit.ordering')]]"
                  name="ordering"
                  type="number"
+                 max="2147483646"
                  value="{{entry.properties.ordering::change}}">
     </nuxeo-input>
   </template>


### PR DESCRIPTION
Below are the findings,that supports for choosing directly number for `max =2147483646` instead of using any language inbuilt property or function.

IN JAVA
` Integer.MAX_VALUE` represents the maximum positive integer value that can be represented in 32 bits (i.e., 2147483647).
2^31-1 = 2147483647
https://www.educative.io/answers/what-is-integermaxvalue
https://www.geeksforgeeks.org/integer-max_value-and-integer-min_value-in-java-with-examples/

IN JAVASCRIPT

`Number.MAX_VALUE` has the value of 1.7976931348623157e+308.
https://www.geeksforgeeks.org/javascript-number-max_value-property/

253-1, or +/- 9,007,199,254,740,991
https://stackoverflow.com/questions/307179/what-is-javascripts-highest-integer-value-that-a-number-can-go-to-without-losin
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER