### PR TITLE
WEBUI-731: rename version used for catalog generator

### DIFF
--- a/.github/workflows/catalog.yaml
+++ b/.github/workflows/catalog.yaml
@@ -144,7 +144,7 @@ jobs:
           GH_TOKEN: ${{ secrets.WEBUI_JX_BOT_GITHUB_ACTIONS_TOKEN }}
         run: | 
           git checkout -b designer-catalog-update-$CATALOG_VERSION
-          mvn versions:set-property -Dproperty=view.designer.catalog.3.0.x -DnewVersion=$CATALOG_VERSION
+          mvn versions:set-property -Dproperty=view.designer.catalog.11.3 -DnewVersion=$CATALOG_VERSION
           git add .
           git commit -m "Update Designer catalog with version $CATALOG_VERSION"
           git push origin designer-catalog-update-$CATALOG_VERSION


### PR DESCRIPTION
Renaming this because it makes it easier to understand the mapping between the Web UI version (`3.0.x`) and the platform version used in Nuxeo Studio (`11.3`).