### PR TITLE
WEBUI-920: fix URL to Kawaii background

### DIFF
--- a/themes/kawaii/theme.html
+++ b/themes/kawaii/theme.html
@@ -25,7 +25,7 @@ limitations under the License.
       --nuxeo-secondary-color: #6d0043;
       --nuxeo-button-secondary-text: #dd32b5;
 
-      --nuxeo-page-background: url(themes/kawaii/background.png) repeat #f8d3e0;
+      --nuxeo-page-background: url(background.png) repeat #f8d3e0;
       --nuxeo-border: rgba(0, 0, 0, 0.15);
 
       /* App Header */


### PR DESCRIPTION
the current background URL was duplicating the path with /ui/themes/kawaii/themes/kawaii/background.png instead of /ui/themes/kawaii/background.png