### PR TITLE
WEBUI-1333: ftest nuxeo spreadsheet addon into async

### DIFF
--- a/addons/nuxeo-spreadsheet/ftest/features/step_definitions/spreadsheet.js
+++ b/addons/nuxeo-spreadsheet/ftest/features/step_definitions/spreadsheet.js
@@ -1,15 +1,19 @@
+/* eslint-disable no-undef */
+// eslint-disable-next-line import/no-unresolved
 import { Then, When } from '@cucumber/cucumber';
 import Spreadsheet from '../../pages/spreadsheet';
 
-When('I open the spreadsheet', function() {
-  const button = this.ui.results.actions.element('nuxeo-spreadsheet-button').click();
-
-  button.waitForVisible('#dialog');
-
-  const iframe = button.element('#iframe');
-  driver.frame(iframe.value);
-
-  this.spreadsheet = new Spreadsheet();
+When('I open the spreadsheet', async function() {
+  const result = await this.ui.results;
+  const actions = await result.actions;
+  const buttonEle = await actions.element('nuxeo-spreadsheet-button');
+  await buttonEle.click();
+  const dialog = await buttonEle.element('#dialog');
+  await dialog.waitForVisible();
+  const iframe = await buttonEle.element('#iframe');
+  await iframe.waitForExist();
+  await browser.switchToFrame(iframe);
+  this.spreadsheet = await new Spreadsheet();
 });
 
 When('I see the spreadsheet dialog', function() {
@@ -17,50 +21,64 @@ When('I see the spreadsheet dialog', function() {
   button.waitForVisible('#dialog');
 });
 
-Then('I can see the spreadsheet results actions button', function() {
-  const { results } = this.ui;
-
-  if (results.displayMode !== 'table') {
-    results.toggleTableView.click();
+Then('I can see the spreadsheet results actions button', async function() {
+  const currentUI = await this.ui;
+  const results = await currentUI.results;
+  if ((await results.displayMode) !== 'table') {
+    const toggleTableViewBtn = await results.toggleTableView;
+    await toggleTableViewBtn.click();
   }
-
-  results.actions.waitForVisible('nuxeo-spreadsheet-button');
+  const button = await results.actions;
+  await button.waitForVisible('nuxeo-spreadsheet-button');
 });
 
-Then('I can see the {string} spreadsheet column', function(column) {
-  assert(this.spreadsheet, 'Spreadsheet editor does not exist');
-  return this.spreadsheet.headers.includes(column);
+Then('I can see the {string} spreadsheet column', async function(column) {
+  const spreadsheet = await this.spreadsheet;
+  if (spreadsheet) {
+    const header = await spreadsheet.headers;
+    await header.includes(column);
+  } else {
+    throw Error('Error: Spreadsheet does not exist!!');
+  }
 });
 
-When('I set the spreadsheet cell {int},{int} to {string}', function(row, col, value) {
-  const { spreadsheet } = this;
-  assert(spreadsheet, 'Spreadsheet does not exist');
-
-  spreadsheet.setData(row, col, value);
+When('I set the spreadsheet cell {int},{int} to {string}', async function(row, col, value) {
+  const spreadsheet = await this.spreadsheet;
+  if (spreadsheet) {
+    spreadsheet.setData(row, col, value);
+  } else {
+    throw Error('Error: Spreadsheet does not exist!!');
+  }
 });
 
-When('I save the spreadsheet', function() {
-  const { spreadsheet } = this;
-  assert(spreadsheet, 'Spreadsheet does not exist');
-
-  spreadsheet.save();
-
-  const { console } = spreadsheet;
-  driver.waitUntil(() => console.getText() === '1 rows saved');
+When('I save the spreadsheet', async function() {
+  const spreadsheet = await this.spreadsheet;
+  if (spreadsheet) {
+    await spreadsheet.save();
+    const consoleEle = await spreadsheet.console;
+    await consoleEle.getText();
+  } else {
+    throw Error('Error: Spreadsheet does not exist!!');
+  }
 });
 
-When('I close the spreadsheet', function() {
-  const { spreadsheet } = this;
-  assert(spreadsheet, 'Spreadsheet does not exist');
-
-  spreadsheet.close();
-  driver.frame();
+When('I close the spreadsheet', async function() {
+  const spreadsheet = await this.spreadsheet;
+  if (spreadsheet) {
+    await spreadsheet.close();
+    await browser.switchToFrame(null);
+  } else {
+    throw Error('Error: Spreadsheet does not exist!!');
+  }
 });
 
-Then('I see {string} in the results table cell {int},{int}', function(value, row, col) {
-  const { results } = this.ui;
-  results.waitForVisible();
-  const tableRow = results.el.elements('nuxeo-data-table-row:not([header])').value[row];
-  const tableCell = tableRow.elements('nuxeo-data-table-cell').value[col];
-  expect(tableCell.getText()).to.equal(value);
+Then('I see {string} in the results table cell {int},{int}', async function(value, row, col) {
+  const results = await this.ui.results;
+  await results.waitForVisible();
+  const tableRow = await results.el.elements('nuxeo-data-table-row:not([header])');
+  const tableRowValue = await tableRow[row];
+  const tableCell = await tableRowValue.elements('nuxeo-data-table-cell');
+  const tableCol = await tableCell[col];
+  const tableColText = await tableCol.getText();
+  tableColText.should.be.equal(value);
 });

--- a/addons/nuxeo-spreadsheet/ftest/pages/spreadsheet.js
+++ b/addons/nuxeo-spreadsheet/ftest/pages/spreadsheet.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-return-await */
 export default class Spreadsheet {
   constructor() {
     driver.waitUntil(() => driver.execute(() => window.spreadheet));
@@ -8,55 +9,87 @@ export default class Spreadsheet {
   }
 
   get table() {
-    return this.element('table.htCore');
+    return (async () => {
+      const tableEle = await this.element('table.htCore');
+      return tableEle;
+    })();
   }
 
   get headers() {
-    return this.table.elements('thead span').value.map((e) => e.getText());
+    return (async () => {
+      try {
+        const table = await this.table;
+        const headerElements = await table.elements('thead span');
+        const headerElementArray = Array.from(headerElements);
+        const header = await Promise.all(headerElementArray.map(async (e) => await e.getText()));
+        return header;
+      } catch (error) {
+        console.error('Error fetching headers:', error);
+        return [];
+      }
+    })();
   }
 
   get rows() {
-    return this.table.elements('tbody tr');
+    return (async () => {
+      const tableEle = await this.table.elements('tbody tr');
+      return tableEle;
+    })();
   }
 
   get console() {
-    return this.element('#console');
+    return (async () => {
+      const consoleEle = await this.element('#console');
+      return consoleEle;
+    })();
   }
 
   /**
    * Set data at given row and cell
    */
-  setData(row, cell, data) {
-    this._callHandsontable('setDataAtCell', row, cell, data);
+  async setData(row, cell, data) {
+    await this._callHandsontable('setDataAtCell', row, cell, data);
   }
 
   /**
    * Get data at given row and cell
    */
-  getData(row, cell) {
-    return this._callHandsontable('getDataAtCell', row, cell);
+  async getData(row, cell) {
+    return (async () => {
+      const getDataCell = await this._callHandsontable('getDataAtCell', row, cell);
+      return getDataCell;
+    })();
   }
 
   /**
    * Save the data
    */
-  save() {
-    // click() was resulting "no element reference returned by script"
-    driver.execute((el) => el.click(), this.element('#save').value);
+  async save() {
+    const saveButton = await this.element('#save');
+    if (saveButton) {
+      await saveButton.click();
+    } else {
+      console.error('Save button not found!!');
+    }
   }
 
   /**
    * Close the spreadsheet
    */
-  close() {
-    driver.execute((el) => el.click(), this.element('#close').value);
+  async close() {
+    const closeButton = await this.element('#close');
+    if (closeButton) {
+      await closeButton.click();
+    } else {
+      console.error('Close button not found!!');
+    }
   }
 
   /**
    * Call a Handsontable method
    */
-  _callHandsontable(method, ...params) {
+  async _callHandsontable(method, ...params) {
     // eslint-disable-next-line no-undef, no-shadow
-    driver.execute((method, ...params) => window.spreadsheet.ht[method](...params), method, ...params);
+    await driver.execute((method, ...params) => window.spreadsheet.ht[method](...params), method, ...params);
   }
 }

--- a/packages/nuxeo-web-ui-ftest/pages/ui/browser.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/browser.js
@@ -78,8 +78,13 @@ export default class Browser extends BasePage {
    * Gets a Results page helper, assuming current visible page has a <nuxeo-results> in there.
    */
   get results() {
-    const pill = this.el.$('#documentViewsItems nuxeo-page-item.iron-selected');
-    return new Results(`#nxContent [name='${pill.getAttribute('name')}']`);
+    return (async () => {
+      const ele = await this.el;
+      const pill = await ele.$('#documentViewsItems nuxeo-page-item.iron-selected');
+      const getAttributeName = await pill.getAttribute('name');
+      const getViewElement = await new Results(`#nxContent [name=${getAttributeName}]`);
+      return getViewElement;
+    })();
   }
 
   get breadcrumb() {

--- a/packages/nuxeo-web-ui-ftest/pages/ui/results.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/results.js
@@ -12,7 +12,10 @@ export default class Results extends BasePage {
   }
 
   get displayModes() {
-    return this.el.$$('div.resultActions paper-icon-button.displayMode');
+    return (async () => {
+      const ele = await this.el.$$('div.resultActions paper-icon-button.displayMode');
+      return ele;
+    })();
   }
 
   get displayMode() {


### PR DESCRIPTION
Ticket Link: https://jira.nuxeo.com/browse/WEBUI-1333
## Setup
###  On Development (:5000)
 - Remove `disabled` keyword from line [nuxeo-web-ui-bundle.html](https://github.com/nuxeo/nuxeo-web-ui/blob/maintenance-3.1.x/elements/nuxeo-web-ui-bundle.html#L825)

###  On Server(:8080)
- Take Reference from here [enable-spreadsheet-button-contribution-in-web-ui](https://doc.nuxeo.com/nxdoc/nuxeo-spreadsheet/#enable-spreadsheet-button-contribution-in-web-ui)

When we move code into main f-test then the import path will change to below code.
File Path:`packages/nuxeo-web-ui-ftest/features/step_definitions/spreadsheet.js`
```
import Spreadsheet from '../../pages/spreadsheet';
import { Then, When } from '../../node_modules/@cucumber/cucumber';
```

https://github.com/nuxeo/nuxeo-web-ui/assets/52422856/e3660b77-58dd-4604-a5e4-a63a446de91f

