### PR TITLE
[WEBUI-1840] - Potential fix for code scanning alert no. 6: Prototype-polluting function

### DIFF
--- a/addons/nuxeo-spreadsheet/app/lib/handsontable.patches.js
+++ b/addons/nuxeo-spreadsheet/app/lib/handsontable.patches.js
@@ -56,11 +56,20 @@ Handsontable.DataMap.prototype.set = function(row, prop, value, source) {
     let i;
     let ilen;
     for (i = 0, ilen = sliced.length - 1; i < ilen; i++) {
+      // Prevent prototype pollution
+      if (sliced[i] === '__proto__' || sliced[i] === 'constructor') {
+        // Do not assign dangerous property, abort
+        return;
+      }
       // NXP-28923 - if (typeof out[sliced[i]] === 'undefined'){
       if (out[sliced[i]] == null) {
         out[sliced[i]] = {};
       }
       out = out[sliced[i]];
+    }
+    // Prevent prototype pollution at assignment as well
+    if (sliced[i] === '__proto__' || sliced[i] === 'constructor') {
+      return;
     }
     out[sliced[i]] = value;
   } else if (typeof prop === 'function') {

--- a/addons/nuxeo-spreadsheet/app/vendor/jquery.handsontable.full.js
+++ b/addons/nuxeo-spreadsheet/app/vendor/jquery.handsontable.full.js
@@ -4737,11 +4737,27 @@ Handsontable.helper.toString = function (obj) {
       var sliced = prop.split(".");
       var out = this.dataSource[row];
       for (var i = 0, ilen = sliced.length - 1; i < ilen; i++) {
-
+        // Block prototype-polluting keys
+        if (
+          sliced[i] === '__proto__' ||
+          sliced[i] === 'constructor' ||
+          sliced[i] === 'prototype'
+        ) {
+          // Skip this assignment, or optionally throw an error.
+          return;
+        }
         if (typeof out[sliced[i]] === 'undefined'){
           out[sliced[i]] = {};
         }
         out = out[sliced[i]];
+      }
+      // Also block at the leaf before assignment
+      if (
+        sliced[i] === '__proto__' ||
+        sliced[i] === 'constructor' ||
+        sliced[i] === 'prototype'
+      ) {
+        return;
       }
       out[sliced[i]] = value;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/nuxeo/nuxeo-web-ui/security/code-scanning/6](https://github.com/nuxeo/nuxeo-web-ui/security/code-scanning/6)

To fix this prototype pollution vulnerability, we should block assignments to forbidden property names—specifically `__proto__`, `constructor`, and, optionally, `prototype`—at each level of the property chain, before setting intermediate or final values. This can be done by skipping or throwing an error when any segment in the property path is a forbidden name. The required change is inside the loop for chained property assignment (`for (var i = 0, ilen = sliced.length - 1; i < ilen; i++)`). The fix is localized to the snippet in `addons/nuxeo-spreadsheet/app/vendor/jquery.handsontable.full.js`, specifically inside the `Handsontable.DataMap.prototype.set` function, lines 4736–4747. No new external method or import is needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
