### PR TITLE
WEBUI-1623: Date change on Workflow Analytics does not trigger request [LTS-2025]

### DIFF
--- a/elements/nuxeo-admin/nuxeo-workflow-analytics.js
+++ b/elements/nuxeo-admin/nuxeo-workflow-analytics.js
@@ -110,8 +110,8 @@ Polymer({
             selected="{{workflow}}"
             options="[[workflows]]"
           ></nuxeo-select>
-          <nuxeo-date-picker value="{{startDate::change}}" label="[[i18n('analytics.after')]]"></nuxeo-date-picker>
-          <nuxeo-date-picker value="{{endDate::change}}" label="[[i18n('analytics.before')]]"></nuxeo-date-picker>
+          <nuxeo-date-picker value="{{startDate}}" label="[[i18n('analytics.after')]]"></nuxeo-date-picker>
+          <nuxeo-date-picker value="{{endDate}}" label="[[i18n('analytics.before')]]"></nuxeo-date-picker>
         </div>
       </nuxeo-card>
 


### PR DESCRIPTION
**Issue Identified**

Incorrect Polymer data binding annotation in elements/nuxeo-admin/nuxeo-workflow-analytics.js (lines 113-114) preventing date changes from triggering data refresh requests.

**Technical Root Cause:**

The workflow analytics component used the ::change event annotation in its date picker bindings:

**The Problem:**

The ::change annotation forces Polymer to only update the bound property when a DOM change event fires.
However, nuxeo-date-picker uses Polymer's standard notify: true pattern, which notifies via property changes, not DOM events, When users selected new dates, the date picker's value changed and notified the parent component, But since the parent was listening for a change event (not property notifications), the startDate and endDate properties never updated Without property updates, the elements didn't receive new date values and couldn't trigger new API requests