### PR TITLE
WEBUI-2026: move recent documents NXQL query to server-side page provider

### DIFF
--- a/elements/nuxeo-home.html
+++ b/elements/nuxeo-home.html
@@ -201,7 +201,12 @@ limitations under the License.
               name="nuxeo-recent-documents"
               documents="{{_recentDocuments}}"
             ></nuxeo-document-storage>
-            <nuxeo-page-provider id="recentProvider" page-size="15" schemas="uid"></nuxeo-page-provider>
+            <nuxeo-page-provider
+              id="recentProvider"
+              provider="webui_recently_viewed"
+              page-size="15"
+              schemas="uid"
+            ></nuxeo-page-provider>
             <nuxeo-data-table
               id="latestViewedDocs"
               wrapper-height="350px"
@@ -367,8 +372,7 @@ limitations under the License.
         if (docs && docs.length > 0) {
           const storage = this.$.recentStorage;
           const provider = this.$.recentProvider;
-          const ids = docs.map((doc) => `'${doc.uid}'`).join(',');
-          provider.query = `SELECT * FROM Document WHERE ecm:uuid IN (${ids}) AND ecm:isTrashed = 0`;
+          provider.params = [docs.map((doc) => doc.uid)];
           provider.fetch().then((result) => {
             docs.forEach((doc) => {
               if (result.entries.findIndex((entry) => entry.uid === doc.uid) === -1) {

--- a/plugin/web-ui/addon/src/main/resources/META-INF/MANIFEST.MF
+++ b/plugin/web-ui/addon/src/main/resources/META-INF/MANIFEST.MF
@@ -10,4 +10,5 @@ Nuxeo-Component: OSGI-INF/auth-config.xml,
   OSGI-INF/login-startup-page-web-contrib.xml,
   OSGI-INF/url-codecs-web-contrib.xml,
   OSGI-INF/browser-cache-contrib.xml,
-  OSGI-INF/web-ui-properties.xml
+  OSGI-INF/web-ui-properties.xml,
+  OSGI-INF/pageproviders-contrib.xml

--- a/plugin/web-ui/addon/src/main/resources/OSGI-INF/pageproviders-contrib.xml
+++ b/plugin/web-ui/addon/src/main/resources/OSGI-INF/pageproviders-contrib.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.web.ui.pageproviders">
+
+  <extension target="org.nuxeo.ecm.platform.query.api.PageProviderService" point="providers">
+
+    <coreQueryPageProvider name="webui_recently_viewed">
+      <pattern>
+        SELECT * FROM Document WHERE ecm:uuid IN (?) AND ecm:isTrashed = 0
+      </pattern>
+      <pageSize>15</pageSize>
+    </coreQueryPageProvider>
+
+  </extension>
+
+</component>


### PR DESCRIPTION
Replace the client-side NXQL query string in nuxeo-home.html with a
server-side 'webui_recently_viewed' page provider to address the DAST
scanner SQL Information Leakage finding.
