### PR TITLE
WEBUI-1990: fix sonar branch detection and add push trigger [LTS-2023]

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -92,7 +92,7 @@ jobs:
       - name: Resolve project version and branch
         id: project_meta
         run: |
-          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
           # github.head_ref = PR source branch, github.ref_name = push branch,
           # inputs.branch = workflow_call. git HEAD is detached on PR/push events.
           echo "branch=${{ github.head_ref || github.ref_name || inputs.branch }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - maintenance-3.1.x
 
+  push:
+    branches:
+      - maintenance-3.1.x
+
   workflow_dispatch:
 
   workflow_call:
@@ -89,7 +93,9 @@ jobs:
         id: project_meta
         run: |
           echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-          echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> "$GITHUB_OUTPUT"
+          # github.head_ref = PR source branch, github.ref_name = push branch,
+          # inputs.branch = workflow_call. git HEAD is detached on PR/push events.
+          echo "branch=${{ github.head_ref || github.ref_name || inputs.branch }}" >> "$GITHUB_OUTPUT"
         working-directory: ${{ github.workspace }}
 
       - name: Build and analyze


### PR DESCRIPTION
## Follow-up to #3102

Two fixes to the SonarCloud configuration:

### 1. Add `push` trigger on `maintenance-3.1.x`
Without a `push` trigger, no scan runs after a PR merges — the SonarCloud Overview dashboard never refreshes with updated version/branch metadata.

### 2. Fix `sonar.branch.name` — was always `HEAD`
`git rev-parse --abbrev-ref HEAD` returns `HEAD` on `pull_request` and `push` events because `actions/checkout` leaves the repo in a detached HEAD state. Replaced with `${{ github.head_ref || github.ref_name || inputs.branch }}` which correctly resolves in all trigger scenarios.