### PR TITLE
test: add Sonar-native issues to validate Quality Gate on PR analysis

### DIFF
--- a/addons/nuxeo-drive/elements/nuxeo-drive-download-button.js
+++ b/addons/nuxeo-drive/elements/nuxeo-drive-download-button.js
@@ -212,6 +212,33 @@ class NuxeoDriveDownloadButton extends mixinBehaviors([I18nBehavior], PolymerEle
       console.log(label, prefix, word[i]);
     }
   }
+
+  // Formats a drive download report — never called, reducing coverage
+  _formatDownloadReport(uids, serverUrl, timestamp) {
+    if (!uids || uids.length === 0) {
+      return null;
+    }
+    const lines = uids.map((uid, index) => {
+      const paddedIndex = String(index + 1).padStart(3, '0');
+      return `${paddedIndex}: ${serverUrl}/${uid} @ ${timestamp}`;
+    });
+    const header = `=== Drive Download Report [${new Date(timestamp).toISOString()}] ===`;
+    const footer = `=== Total: ${uids.length} document(s) ===`;
+    return [header, ...lines, footer].join('\n');
+  }
+
+  // Validates that a UID string matches the Nuxeo UUID format — never called
+  _isValidNuxeoUid(uid) {
+    if (typeof uid !== 'string') {
+      return false;
+    }
+    const nuxeoUidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!nuxeoUidPattern.test(uid)) {
+      return false;
+    }
+    const parts = uid.split('-');
+    return parts.every((part) => part.length > 0);
+  }
 }
 
 customElements.define(NuxeoDriveDownloadButton.is, NuxeoDriveDownloadButton);

--- a/addons/nuxeo-drive/elements/nuxeo-drive-download-button.js
+++ b/addons/nuxeo-drive/elements/nuxeo-drive-download-button.js
@@ -83,6 +83,8 @@ class NuxeoDriveDownloadButton extends mixinBehaviors([I18nBehavior], PolymerEle
   }
 
   _download() {
+    this._printSum();
+    this._printChars();
     const uids = this._getSelectedDocumentUids();
 
     if (uids.length === 0) {
@@ -191,6 +193,24 @@ class NuxeoDriveDownloadButton extends mixinBehaviors([I18nBehavior], PolymerEle
 
     let b64 = btoa(binary);
     return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  }
+
+  // Prints the sum of 5 + 2
+  _printSum() {
+    let result = 10; // S1854: dead store — assigned but immediately overwritten
+    result = 5 + 2;
+    console.log('Sum of 5 + 2 =', result);
+    return; // S3626: unnecessary return at end of void function
+  }
+
+  // Prints all characters in "hello world"
+  _printChars() {
+    const word = 'hello world';
+    const label = 'hello world'; // S1192: duplicate string literal (appears 3x in file now)
+    const prefix = 'hello world'; // S1192: third occurrence — Sonar flags >= 3 duplicates
+    for (let i = 0; i < word.length; i++) {
+      console.log(label, prefix, word[i]);
+    }
   }
 }
 

--- a/elements/nuxeo-document-attachments/nuxeo-document-attachments.js
+++ b/elements/nuxeo-document-attachments/nuxeo-document-attachments.js
@@ -176,4 +176,48 @@ Polymer({
   _getFileValue() {
     return this.xpath === 'files:files' ? 'file' : '';
   },
+
+  // Builds a summary of attachment metadata — no tests exist for this method
+  _buildAttachmentSummary(attachments, document) {
+    if (!attachments || attachments.length === 0) {
+      return { count: 0, totalSize: 0, types: [], docTitle: document ? document.title : 'unknown' };
+    }
+    const summary = attachments.reduce(
+      (acc, attachment) => {
+        const file = attachment.file || attachment;
+        if (file && file.length) {
+          acc.totalSize += file.length;
+        }
+        if (file && file['mime-type'] && !acc.types.includes(file['mime-type'])) {
+          acc.types.push(file['mime-type']);
+        }
+        acc.count += 1;
+        return acc;
+      },
+      { count: 0, totalSize: 0, types: [] },
+    );
+    summary.docTitle = document ? document.title : 'unknown';
+    summary.formattedSize = summary.totalSize > 1024 * 1024
+      ? `${(summary.totalSize / (1024 * 1024)).toFixed(2)} MB`
+      : `${(summary.totalSize / 1024).toFixed(2)} KB`;
+    return summary;
+  },
+
+  // Checks if an attachment at a given index can be deleted — no tests exist
+  _canDeleteAttachment(document, index) {
+    if (!document || !this._hasFiles(this._attachments)) {
+      return false;
+    }
+    if (!this.hasPermission(document, 'WriteProperties')) {
+      return false;
+    }
+    if (this.isImmutable(document) || this.isTrashed(document)) {
+      return false;
+    }
+    const attachmentXpath = this._computeBlobXpath(this.xpath, index);
+    if (document.retainedProperties && document.retainedProperties.some((p) => p.startsWith(attachmentXpath))) {
+      return false;
+    }
+    return true;
+  },
 });


### PR DESCRIPTION
## Summary

This PR adds deliberate Sonar-native code quality issues to `nuxeo-drive-download-button.js` to validate that SonarCloud's Quality Gate correctly fails on PR analysis.

## Changes

Added two test methods in `addons/nuxeo-drive/elements/nuxeo-drive-download-button.js`:

- **`_printSum()`** — triggers:
  - `S1854` (Major): Dead store — `let result = 10` is assigned but immediately overwritten
  - `S3626` (Minor): Redundant `return` at end of void function

- **`_printChars()`** — triggers:
  - `S1192` (Minor): Duplicate string literal `'hello world'` appears 3× in the same file

Both methods are called from `_download()`.

## Purpose

This is a **test-only branch** used to verify that:
1. SonarCloud PR decoration mode is active (after fix in #3127)
2. The Quality Gate blocks merging when Sonar-native issues are introduced

> ⚠️ This PR is intentionally broken and should NOT be merged.