### PR TITLE
fix(sonar): include addon test directories in sonar.tests and sonar.test.inclusions

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,13 @@ sonar.organization=nuxeo
 sonar.sources=elements,addons,themes,i18n,index.js,legacy.js,.github
 
 # Test files (root + addon test directories)
-sonar.tests=test,addons/nuxeo-csv/test,addons/nuxeo-drive/test,addons/nuxeo-liveconnect/test,addons/nuxeo-template-rendering/test,addons/nuxeo-wopi/test
+sonar.tests=\
+  test,\
+  addons/nuxeo-csv/test,\
+  addons/nuxeo-drive/test,\
+  addons/nuxeo-liveconnect/test,\
+  addons/nuxeo-template-rendering/test,\
+  addons/nuxeo-wopi/test
 
 # Coverage report from Karma + Istanbul
 sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,8 +5,8 @@ sonar.organization=nuxeo
 # JS/HTML front-end sources
 sonar.sources=elements,addons,themes,i18n,index.js,legacy.js,.github
 
-# Test files
-sonar.tests=test
+# Test files (root + addon test directories)
+sonar.tests=test,addons/nuxeo-csv/test,addons/nuxeo-drive/test,addons/nuxeo-liveconnect/test,addons/nuxeo-template-rendering/test,addons/nuxeo-wopi/test
 
 # Coverage report from Karma + Istanbul
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
@@ -48,8 +48,8 @@ sonar.coverage.exclusions=\
   addons/nuxeo-platform-3d/controls/**,\
   i18n/**/*.json
 
-# Treat test/**/*.test.js as test code, not source
-sonar.test.inclusions=test/**/*.test.js
+# Treat test/**/*.test.js and addon test files as test code, not source
+sonar.test.inclusions=test/**/*.test.js,addons/*/test/**/*.test.js
 
 sonar.sourceEncoding=UTF-8
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -35,6 +35,7 @@ sonar.exclusions=\
   packages/**,\
   charts/**,\
   server/**,\
+  addons/**/test/**,\
   addons/**/vendor/**,\
   addons/**/webpack.config.js,\
   addons/nuxeo-spreadsheet/app/**,\


### PR DESCRIPTION
## Problem

Addon unit tests (`addons/*/test/**/*.test.js`) were invisible to SonarCloud because `sonar.tests` only pointed to the root `test/` directory.

This caused coverage for addon source files (e.g. `addons/nuxeo-drive/elements/nuxeo-drive-download-button.js`) to show as **N/A** instead of being measured. When coverage is N/A, SonarCloud skips the coverage gate condition entirely — allowing PRs that introduce uncovered code to pass.

## Fix

- Expand `sonar.tests` to include all addon test directories that contain test files:
  - `addons/nuxeo-csv/test`
  - `addons/nuxeo-drive/test`
  - `addons/nuxeo-liveconnect/test`
  - `addons/nuxeo-template-rendering/test`
  - `addons/nuxeo-wopi/test`
- Expand `sonar.test.inclusions` to match `addons/*/test/**/*.test.js`

## Impact

After this fix, SonarCloud will correctly measure coverage for addon source files and apply the Quality Gate coverage condition on new code in addon files.