### PR TITLE
WEBUI-1990: declare addon test dirs as test code in sonar-project.properties [LTS-2023]

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -35,7 +35,6 @@ sonar.exclusions=\
   packages/**,\
   charts/**,\
   server/**,\
-  addons/**/test/**,\
   addons/**/vendor/**,\
   addons/**/webpack.config.js,\
   addons/nuxeo-spreadsheet/app/**,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,14 +5,19 @@ sonar.organization=nuxeo
 # JS/HTML front-end sources
 sonar.sources=elements,addons,themes,i18n,index.js,legacy.js,.github
 
-# Test files (root + addon test directories)
+# Test files (root + all addon directories)
 sonar.tests=\
   test,\
-  addons/nuxeo-csv/test,\
-  addons/nuxeo-drive/test,\
-  addons/nuxeo-liveconnect/test,\
-  addons/nuxeo-template-rendering/test,\
-  addons/nuxeo-wopi/test
+  addons/amazon-s3-online-storage,\
+  addons/easyshare,\
+  addons/nuxeo-csv,\
+  addons/nuxeo-drive,\
+  addons/nuxeo-imap-connector,\
+  addons/nuxeo-liveconnect,\
+  addons/nuxeo-platform-3d,\
+  addons/nuxeo-spreadsheet,\
+  addons/nuxeo-template-rendering,\
+  addons/nuxeo-wopi
 
 # Coverage report from Karma + Istanbul
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
@@ -37,9 +42,6 @@ sonar.exclusions=\
   server/**,\
   addons/**/vendor/**,\
   addons/**/webpack.config.js,\
-  addons/nuxeo-spreadsheet/app/**,\
-  addons/nuxeo-platform-3d/loaders/**,\
-  addons/nuxeo-platform-3d/controls/**,\
   i18n/**/*.json
 
 # Exclude test/generated files from coverage metrics
@@ -47,14 +49,10 @@ sonar.coverage.exclusions=\
   **/*.test.js,\
   **/*.yaml,\
   **/*.yml,\
-  addons/**/vendor/**,\
-  addons/nuxeo-spreadsheet/app/**,\
-  addons/nuxeo-platform-3d/loaders/**,\
-  addons/nuxeo-platform-3d/controls/**,\
   i18n/**/*.json
 
 # Treat test/**/*.test.js and addon test files as test code, not source
-sonar.test.inclusions=test/**/*.test.js,addons/*/test/**/*.test.js
+sonar.test.inclusions=test/**/*.test.js,addons/**/*.test.js
 
 sonar.sourceEncoding=UTF-8
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -47,7 +47,6 @@ sonar.coverage.exclusions=\
   **/*.test.js,\
   **/*.yaml,\
   **/*.yml,\
-  addons/**/test/**,\
   addons/**/vendor/**,\
   addons/nuxeo-spreadsheet/app/**,\
   addons/nuxeo-platform-3d/loaders/**,\


### PR DESCRIPTION
https://hyland.atlassian.net/browse/WEBUI-1990
## Summary

Fixes an inconsistency in `sonar-project.properties` where addon test directories were not declared as test code.

## Changes

- Added addon test directories to `sonar.tests`
- Updated `sonar.test.inclusions` to include `addons/*/test/**/*.test.js`



