### PR TITLE
WEBUI-1990: fix sonar.tests source/test overlap [LTS-2025]

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,19 +5,14 @@ sonar.organization=nuxeo
 # JS/HTML front-end sources
 sonar.sources=elements,addons,themes,i18n,index.js,legacy.js,.github
 
-# Test files (root + all addon directories)
+# Test files (root + addon test directories)
 sonar.tests=\
   test,\
-  addons/amazon-s3-online-storage,\
-  addons/easyshare,\
-  addons/nuxeo-csv,\
-  addons/nuxeo-drive,\
-  addons/nuxeo-imap-connector,\
-  addons/nuxeo-liveconnect,\
-  addons/nuxeo-platform-3d,\
-  addons/nuxeo-spreadsheet,\
-  addons/nuxeo-template-rendering,\
-  addons/nuxeo-wopi
+  addons/nuxeo-csv/test,\
+  addons/nuxeo-drive/test,\
+  addons/nuxeo-liveconnect/test,\
+  addons/nuxeo-template-rendering/test,\
+  addons/nuxeo-wopi/test
 
 # Coverage report from Karma + Istanbul
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
@@ -52,7 +47,7 @@ sonar.coverage.exclusions=\
   i18n/**/*.json
 
 # Treat test/**/*.test.js and addon test files as test code, not source
-sonar.test.inclusions=test/**/*.test.js,addons/**/*.test.js
+sonar.test.inclusions=test/**/*.test.js,addons/*/test/**/*.test.js
 
 sonar.sourceEncoding=UTF-8
 


### PR DESCRIPTION
https://hyland.atlassian.net/browse/WEBUI-1990

sonar.sources includes 'addons' and sonar.tests listed entire addon directories (e.g. addons/nuxeo-csv), causing a source/test overlap that made the scanner fail with exit code 3.

Fix: revert sonar.tests to list only the test/ subdirectories and sonar.test.inclusions to addons/*/test/**/*.test.js.