### PR TITLE
WEBUI-1990: sonarqube configuration- set previous version [LTS-2025]

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -51,6 +51,12 @@ sonar.test.inclusions=test/**/*.test.js,addons/*/test/**/*.test.js
 
 sonar.sourceEncoding=UTF-8
 
+# New Code definition — use "previous_version" so that only code changed
+# since the last sonar.projectVersion bump is treated as new code.
+# This ensures the quality gate evaluates only genuinely new/changed code,
+# not the entire codebase (which would fail on a newly tracked branch).
+sonar.newCode.definition=previous_version
+
 # Block PR merge on Quality Gate failure.
 # Gate conditions (set in SonarCloud UI, new code only):
 #   Coverage >= 90%, Issues == 0, Hotspots reviewed == 100%, Duplications <= 3%


### PR DESCRIPTION
https://hyland.atlassian.net/browse/WEBUI-1990

lts-2025 is a new branch in SonarCloud with no scan history. Without a New Code baseline, SonarCloud treats all code as new and the quality gate fails on overall coverage (68.3% < 90%).

Setting `sonar.newCode.definition=previous_version` tells SonarCloud to use `sonar.projectVersion` changes as the baseline, matching how maintenance-3.1.x works ("New code: since 3.1.30-SNAPSHOT").