### PR TITLE
WEBUI-1990: fix sonar quality gate for new branches [LTS-2025]

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -112,7 +112,7 @@ jobs:
                 github.event.pull_request.number,
                 github.event.pull_request.head.ref,
                 github.event.pull_request.base.ref)
-              || format('-Dsonar.branch.name={0}', steps.project_meta.outputs.branch) }}
+              || format('-Dsonar.branch.name={0} -Dsonar.newCode.referenceBranch={0}', steps.project_meta.outputs.branch) }}
 
       - name: Enforce Quality Gate
         # Fails if sonar scan was skipped (e.g. prior step failed) or gate not passed.


### PR DESCRIPTION
Add `-Dsonar.newCode.referenceBranch` to branch analysis so SonarCloud compares the branch against itself. This bootstraps the New Code baseline for branches with no prior scan history (e.g. lts-2025), preventing the quality gate from treating all code as new.

Replaces the ineffective `sonar.newCode.definition` property approach (PR #3145) — that property is only supported by SonarQube Server, not SonarCloud.