### PR TITLE
WEBUI-2038: Fix json5 and tmp Dependabot vulnerabilities in lockfiles

### DIFF
--- a/plugin/a11y/package-lock.json
+++ b/plugin/a11y/package-lock.json
@@ -39,14 +39,10 @@
         "@wdio/local-runner": "9.27.1",
         "@wdio/spec-reporter": "9.27.1",
         "babel-plugin-transform-rename-import": "^2.3.0",
-        "babel-preset-env": "^1.7.0",
-        "babel-register": "^6.26.0",
         "chai": "^4.1.2",
         "check-engine": "^1.10.0",
         "chrome-launcher": "^0.14.0",
-        "cucumber-junit": "^1.7.1",
         "fs-extra": "^9.1.0",
-        "fs-finder": "^1.8.1",
         "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
         "moment": "^2.29.4",
@@ -63,8 +59,10 @@
         "node": ">=18.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/code-frame": {
+    "node_modules/@babel/code-frame": {
       "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -75,15 +73,19 @@
         "node": ">=6.9.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/compat-data": {
+    "node_modules/@babel/compat-data": {
       "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/core": {
+    "node_modules/@babel/core": {
       "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -110,8 +112,10 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/generator": {
+    "node_modules/@babel/generator": {
       "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -124,8 +128,10 @@
         "node": ">=6.9.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-annotate-as-pure": {
+    "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.27.3"
@@ -134,8 +140,10 @@
         "node": ">=6.9.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-compilation-targets": {
+    "node_modules/@babel/helper-compilation-targets": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -148,8 +156,10 @@
         "node": ">=6.9.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-create-class-features-plugin": {
+    "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.3.tgz",
+      "integrity": "sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -167,8 +177,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-create-regexp-features-plugin": {
+    "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
+      "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -182,8 +194,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-define-polyfill-provider": {
+    "node_modules/@babel/helper-define-polyfill-provider": {
       "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+      "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.28.6",
@@ -196,15 +210,19 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-globals": {
+    "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-member-expression-to-functions": {
+    "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.5",
@@ -214,8 +232,10 @@
         "node": ">=6.9.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-module-imports": {
+    "node_modules/@babel/helper-module-imports": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -225,8 +245,10 @@
         "node": ">=6.9.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-module-transforms": {
+    "node_modules/@babel/helper-module-transforms": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -240,8 +262,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-optimise-call-expression": {
+    "node_modules/@babel/helper-optimise-call-expression": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.27.1"
@@ -250,15 +274,19 @@
         "node": ">=6.9.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-plugin-utils": {
+    "node_modules/@babel/helper-plugin-utils": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-remap-async-to-generator": {
+    "node_modules/@babel/helper-remap-async-to-generator": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
+      "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
@@ -272,8 +300,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-replace-supers": {
+    "node_modules/@babel/helper-replace-supers": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.28.5",
@@ -287,8 +317,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.27.1",
@@ -298,29 +330,37 @@
         "node": ">=6.9.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-string-parser": {
+    "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-validator-identifier": {
+    "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-validator-option": {
+    "node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helper-wrap-function": {
+    "node_modules/@babel/helper-wrap-function": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
+      "integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -331,8 +371,10 @@
         "node": ">=6.9.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/helpers": {
+    "node_modules/@babel/helpers": {
       "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -342,8 +384,10 @@
         "node": ">=6.9.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/parser": {
+    "node_modules/@babel/parser": {
       "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -355,8 +399,10 @@
         "node": ">=6.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+    "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
       "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.28.5.tgz",
+      "integrity": "sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -369,8 +415,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+    "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
+      "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -382,8 +430,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+    "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
+      "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -395,8 +445,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+    "node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
       "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.3.tgz",
+      "integrity": "sha512-SRS46DFR4HqzUzCVgi90/xMoL+zeBDBvWdKYXSEzh79kXswNFEglUpMKxR04//dPqwYXWUBJ3mpUd933ru9Kmg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -409,8 +461,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
+      "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -424,8 +478,10 @@
         "@babel/core": "^7.13.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+    "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
+      "integrity": "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -438,8 +494,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-proposal-private-property-in-object": {
+    "node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -448,8 +506,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-syntax-import-assertions": {
+    "node_modules/@babel/plugin-syntax-import-assertions": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
+      "integrity": "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -461,8 +521,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-syntax-import-attributes": {
+    "node_modules/@babel/plugin-syntax-import-attributes": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -474,8 +536,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-syntax-unicode-sets-regex": {
+    "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
       "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+      "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.18.6",
@@ -488,8 +552,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-arrow-functions": {
+    "node_modules/@babel/plugin-transform-arrow-functions": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
+      "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -501,8 +567,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-async-generator-functions": {
+    "node_modules/@babel/plugin-transform-async-generator-functions": {
       "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
+      "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -516,8 +584,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-async-to-generator": {
+    "node_modules/@babel/plugin-transform-async-to-generator": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
+      "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -531,8 +601,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-block-scoped-functions": {
+    "node_modules/@babel/plugin-transform-block-scoped-functions": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
+      "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -544,8 +616,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-block-scoping": {
+    "node_modules/@babel/plugin-transform-block-scoping": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
+      "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -557,8 +631,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-class-properties": {
+    "node_modules/@babel/plugin-transform-class-properties": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
+      "integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.28.6",
@@ -571,8 +647,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-class-static-block": {
+    "node_modules/@babel/plugin-transform-class-static-block": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
+      "integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.28.6",
@@ -585,8 +663,10 @@
         "@babel/core": "^7.12.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-classes": {
+    "node_modules/@babel/plugin-transform-classes": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
+      "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -603,8 +683,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-computed-properties": {
+    "node_modules/@babel/plugin-transform-computed-properties": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
+      "integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -617,8 +699,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-destructuring": {
+    "node_modules/@babel/plugin-transform-destructuring": {
       "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
+      "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -631,8 +715,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-dotall-regex": {
+    "node_modules/@babel/plugin-transform-dotall-regex": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
+      "integrity": "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.28.5",
@@ -645,8 +731,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-duplicate-keys": {
+    "node_modules/@babel/plugin-transform-duplicate-keys": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
+      "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -658,8 +746,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+    "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
       "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.0.tgz",
+      "integrity": "sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.28.5",
@@ -672,8 +762,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-dynamic-import": {
+    "node_modules/@babel/plugin-transform-dynamic-import": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
+      "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -685,8 +777,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-explicit-resource-management": {
+    "node_modules/@babel/plugin-transform-explicit-resource-management": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
+      "integrity": "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -699,8 +793,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-exponentiation-operator": {
+    "node_modules/@babel/plugin-transform-exponentiation-operator": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
+      "integrity": "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -712,8 +808,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-export-namespace-from": {
+    "node_modules/@babel/plugin-transform-export-namespace-from": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
+      "integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -725,8 +823,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-for-of": {
+    "node_modules/@babel/plugin-transform-for-of": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
+      "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -739,8 +839,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-function-name": {
+    "node_modules/@babel/plugin-transform-function-name": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
+      "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.27.1",
@@ -754,8 +856,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-json-strings": {
+    "node_modules/@babel/plugin-transform-json-strings": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
+      "integrity": "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -767,8 +871,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-literals": {
+    "node_modules/@babel/plugin-transform-literals": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
+      "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -780,8 +886,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-logical-assignment-operators": {
+    "node_modules/@babel/plugin-transform-logical-assignment-operators": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
+      "integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -793,8 +901,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-member-expression-literals": {
+    "node_modules/@babel/plugin-transform-member-expression-literals": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
+      "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -806,8 +916,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-modules-amd": {
+    "node_modules/@babel/plugin-transform-modules-amd": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
+      "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.27.1",
@@ -820,8 +932,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-modules-commonjs": {
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.28.6",
@@ -834,8 +948,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-modules-systemjs": {
+    "node_modules/@babel/plugin-transform-modules-systemjs": {
       "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.28.6",
@@ -850,8 +966,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-modules-umd": {
+    "node_modules/@babel/plugin-transform-modules-umd": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
+      "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.27.1",
@@ -864,8 +982,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+    "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
       "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
+      "integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.28.5",
@@ -878,8 +998,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-new-target": {
+    "node_modules/@babel/plugin-transform-new-target": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
+      "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -891,8 +1013,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+    "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
+      "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -904,8 +1028,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-numeric-separator": {
+    "node_modules/@babel/plugin-transform-numeric-separator": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
+      "integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -917,8 +1043,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-object-rest-spread": {
+    "node_modules/@babel/plugin-transform-object-rest-spread": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
+      "integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.28.6",
@@ -934,8 +1062,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-object-super": {
+    "node_modules/@babel/plugin-transform-object-super": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
+      "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -948,8 +1078,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-optional-catch-binding": {
+    "node_modules/@babel/plugin-transform-optional-catch-binding": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
+      "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -961,8 +1093,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-optional-chaining": {
+    "node_modules/@babel/plugin-transform-optional-chaining": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
+      "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -975,8 +1109,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-parameters": {
+    "node_modules/@babel/plugin-transform-parameters": {
       "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+      "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -988,8 +1124,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-private-methods": {
+    "node_modules/@babel/plugin-transform-private-methods": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
+      "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.28.6",
@@ -1002,8 +1140,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-private-property-in-object": {
+    "node_modules/@babel/plugin-transform-private-property-in-object": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
+      "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -1017,8 +1157,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-property-literals": {
+    "node_modules/@babel/plugin-transform-property-literals": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
+      "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1030,8 +1172,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-regenerator": {
+    "node_modules/@babel/plugin-transform-regenerator": {
       "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
+      "integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -1043,8 +1187,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-regexp-modifiers": {
+    "node_modules/@babel/plugin-transform-regexp-modifiers": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
+      "integrity": "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.28.5",
@@ -1057,8 +1203,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-reserved-words": {
+    "node_modules/@babel/plugin-transform-reserved-words": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
+      "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1070,8 +1218,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-shorthand-properties": {
+    "node_modules/@babel/plugin-transform-shorthand-properties": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
+      "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1083,8 +1233,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-spread": {
+    "node_modules/@babel/plugin-transform-spread": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
+      "integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -1097,8 +1249,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-sticky-regex": {
+    "node_modules/@babel/plugin-transform-sticky-regex": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
+      "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1110,8 +1264,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-template-literals": {
+    "node_modules/@babel/plugin-transform-template-literals": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+      "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1123,8 +1279,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-typeof-symbol": {
+    "node_modules/@babel/plugin-transform-typeof-symbol": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
+      "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1136,8 +1294,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-unicode-escapes": {
+    "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
+      "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1149,8 +1309,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-unicode-property-regex": {
+    "node_modules/@babel/plugin-transform-unicode-property-regex": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
+      "integrity": "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.28.5",
@@ -1163,8 +1325,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-unicode-regex": {
+    "node_modules/@babel/plugin-transform-unicode-regex": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
+      "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -1177,8 +1341,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/plugin-transform-unicode-sets-regex": {
+    "node_modules/@babel/plugin-transform-unicode-sets-regex": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
+      "integrity": "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.28.5",
@@ -1191,8 +1357,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/preset-env": {
+    "node_modules/@babel/preset-env": {
       "version": "7.29.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.5.tgz",
+      "integrity": "sha512-/69t2aEzGKHD76DyLbHysF/QH2LJOB8iFnYO37unDTKBTubzcMRv0f3H5EiN1Q6ajOd/eB7dAInF0qdFVS06kA==",
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.29.3",
@@ -1274,9458 +1442,10 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/preset-modules": {
-      "version": "0.1.6-no-external-plugins",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/types": "^7.4.4",
-        "esutils": "^2.0.2"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/register": {
-      "version": "7.29.3",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "find-cache-dir": "^2.0.0",
-        "make-dir": "^2.1.0",
-        "pirates": "^4.0.6",
-        "source-map-support": "^0.5.16"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/template": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@babel/types": {
-      "version": "7.29.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/ci-environment": {
-      "version": "10.0.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/cucumber": {
-      "version": "10.9.0",
-      "license": "MIT",
-      "dependencies": {
-        "@cucumber/ci-environment": "10.0.1",
-        "@cucumber/cucumber-expressions": "17.1.0",
-        "@cucumber/gherkin": "28.0.0",
-        "@cucumber/gherkin-streams": "5.0.1",
-        "@cucumber/gherkin-utils": "9.0.0",
-        "@cucumber/html-formatter": "21.6.0",
-        "@cucumber/message-streams": "4.0.1",
-        "@cucumber/messages": "24.1.0",
-        "@cucumber/tag-expressions": "6.1.0",
-        "assertion-error-formatter": "^3.0.0",
-        "capital-case": "^1.0.4",
-        "chalk": "^4.1.2",
-        "cli-table3": "0.6.3",
-        "commander": "^10.0.0",
-        "debug": "^4.3.4",
-        "error-stack-parser": "^2.1.4",
-        "figures": "^3.2.0",
-        "glob": "^10.3.10",
-        "has-ansi": "^4.0.1",
-        "indent-string": "^4.0.0",
-        "is-installed-globally": "^0.4.0",
-        "is-stream": "^2.0.0",
-        "knuth-shuffle-seeded": "^1.0.6",
-        "lodash.merge": "^4.6.2",
-        "lodash.mergewith": "^4.6.2",
-        "luxon": "3.2.1",
-        "mime": "^3.0.0",
-        "mkdirp": "^2.1.5",
-        "mz": "^2.7.0",
-        "progress": "^2.0.3",
-        "read-pkg-up": "^7.0.1",
-        "resolve-pkg": "^2.0.0",
-        "semver": "7.5.3",
-        "string-argv": "0.3.1",
-        "strip-ansi": "6.0.1",
-        "supports-color": "^8.1.1",
-        "tmp": "0.2.3",
-        "type-fest": "^4.8.3",
-        "util-arity": "^1.1.0",
-        "xmlbuilder": "^15.1.1",
-        "yaml": "^2.2.2",
-        "yup": "1.2.0"
-      },
-      "bin": {
-        "cucumber-js": "bin/cucumber.js"
-      },
-      "engines": {
-        "node": "18 || >=20"
-      },
-      "funding": {
-        "url": "https://opencollective.com/cucumber"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/cucumber-expressions": {
-      "version": "17.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "regexp-match-indices": "1.0.2"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/cucumber/node_modules/@cucumber/gherkin": {
-      "version": "28.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@cucumber/messages": ">=19.1.4 <=24"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/cucumber/node_modules/@cucumber/messages": {
-      "version": "24.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/uuid": "9.0.8",
-        "class-transformer": "0.5.1",
-        "reflect-metadata": "0.2.1",
-        "uuid": "9.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/cucumber/node_modules/@cucumber/tag-expressions": {
-      "version": "6.1.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/cucumber/node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/cucumber/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/cucumber/node_modules/mkdirp": {
-      "version": "2.1.6",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/cucumber/node_modules/reflect-metadata": {
-      "version": "0.2.1",
-      "license": "Apache-2.0"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/cucumber/node_modules/semver": {
-      "version": "7.5.3",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/cucumber/node_modules/uuid": {
-      "version": "9.0.1",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/cucumber/node_modules/yallist": {
-      "version": "4.0.0",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/gherkin": {
-      "version": "29.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@cucumber/messages": "<=25"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/gherkin-streams": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "9.1.0",
-        "source-map-support": "0.5.21"
-      },
-      "bin": {
-        "gherkin-javascript": "bin/gherkin"
-      },
-      "peerDependencies": {
-        "@cucumber/gherkin": ">=22.0.0",
-        "@cucumber/message-streams": ">=4.0.0",
-        "@cucumber/messages": ">=17.1.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/gherkin-streams/node_modules/commander": {
-      "version": "9.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/gherkin-utils": {
-      "version": "9.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@cucumber/gherkin": "^28.0.0",
-        "@cucumber/messages": "^24.0.0",
-        "@teppeis/multimaps": "3.0.0",
-        "commander": "12.0.0",
-        "source-map-support": "^0.5.21"
-      },
-      "bin": {
-        "gherkin-utils": "bin/gherkin-utils"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin": {
-      "version": "28.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@cucumber/messages": ">=19.1.4 <=24"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/messages": {
-      "version": "24.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/uuid": "9.0.8",
-        "class-transformer": "0.5.1",
-        "reflect-metadata": "0.2.1",
-        "uuid": "9.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/gherkin-utils/node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/gherkin-utils/node_modules/commander": {
-      "version": "12.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/gherkin-utils/node_modules/reflect-metadata": {
-      "version": "0.2.1",
-      "license": "Apache-2.0"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/gherkin-utils/node_modules/uuid": {
-      "version": "9.0.1",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/gherkin/node_modules/@cucumber/messages": {
-      "version": "25.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/uuid": "9.0.8",
-        "class-transformer": "0.5.1",
-        "reflect-metadata": "0.2.2",
-        "uuid": "9.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/gherkin/node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/gherkin/node_modules/uuid": {
-      "version": "9.0.1",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/html-formatter": {
-      "version": "21.6.0",
-      "license": "MIT",
-      "peerDependencies": {
-        "@cucumber/messages": ">=18"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/message-streams": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "peerDependencies": {
-        "@cucumber/messages": ">=17.1.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/messages": {
-      "version": "26.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/uuid": "10.0.0",
-        "class-transformer": "0.5.1",
-        "reflect-metadata": "0.2.2",
-        "uuid": "10.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@cucumber/tag-expressions": {
-      "version": "2.0.4",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@inquirer/ansi": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@inquirer/checkbox": {
-      "version": "4.3.2",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@inquirer/confirm": {
-      "version": "5.1.21",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@inquirer/core": {
-      "version": "10.3.2",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@inquirer/editor": {
-      "version": "4.2.23",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/external-editor": "^1.0.3",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@inquirer/expand": {
-      "version": "4.0.23",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@inquirer/external-editor": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^2.1.1",
-        "iconv-lite": "^0.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@inquirer/figures": {
-      "version": "1.0.15",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@inquirer/input": {
-      "version": "4.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@inquirer/number": {
-      "version": "3.0.23",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@inquirer/password": {
-      "version": "4.0.23",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@inquirer/prompts": {
-      "version": "7.10.1",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/checkbox": "^4.3.2",
-        "@inquirer/confirm": "^5.1.21",
-        "@inquirer/editor": "^4.2.23",
-        "@inquirer/expand": "^4.0.23",
-        "@inquirer/input": "^4.3.1",
-        "@inquirer/number": "^3.0.23",
-        "@inquirer/password": "^4.0.23",
-        "@inquirer/rawlist": "^4.1.11",
-        "@inquirer/search": "^3.2.2",
-        "@inquirer/select": "^4.4.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@inquirer/rawlist": {
-      "version": "4.1.11",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@inquirer/search": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@inquirer/select": {
-      "version": "4.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@inquirer/type": {
-      "version": "3.0.10",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@jest/diff-sequences": {
-      "version": "30.4.0",
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@jest/expect-utils": {
-      "version": "30.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@jest/get-type": {
-      "version": "30.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@jest/pattern": {
-      "version": "30.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-regex-util": "30.4.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@jest/types": {
-      "version": "30.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.4.0",
-        "@jest/schemas": "30.4.1",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@promptbook/utils": {
-      "version": "0.69.5",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://buymeacoffee.com/hejny"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/webgptorg/promptbook/blob/main/README.md#%EF%B8%8F-contributing"
-        }
-      ],
-      "license": "CC-BY-4.0",
-      "dependencies": {
-        "spacetrim": "0.11.59"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@puppeteer/browsers": {
-      "version": "2.13.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "extract-zip": "^2.0.1",
-        "progress": "^2.0.3",
-        "proxy-agent": "^6.5.0",
-        "semver": "^7.7.4",
-        "tar-fs": "^3.1.1",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.8.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@sec-ant/readable-stream": {
-      "version": "0.4.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@sindresorhus/merge-streams": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@teppeis/multimaps": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@types/istanbul-lib-coverage": {
-      "version": "2.0.6",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@types/istanbul-reports": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@types/node": {
-      "version": "20.19.41",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@types/normalize-package-data": {
-      "version": "2.4.4",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@types/sinonjs__fake-timers": {
-      "version": "8.1.5",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@types/stack-utils": {
-      "version": "2.0.3",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@types/which": {
-      "version": "2.0.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@types/ws": {
-      "version": "8.18.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@types/yargs": {
-      "version": "17.0.35",
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@types/yargs-parser": {
-      "version": "21.0.3",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@vitest/pretty-format": {
-      "version": "2.1.9",
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@vitest/snapshot": {
-      "version": "2.1.9",
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@vitest/utils": {
-      "version": "4.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@vitest/utils/node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/snapshot": "^2.1.1",
-        "@wdio/config": "9.27.1",
-        "@wdio/globals": "9.27.1",
-        "@wdio/logger": "9.18.0",
-        "@wdio/protocols": "9.27.1",
-        "@wdio/types": "9.27.1",
-        "@wdio/utils": "9.27.1",
-        "async-exit-hook": "^2.0.1",
-        "chalk": "^5.4.1",
-        "chokidar": "^4.0.0",
-        "create-wdio": "9.27.1",
-        "dotenv": "^17.2.0",
-        "import-meta-resolve": "^4.0.0",
-        "lodash.flattendeep": "^4.4.0",
-        "lodash.pickby": "^4.6.0",
-        "lodash.union": "^4.6.0",
-        "read-pkg-up": "^10.0.0",
-        "tsx": "^4.7.2",
-        "webdriverio": "9.27.1",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "wdio": "bin/wdio.js"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/chalk": {
-      "version": "5.6.2",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/find-up": {
-      "version": "6.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^7.1.0",
-        "path-exists": "^5.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/hosted-git-info": {
-      "version": "7.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^10.0.1"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/json-parse-even-better-errors": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/lines-and-columns": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/locate-path": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^6.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/normalize-package-data": {
-      "version": "6.0.2",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/p-limit": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/p-locate": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/parse-json": {
-      "version": "7.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.21.4",
-        "error-ex": "^1.3.2",
-        "json-parse-even-better-errors": "^3.0.0",
-        "lines-and-columns": "^2.0.3",
-        "type-fest": "^3.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/parse-json/node_modules/type-fest": {
-      "version": "3.13.1",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/path-exists": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/read-pkg": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.1",
-        "normalize-package-data": "^6.0.0",
-        "parse-json": "^7.0.0",
-        "type-fest": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/read-pkg-up": {
-      "version": "10.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^6.3.0",
-        "read-pkg": "^8.1.0",
-        "type-fest": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/semver": {
-      "version": "7.8.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cli/node_modules/yocto-queue": {
-      "version": "1.2.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/config": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.27.1",
-        "@wdio/utils": "9.27.1",
-        "deepmerge-ts": "^7.0.3",
-        "glob": "^10.2.2",
-        "import-meta-resolve": "^4.0.0",
-        "jiti": "^2.6.1"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/cucumber-framework": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@cucumber/cucumber": "^10.3.1",
-        "@cucumber/gherkin": "29.0.0",
-        "@cucumber/messages": "26.0.1",
-        "@types/node": "^20.1.0",
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.27.1",
-        "@wdio/utils": "9.27.1",
-        "glob": "^10.2.2",
-        "import-meta-resolve": "^4.1.0",
-        "is-glob": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/dot-reporter": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/reporter": "9.27.1",
-        "@wdio/types": "9.27.1",
-        "chalk": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/dot-reporter/node_modules/chalk": {
-      "version": "5.6.2",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/globals": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20.0"
-      },
-      "peerDependencies": {
-        "expect-webdriverio": "^5.6.5",
-        "webdriverio": "^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "expect-webdriverio": {
-          "optional": false
-        },
-        "webdriverio": {
-          "optional": false
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/local-runner": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0",
-        "@wdio/logger": "9.18.0",
-        "@wdio/repl": "9.16.2",
-        "@wdio/runner": "9.27.1",
-        "@wdio/types": "9.27.1",
-        "@wdio/xvfb": "9.27.1",
-        "exit-hook": "^4.0.0",
-        "expect-webdriverio": "^5.6.5",
-        "split2": "^4.1.0",
-        "stream-buffers": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/local-runner/node_modules/@wdio/repl": {
-      "version": "9.16.2",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/logger": {
-      "version": "9.18.0",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.1.2",
-        "loglevel": "^1.6.0",
-        "loglevel-plugin-prefix": "^0.8.4",
-        "safe-regex2": "^5.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/logger/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/logger/node_modules/chalk": {
-      "version": "5.6.2",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/logger/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/protocols": {
-      "version": "9.27.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/reporter": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0",
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.27.1",
-        "diff": "^8.0.2",
-        "object-inspect": "^1.12.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/runner": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.11.28",
-        "@wdio/config": "9.27.1",
-        "@wdio/dot-reporter": "9.27.1",
-        "@wdio/globals": "9.27.1",
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.27.1",
-        "@wdio/utils": "9.27.1",
-        "deepmerge-ts": "^7.0.3",
-        "webdriver": "9.27.1",
-        "webdriverio": "9.27.1"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      },
-      "peerDependencies": {
-        "expect-webdriverio": "^5.6.5",
-        "webdriverio": "^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "expect-webdriverio": {
-          "optional": false
-        },
-        "webdriverio": {
-          "optional": false
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/runner/node_modules/undici": {
-      "version": "6.25.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/runner/node_modules/webdriver": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0",
-        "@types/ws": "^8.5.3",
-        "@wdio/config": "9.27.1",
-        "@wdio/logger": "9.18.0",
-        "@wdio/protocols": "9.27.1",
-        "@wdio/types": "9.27.1",
-        "@wdio/utils": "9.27.1",
-        "deepmerge-ts": "^7.0.3",
-        "https-proxy-agent": "^7.0.6",
-        "undici": "^6.21.3",
-        "ws": "^8.8.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/spec-reporter": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/reporter": "9.27.1",
-        "@wdio/types": "9.27.1",
-        "chalk": "^5.1.2",
-        "easy-table": "^1.2.0",
-        "pretty-ms": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/spec-reporter/node_modules/chalk": {
-      "version": "5.6.2",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/types": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/utils": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@puppeteer/browsers": "^2.2.0",
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.27.1",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^7.0.3",
-        "edgedriver": "^6.1.2",
-        "geckodriver": "^6.1.0",
-        "get-port": "^7.0.0",
-        "import-meta-resolve": "^4.0.0",
-        "locate-app": "^2.2.24",
-        "mitt": "^3.0.1",
-        "safaridriver": "^1.0.0",
-        "split2": "^4.2.0",
-        "wait-port": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@wdio/xvfb": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/logger": "9.18.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/@zip.js/zip.js": {
-      "version": "2.8.26",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "bun": ">=0.7.0",
-        "deno": ">=1.0.0",
-        "node": ">=18.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/abort-controller": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/agent-base": {
-      "version": "7.1.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/any-promise": {
-      "version": "1.3.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/anymatch": {
-      "version": "3.1.3",
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/archiver": {
-      "version": "7.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^5.0.2",
-        "async": "^3.2.4",
-        "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/archiver-utils": {
-      "version": "5.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^10.0.0",
-        "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
-        "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/archiver/node_modules/async": {
-      "version": "3.2.6",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/argparse": {
-      "version": "2.0.1",
-      "license": "Python-2.0"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/aria-query": {
-      "version": "5.3.2",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/array-back": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/assertion-error": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/assertion-error-formatter": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "diff": "^4.0.1",
-        "pad-right": "^0.2.2",
-        "repeat-string": "^1.6.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/assertion-error-formatter/node_modules/diff": {
-      "version": "4.0.4",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/ast-types": {
-      "version": "0.13.4",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/async": {
-      "version": "0.2.10"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/async-exit-hook": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/asynckit": {
-      "version": "0.4.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/at-least-node": {
-      "version": "1.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/b4a": {
-      "version": "1.8.1",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-code-frame": {
-      "version": "6.26.0",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-code-frame/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-code-frame/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-code-frame/node_modules/chalk": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-code-frame/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-code-frame/node_modules/has-ansi": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-code-frame/node_modules/js-tokens": {
-      "version": "3.0.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-code-frame/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-code-frame/node_modules/supports-color": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-core": {
-      "version": "6.26.3",
-      "license": "MIT",
-      "dependencies": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.1",
-        "debug": "^2.6.9",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.8",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.7"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-core/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-core/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-core/node_modules/debug": {
-      "version": "2.6.9",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-core/node_modules/json5": {
-      "version": "0.5.1",
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-core/node_modules/minimatch": {
-      "version": "3.1.5",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-core/node_modules/ms": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-generator": {
-      "version": "6.26.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-generator/node_modules/jsesc": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-helper-call-delegate": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-helper-define-map": {
-      "version": "6.26.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-helper-explode-assignable-expression": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-helper-function-name": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-helper-get-function-arity": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-helper-hoist-variables": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-helper-optimise-call-expression": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-helper-regex": {
-      "version": "6.26.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-helper-remap-async-to-generator": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-helper-replace-supers": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-helpers": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-messages": {
-      "version": "6.23.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-check-es2015-constants": {
-      "version": "6.22.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.17",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.8",
-        "semver": "^6.3.1"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.14.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.8",
-        "core-js-compat": "^3.48.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.8",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.8"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-syntax-async-functions": {
-      "version": "6.13.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-syntax-exponentiation-operator": {
-      "version": "6.13.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.22.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-async-to-generator": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.22.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.22.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.26.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-classes": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-define-map": "^6.24.1",
-        "babel-helper-function-name": "^6.24.1",
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-destructuring": {
-      "version": "6.23.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-for-of": {
-      "version": "6.23.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-function-name": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-literals": {
-      "version": "6.22.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-modules-amd": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.2",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-modules-systemjs": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-modules-umd": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-object-super": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-parameters": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-spread": {
-      "version": "6.22.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-template-literals": {
-      "version": "6.22.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.23.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-unicode-regex/node_modules/jsesc": {
-      "version": "0.5.0",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-unicode-regex/node_modules/regexpu-core": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-unicode-regex/node_modules/regjsgen": {
-      "version": "0.2.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-es2015-unicode-regex/node_modules/regjsparser": {
-      "version": "0.1.5",
-      "license": "BSD",
-      "dependencies": {
-        "jsesc": "~0.5.0"
-      },
-      "bin": {
-        "regjsparser": "bin/parser"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-exponentiation-operator": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-regenerator": {
-      "version": "6.26.0",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-transform": "^0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-rename-import": {
-      "version": "2.3.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-preset-env": {
-      "version": "1.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-to-generator": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-        "babel-plugin-transform-es2015-classes": "^6.23.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-        "babel-plugin-transform-es2015-for-of": "^6.23.0",
-        "babel-plugin-transform-es2015-function-name": "^6.22.0",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-        "babel-plugin-transform-es2015-object-super": "^6.22.0",
-        "babel-plugin-transform-es2015-parameters": "^6.23.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-        "babel-plugin-transform-regenerator": "^6.22.0",
-        "browserslist": "^3.2.6",
-        "invariant": "^2.2.2",
-        "semver": "^5.3.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-preset-env/node_modules/browserslist": {
-      "version": "3.2.8",
-      "license": "MIT",
-      "dependencies": {
-        "caniuse-lite": "^1.0.30000844",
-        "electron-to-chromium": "^1.3.47"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-preset-env/node_modules/semver": {
-      "version": "5.7.2",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-register": {
-      "version": "6.26.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-register/node_modules/source-map-support": {
-      "version": "0.4.18",
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "^0.5.6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-runtime": {
-      "version": "6.26.0",
-      "license": "MIT",
-      "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-template": {
-      "version": "6.26.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-traverse": {
-      "version": "6.26.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-traverse/node_modules/debug": {
-      "version": "2.6.9",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-traverse/node_modules/ms": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babel-types": {
-      "version": "6.26.0",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/babylon": {
-      "version": "6.18.0",
-      "license": "MIT",
-      "bin": {
-        "babylon": "bin/babylon.js"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/bare-events": {
-      "version": "2.8.3",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "bare-abort-controller": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/bare-fs": {
-      "version": "4.7.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.5.4",
-        "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4",
-        "bare-url": "^2.2.2",
-        "fast-fifo": "^1.3.2"
-      },
-      "engines": {
-        "bare": ">=1.16.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/bare-os": {
-      "version": "3.9.1",
-      "license": "Apache-2.0",
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/bare-path": {
-      "version": "3.0.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/bare-stream": {
-      "version": "2.13.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "streamx": "^2.25.0",
-        "teex": "^1.0.1"
-      },
-      "peerDependencies": {
-        "bare-abort-controller": "*",
-        "bare-buffer": "*",
-        "bare-events": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        },
-        "bare-buffer": {
-          "optional": true
-        },
-        "bare-events": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/bare-url": {
-      "version": "2.4.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-path": "^3.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/base64-js": {
-      "version": "1.5.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/baseline-browser-mapping": {
-      "version": "2.10.30",
-      "license": "Apache-2.0",
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/basic-ftp": {
-      "version": "5.3.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/bluebird": {
-      "version": "3.7.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/boolbase": {
-      "version": "1.0.0",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/braces": {
-      "version": "3.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/browser-stdout": {
-      "version": "1.3.1",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/browserslist": {
-      "version": "4.28.2",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/buffer-crc32": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/buffer-from": {
-      "version": "1.1.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/camelcase": {
-      "version": "6.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/capital-case": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/chai": {
-      "version": "4.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/chalk": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/chardet": {
-      "version": "2.1.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/charenc": {
-      "version": "0.0.2",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/check-engine": {
-      "version": "1.14.0",
-      "license": "MIT",
-      "dependencies": {
-        "bluebird": "3.7.2",
-        "colors": "1.4.0",
-        "command-line-usage": "6.1.3",
-        "jsonfile": "6.1.0",
-        "semver": "7.5.4",
-        "yargs": "17.7.1"
-      },
-      "bin": {
-        "check-engine": "bin/check-engine.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/check-engine/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/check-engine/node_modules/semver": {
-      "version": "7.5.4",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/check-engine/node_modules/yallist": {
-      "version": "4.0.0",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/check-engine/node_modules/yargs": {
-      "version": "17.7.1",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/check-engine/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/check-error": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cheerio": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "cheerio-select": "^2.1.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.1.0",
-        "parse5": "^7.3.0",
-        "parse5-htmlparser2-tree-adapter": "^7.1.0",
-        "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.19.0",
-        "whatwg-mimetype": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=20.18.1"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cheerio-select": {
-      "version": "2.1.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-select": "^5.1.0",
-        "css-what": "^6.1.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/chokidar": {
-      "version": "4.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/chrome-launcher": {
-      "version": "0.14.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "*",
-        "escape-string-regexp": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "lighthouse-logger": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/ci-info": {
-      "version": "4.4.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/class-transformer": {
-      "version": "0.5.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cli-table3": {
-      "version": "0.6.3",
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      },
-      "optionalDependencies": {
-        "@colors/colors": "1.5.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cli-width": {
-      "version": "4.1.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cliui": {
-      "version": "8.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/clone": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/clone-deep": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.2",
-        "shallow-clone": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/code-point-at": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/color-convert": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/color-name": {
-      "version": "1.1.4",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/colors": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/combined-stream": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/command-line-usage": {
-      "version": "6.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.2",
-        "chalk": "^2.4.2",
-        "table-layout": "^1.0.2",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/command-line-usage/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/command-line-usage/node_modules/chalk": {
-      "version": "2.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/command-line-usage/node_modules/color-convert": {
-      "version": "1.9.3",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/command-line-usage/node_modules/color-name": {
-      "version": "1.1.3",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/command-line-usage/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/command-line-usage/node_modules/has-flag": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/command-line-usage/node_modules/supports-color": {
-      "version": "5.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/commander": {
-      "version": "10.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/commondir": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/compress-commons": {
-      "version": "6.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/concat-map": {
-      "version": "0.0.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/core-js": {
-      "version": "2.6.12",
-      "hasInstallScript": true,
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/core-js-compat": {
-      "version": "3.49.0",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.28.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/core-util-is": {
-      "version": "1.0.3",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/crc-32": {
-      "version": "1.2.2",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/crc32-stream": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "commander": "^14.0.0",
-        "cross-spawn": "^7.0.3",
-        "ejs": "^3.1.10",
-        "execa": "^9.6.0",
-        "import-meta-resolve": "^4.1.0",
-        "inquirer": "^12.7.0",
-        "normalize-package-data": "^7.0.0",
-        "read-pkg-up": "^10.1.0",
-        "recursive-readdir": "^2.2.3",
-        "semver": "^7.6.3",
-        "type-fest": "^4.41.0",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "create-wdio": "bin/wdio.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/chalk": {
-      "version": "5.6.2",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/commander": {
-      "version": "14.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/find-up": {
-      "version": "6.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^7.1.0",
-        "path-exists": "^5.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/hosted-git-info": {
-      "version": "7.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^10.0.1"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/json-parse-even-better-errors": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/lines-and-columns": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/locate-path": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^6.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/p-limit": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/p-locate": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/parse-json": {
-      "version": "7.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.21.4",
-        "error-ex": "^1.3.2",
-        "json-parse-even-better-errors": "^3.0.0",
-        "lines-and-columns": "^2.0.3",
-        "type-fest": "^3.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/parse-json/node_modules/type-fest": {
-      "version": "3.13.1",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/path-exists": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/read-pkg": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.1",
-        "normalize-package-data": "^6.0.0",
-        "parse-json": "^7.0.0",
-        "type-fest": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/read-pkg-up": {
-      "version": "10.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^6.3.0",
-        "read-pkg": "^8.1.0",
-        "type-fest": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "6.0.2",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/semver": {
-      "version": "7.8.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/create-wdio/node_modules/yocto-queue": {
-      "version": "1.2.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/crypt": {
-      "version": "0.0.2",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/css-select": {
-      "version": "5.2.2",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/css-shorthand-properties": {
-      "version": "1.1.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/css-value": {
-      "version": "0.0.1"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/css-what": {
-      "version": "6.2.2",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit": {
-      "version": "1.7.1",
-      "license": "MIT",
-      "dependencies": {
-        "xml": "0.0.12",
-        "yargs": "^5.0.0"
-      },
-      "bin": {
-        "cucumber-junit": "bin/cucumber-junit"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/camelcase": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/cliui": {
-      "version": "3.2.0",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/decamelize": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/find-up": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/get-caller-file": {
-      "version": "1.0.3",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/path-exists": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/read-pkg": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/read-pkg-up": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/semver": {
-      "version": "5.7.2",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/string-width": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/wrap-ansi": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/y18n": {
-      "version": "3.2.2",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/yargs": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "lodash.assign": "^4.2.0",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^1.0.2",
-        "which-module": "^1.0.0",
-        "window-size": "^0.2.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^3.2.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/cucumber-junit/node_modules/yargs-parser": {
-      "version": "3.2.0",
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^3.0.0",
-        "lodash.assign": "^4.1.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/debug": {
-      "version": "4.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/decamelize": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/deep-eql": {
-      "version": "4.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/deep-extend": {
-      "version": "0.6.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/defaults": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/degenerator": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/detect-indent": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "repeating": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/diff": {
-      "version": "8.0.4",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/domelementtype": {
-      "version": "2.3.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/domhandler": {
-      "version": "5.0.3",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/domutils": {
-      "version": "3.2.2",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/dotenv": {
-      "version": "17.4.2",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/easy-table": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "optionalDependencies": {
-        "wcwidth": "^1.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/edge-paths": {
-      "version": "3.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "@types/which": "^2.0.1",
-        "which": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/shirshak55"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/edgedriver": {
-      "version": "6.3.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/logger": "^9.18.0",
-        "@zip.js/zip.js": "^2.8.11",
-        "decamelize": "^6.0.1",
-        "edge-paths": "^3.0.5",
-        "fast-xml-parser": "^5.3.3",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "which": "^6.0.0"
-      },
-      "bin": {
-        "edgedriver": "bin/edgedriver.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/edgedriver/node_modules/isexe": {
-      "version": "4.0.0",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/edgedriver/node_modules/which": {
-      "version": "6.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^4.0.0"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/ejs": {
-      "version": "3.1.10",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/electron-to-chromium": {
-      "version": "1.5.357",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/encoding-sniffer": {
-      "version": "0.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "whatwg-encoding": "^3.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/encoding-sniffer/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/entities": {
-      "version": "4.5.0",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/error-ex": {
-      "version": "1.3.4",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/error-stack-parser": {
-      "version": "2.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "stackframe": "^1.3.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/es-define-property": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/es-errors": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/es6-promise": {
-      "version": "4.2.8",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/esbuild": {
-      "version": "0.28.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/escalade": {
-      "version": "3.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/escape-regexp": {
-      "version": "0.0.1"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/escodegen": {
-      "version": "2.1.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/escodegen/node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/esprima": {
-      "version": "4.0.1",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/estraverse": {
-      "version": "5.3.0",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/esutils": {
-      "version": "2.0.3",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/events": {
-      "version": "3.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/events-universal": {
-      "version": "1.0.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.7.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/execa": {
-      "version": "9.6.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/execa/node_modules/figures": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/execa/node_modules/is-stream": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/execa/node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/exit-hook": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/expect": {
-      "version": "30.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/expect-utils": "30.4.1",
-        "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/expect-webdriverio": {
-      "version": "5.6.5",
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/snapshot": "^4.0.16",
-        "deep-eql": "^5.0.2",
-        "expect": "^30.2.0",
-        "jest-matcher-utils": "^30.2.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@wdio/globals": "^9.0.0",
-        "@wdio/logger": "^9.0.0",
-        "webdriverio": "^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@wdio/globals": {
-          "optional": false
-        },
-        "@wdio/logger": {
-          "optional": false
-        },
-        "webdriverio": {
-          "optional": false
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/expect-webdriverio/node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/expect-webdriverio/node_modules/@vitest/snapshot": {
-      "version": "4.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/utils": "4.1.6",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/expect-webdriverio/node_modules/deep-eql": {
-      "version": "5.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/expect-webdriverio/node_modules/pathe": {
-      "version": "2.0.3",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/expect-webdriverio/node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/extend": {
-      "version": "3.0.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/extract-zip": {
-      "version": "2.0.1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/extract-zip/node_modules/get-stream": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/fast-xml-parser": {
-      "version": "5.8.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.2.0",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.3.0",
-        "xml-naming": "^0.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/figures": {
-      "version": "3.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/filelist": {
-      "version": "1.0.6",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.9",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/fill-range": {
-      "version": "7.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/find": {
-      "version": "0.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "traverse-chain": "~0.1.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/find-cache-dir": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/find-up": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/flat": {
-      "version": "5.0.2",
-      "license": "BSD-3-Clause",
-      "bin": {
-        "flat": "cli.js"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/foreground-child": {
-      "version": "3.3.1",
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/form-data": {
-      "version": "4.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/fs-finder": {
-      "version": "1.8.1",
-      "license": "MIT",
-      "dependencies": {
-        "async": "~0.2.9",
-        "escape-regexp": "~0.0.1",
-        "moment": "~2.5.0",
-        "operator-compare": "~1.0.1",
-        "q": "~1.0.0"
-      },
-      "engines": {
-        "node": ">=0.9"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/fs-finder/node_modules/moment": {
-      "version": "2.5.1",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/function-bind": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/geckodriver": {
-      "version": "6.1.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/logger": "^9.18.0",
-        "@zip.js/zip.js": "^2.8.11",
-        "decamelize": "^6.0.1",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "modern-tar": "^0.7.2"
-      },
-      "bin": {
-        "geckodriver": "bin/geckodriver.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/get-func-name": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/get-port": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/get-proto": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/get-stream": {
-      "version": "9.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/get-stream/node_modules/is-stream": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/get-uri": {
-      "version": "6.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/glob": {
-      "version": "10.5.0",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/global-dirs": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ini": "2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/globals": {
-      "version": "9.18.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/gopd": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/grapheme-splitter": {
-      "version": "1.0.4",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/has-ansi": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/has-ansi/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/has-flag": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/has-symbols": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/hasown": {
-      "version": "2.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/he": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/home-or-tmp": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/hosted-git-info": {
-      "version": "8.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^10.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/hosted-git-info/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/htmlparser2": {
-      "version": "10.1.0",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "entities": "^7.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/htmlparser2/node_modules/entities": {
-      "version": "7.0.1",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/human-signals": {
-      "version": "8.0.1",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/ieee754": {
-      "version": "1.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/immediate": {
-      "version": "3.0.6",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/indent-string": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/inflight": {
-      "version": "1.0.6",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/inherits": {
-      "version": "2.0.4",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/ini": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/inquirer": {
-      "version": "12.11.1",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/prompts": "^7.10.1",
-        "@inquirer/type": "^3.0.10",
-        "mute-stream": "^2.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/invariant": {
-      "version": "2.2.4",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/invert-kv": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/ip-address": {
-      "version": "10.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-buffer": {
-      "version": "1.1.6",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-core-module": {
-      "version": "2.16.2",
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-docker": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-extglob": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-finite": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-glob": {
-      "version": "4.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-installed-globally": {
-      "version": "0.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "global-dirs": "^3.0.0",
-        "is-path-inside": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-number": {
-      "version": "7.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-stream": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-utf8": {
-      "version": "0.2.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/is-wsl": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/isarray": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/isexe": {
-      "version": "2.0.0",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/isobject": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jake": {
-      "version": "10.9.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.6",
-        "filelist": "^1.0.4",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jake/node_modules/async": {
-      "version": "3.2.6",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jest-diff": {
-      "version": "30.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/diff-sequences": "30.4.0",
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jest-matcher-utils": {
-      "version": "30.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "jest-diff": "30.4.1",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jest-message-util": {
-      "version": "30.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.4.1",
-        "@types/stack-utils": "^2.0.3",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "jest-util": "30.4.1",
-        "picomatch": "^4.0.3",
-        "pretty-format": "30.4.1",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jest-message-util/node_modules/slash": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jest-mock": {
-      "version": "30.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jest-regex-util": {
-      "version": "30.4.0",
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jest-util": {
-      "version": "30.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jiti": {
-      "version": "2.7.0",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jsesc": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/json5": {
-      "version": "2.2.3",
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jszip": {
-      "version": "3.10.1",
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "dependencies": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jszip/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jszip/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/jszip/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/kind-of": {
-      "version": "6.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/knuth-shuffle-seeded": {
-      "version": "1.0.6",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "seed-random": "~2.2.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lazystream": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.6.3"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lazystream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lazystream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lazystream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lcid": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "invert-kv": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lie": {
-      "version": "3.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "immediate": "~3.0.5"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lighthouse-logger": {
-      "version": "1.4.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^2.6.9",
-        "marky": "^1.2.2"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lighthouse-logger/node_modules/debug": {
-      "version": "2.6.9",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lighthouse-logger/node_modules/ms": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/load-json-file": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/load-json-file/node_modules/parse-json": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "error-ex": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/load-json-file/node_modules/pify": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/locate-app": {
-      "version": "2.5.0",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://buymeacoffee.com/hejny"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/hejny/locate-app/blob/main/README.md#%EF%B8%8F-contributing"
-        }
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@promptbook/utils": "0.69.5",
-        "type-fest": "4.26.0",
-        "userhome": "1.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/locate-app/node_modules/type-fest": {
-      "version": "4.26.0",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/locate-path": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lodash": {
-      "version": "4.18.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lodash.assign": {
-      "version": "4.2.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lodash.debounce": {
-      "version": "4.0.8",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lodash.flattendeep": {
-      "version": "4.4.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lodash.mergewith": {
-      "version": "4.6.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lodash.pickby": {
-      "version": "4.6.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lodash.union": {
-      "version": "4.6.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lodash.zip": {
-      "version": "4.2.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/log-symbols": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/loglevel": {
-      "version": "1.9.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/loglevel"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/loglevel-plugin-prefix": {
-      "version": "0.8.4",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/loose-envify": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/loupe": {
-      "version": "2.3.7",
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lower-case": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/luxon": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/magic-string": {
-      "version": "0.30.21",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/make-dir": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/make-dir/node_modules/semver": {
-      "version": "5.7.2",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/marky": {
-      "version": "1.3.0",
-      "license": "Apache-2.0"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/md5": {
-      "version": "2.3.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mime": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mime-db": {
-      "version": "1.52.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mime-types": {
-      "version": "2.1.35",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/minimatch": {
-      "version": "9.0.9",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/minimist": {
-      "version": "1.2.8",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/minipass": {
-      "version": "7.1.3",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mitt": {
-      "version": "3.0.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mocha": {
-      "version": "10.8.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-colors": "^4.1.3",
-        "browser-stdout": "^1.3.1",
-        "chokidar": "^3.5.3",
-        "debug": "^4.3.5",
-        "diff": "^5.2.0",
-        "escape-string-regexp": "^4.0.0",
-        "find-up": "^5.0.0",
-        "glob": "^8.1.0",
-        "he": "^1.2.0",
-        "js-yaml": "^4.1.0",
-        "log-symbols": "^4.1.0",
-        "minimatch": "^5.1.6",
-        "ms": "^2.1.3",
-        "serialize-javascript": "^6.0.2",
-        "strip-json-comments": "^3.1.1",
-        "supports-color": "^8.1.1",
-        "workerpool": "^6.5.1",
-        "yargs": "^16.2.0",
-        "yargs-parser": "^20.2.9",
-        "yargs-unparser": "^2.0.0"
-      },
-      "bin": {
-        "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha.js"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mocha/node_modules/chokidar": {
-      "version": "3.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mocha/node_modules/cliui": {
-      "version": "7.0.4",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mocha/node_modules/diff": {
-      "version": "5.2.2",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mocha/node_modules/glob": {
-      "version": "8.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mocha/node_modules/minimatch": {
-      "version": "5.1.9",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mocha/node_modules/picomatch": {
-      "version": "2.3.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mocha/node_modules/readdirp": {
-      "version": "3.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mocha/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mocha/node_modules/yargs": {
-      "version": "16.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/modern-tar": {
-      "version": "0.7.6",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/moment": {
-      "version": "2.30.1",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/ms": {
-      "version": "2.1.3",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/multiple-cucumber-html-reporter": {
-      "version": "1.21.6",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^3.0.0",
-        "find": "^0.3.0",
-        "fs-extra": "^8.1.0",
-        "jsonfile": "^5.0.0",
-        "lodash": "^4.17.19",
-        "moment": "^2.24.0",
-        "open": "^7.0.2",
-        "uuid": "^3.4.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/multiple-cucumber-html-reporter/node_modules/chalk": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/multiple-cucumber-html-reporter/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/multiple-cucumber-html-reporter/node_modules/fs-extra/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/multiple-cucumber-html-reporter/node_modules/jsonfile": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^0.1.2"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/multiple-cucumber-html-reporter/node_modules/supports-color": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/multiple-cucumber-html-reporter/node_modules/universalify": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/multiple-cucumber-html-reporter/node_modules/uuid": {
-      "version": "3.4.0",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mute-stream": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/mz": {
-      "version": "2.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/netmask": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/no-case": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/node-releases": {
-      "version": "2.0.44",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/normalize-package-data": {
-      "version": "7.0.1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^8.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.8.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/normalize-path": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/nth-check": {
-      "version": "2.1.1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/nuxeo": {
-      "version": "4.0.6",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "buffer": "^6.0.0",
-        "es6-promise": "^4.0.0",
-        "extend": "^3.0.0",
-        "form-data": "^4.0.0",
-        "md5": "^2.0.0",
-        "mocha": "^10.0.0",
-        "node-fetch": "^2.0.0",
-        "promise-queue": "^2.0.0",
-        "querystring": "^0.2.0",
-        "random-js": "^1.0.0",
-        "whatwg-fetch": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/object-assign": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/object-inspect": {
-      "version": "1.13.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/once": {
-      "version": "1.4.0",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/open": {
-      "version": "7.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/operator-compare": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/os-homedir": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/os-locale": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "lcid": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/p-limit": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/p-locate": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/p-try": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pac-proxy-agent": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "get-uri": "^6.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.6",
-        "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pac-resolver": {
-      "version": "7.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "degenerator": "^5.0.0",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "license": "BlueOak-1.0.0"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pad-right": {
-      "version": "0.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "repeat-string": "^1.5.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pako": {
-      "version": "1.0.11",
-      "license": "(MIT AND Zlib)"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/parse-json": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/parse-ms": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/parse5": {
-      "version": "7.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "^5.0.3",
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/parse5-parser-stream": {
-      "version": "7.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/parse5/node_modules/entities": {
-      "version": "6.0.1",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/path-exists": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/path-key": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/path-parse": {
-      "version": "1.0.7",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/path-type": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/path-type/node_modules/pify": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pathe": {
-      "version": "1.1.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pathval": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pend": {
-      "version": "1.2.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/picocolors": {
-      "version": "1.1.1",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/picomatch": {
-      "version": "4.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pify": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pinkie": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pinkie-promise": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "pinkie": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pirates": {
-      "version": "4.0.7",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pkg-dir": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pkg-dir/node_modules/find-up": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pkg-dir/node_modules/locate-path": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pkg-dir/node_modules/p-limit": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pkg-dir/node_modules/p-locate": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pkg-dir/node_modules/path-exists": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pretty-ms": {
-      "version": "9.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "parse-ms": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/private": {
-      "version": "0.1.8",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/process": {
-      "version": "0.11.10",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/progress": {
-      "version": "2.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/promise-queue": {
-      "version": "2.2.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/property-expr": {
-      "version": "2.0.6",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/proxy-agent": {
-      "version": "6.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.1.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/pump": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/q": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/query-selector-shadow-dom": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/querystring": {
-      "version": "0.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/random-js": {
-      "version": "1.0.8",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/react-is-18": {
-      "name": "react-is",
-      "version": "18.3.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/react-is-19": {
-      "name": "react-is",
-      "version": "19.2.6",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/read-pkg": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/read-pkg-up/node_modules/locate-path": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/read-pkg-up/node_modules/p-limit": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/read-pkg-up/node_modules/p-locate": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.2",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/readdir-glob": {
-      "version": "1.1.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.9",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/readdirp": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/recursive-readdir": {
-      "version": "2.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "minimatch": "^3.0.5"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/recursive-readdir/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/recursive-readdir/node_modules/minimatch": {
-      "version": "3.1.5",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/reduce-flatten": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/reflect-metadata": {
-      "version": "0.2.2",
-      "license": "Apache-2.0"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/regenerate": {
-      "version": "1.4.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/regenerate-unicode-properties": {
-      "version": "10.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "regenerate": "^1.4.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/regenerator-runtime": {
-      "version": "0.11.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/regenerator-transform": {
-      "version": "0.10.1",
-      "license": "BSD",
-      "dependencies": {
-        "babel-runtime": "^6.18.0",
-        "babel-types": "^6.19.0",
-        "private": "^0.1.6"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/regexp-match-indices": {
-      "version": "1.0.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "regexp-tree": "^0.1.11"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/regexp-tree": {
-      "version": "0.1.27",
-      "license": "MIT",
-      "bin": {
-        "regexp-tree": "bin/regexp-tree"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/regexpu-core": {
-      "version": "6.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "regenerate": "^1.4.2",
-        "regenerate-unicode-properties": "^10.2.2",
-        "regjsgen": "^0.8.0",
-        "regjsparser": "^0.13.0",
-        "unicode-match-property-ecmascript": "^2.0.0",
-        "unicode-match-property-value-ecmascript": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/regjsgen": {
-      "version": "0.8.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/regjsparser": {
-      "version": "0.13.1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "jsesc": "~3.1.0"
-      },
-      "bin": {
-        "regjsparser": "bin/parser"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/repeat-string": {
-      "version": "1.6.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/repeating": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-finite": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/require-directory": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/require-main-filename": {
-      "version": "1.0.1",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/resolve": {
-      "version": "1.22.12",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/resolve-pkg": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/resq": {
-      "version": "1.11.0",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^2.0.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/ret": {
-      "version": "0.5.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/rgb2hex": {
-      "version": "0.2.5",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/run-async": {
-      "version": "4.0.6",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/rxjs": {
-      "version": "7.8.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/safaridriver": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/safe-regex2": {
-      "version": "5.1.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "ret": "~0.5.0"
-      },
-      "bin": {
-        "safe-regex2": "bin/safe-regex2.js"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/seed-random": {
-      "version": "2.2.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/semver": {
-      "version": "6.3.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/serialize-error": {
-      "version": "12.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^4.31.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/serialize-javascript": {
-      "version": "7.0.5",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/set-blocking": {
-      "version": "2.0.0",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/setimmediate": {
-      "version": "1.0.5",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/shallow-clone": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/slash": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/socks": {
-      "version": "2.8.9",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.1.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/source-map": {
-      "version": "0.5.7",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/source-map-support": {
-      "version": "0.5.21",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/spacetrim": {
-      "version": "0.11.59",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://buymeacoffee.com/hejny"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/hejny/spacetrim/blob/main/README.md#%EF%B8%8F-contributing"
-        }
-      ],
-      "license": "Apache-2.0"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/spdx-exceptions": {
-      "version": "2.5.0",
-      "license": "CC-BY-3.0"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/spdx-license-ids": {
-      "version": "3.0.23",
-      "license": "CC0-1.0"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/split2": {
-      "version": "4.2.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/stack-utils": {
-      "version": "2.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/stack-utils/node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/stackframe": {
-      "version": "1.3.4",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/stream-buffers": {
-      "version": "3.0.3",
-      "license": "Unlicense",
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/streamx": {
-      "version": "2.25.0",
-      "license": "MIT",
-      "dependencies": {
-        "events-universal": "^1.0.0",
-        "fast-fifo": "^1.3.2",
-        "text-decoder": "^1.1.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/string-argv": {
-      "version": "0.3.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.19"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/string-width": {
-      "version": "4.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/strip-bom": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-utf8": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/strnum": {
-      "version": "2.3.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/supports-color": {
-      "version": "8.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/table-layout": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.1",
-        "deep-extend": "~0.6.0",
-        "typical": "^5.2.0",
-        "wordwrapjs": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/tar-fs": {
-      "version": "3.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^4.0.1",
-        "bare-path": "^3.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/tar-stream": {
-      "version": "3.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "bare-fs": "^4.5.5",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/teex": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "streamx": "^2.12.5"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/text-decoder": {
-      "version": "1.2.7",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.6.4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/thenify": {
-      "version": "3.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/thenify-all": {
-      "version": "1.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/tiny-case": {
-      "version": "1.0.3",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/tinyrainbow": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/tmp": {
-      "version": "0.2.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/to-fast-properties": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/toposort": {
-      "version": "2.0.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/tr46": {
-      "version": "0.0.3",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/traverse-chain": {
-      "version": "0.1.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/trim-right": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/tslib": {
-      "version": "2.8.1",
-      "license": "0BSD"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/tsx": {
-      "version": "4.22.1",
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "~0.28.0"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/type-detect": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/type-fest": {
-      "version": "4.41.0",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/typical": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/undici": {
-      "version": "7.25.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/undici-types": {
-      "version": "6.21.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/unicode-canonical-property-names-ecmascript": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/unicode-match-property-ecmascript": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "unicode-canonical-property-names-ecmascript": "^2.0.0",
-        "unicode-property-aliases-ecmascript": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/unicode-match-property-value-ecmascript": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/unicode-property-aliases-ecmascript": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/unicorn-magic": {
-      "version": "0.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/universalify": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/urlpattern-polyfill": {
-      "version": "10.1.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/userhome": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/util-arity": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/uuid": {
-      "version": "10.0.0",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/wait-port": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "commander": "^9.3.0",
-        "debug": "^4.3.4"
-      },
-      "bin": {
-        "wait-port": "bin/wait-port.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/wait-port/node_modules/commander": {
-      "version": "9.5.0",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/wcwidth": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/wdio-cucumberjs-json-reporter": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "@cucumber/gherkin": "^29.0.0",
-        "@wdio/logger": "^9.0.4",
-        "@wdio/reporter": "^9.0.0",
-        "fs-extra": "^11.1.1",
-        "strip-ansi": "^7.1.0"
-      },
-      "peerDependencies": {
-        "@wdio/cucumber-framework": "^9.0.0",
-        "@wdio/globals": "^9.0.0",
-        "@wdio/types": "^9.0.0",
-        "webdriverio": "^9.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/wdio-cucumberjs-json-reporter/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/wdio-cucumberjs-json-reporter/node_modules/fs-extra": {
-      "version": "11.3.5",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/wdio-cucumberjs-json-reporter/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/webdriverio": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.11.30",
-        "@types/sinonjs__fake-timers": "^8.1.5",
-        "@wdio/config": "9.27.1",
-        "@wdio/logger": "9.18.0",
-        "@wdio/protocols": "9.27.1",
-        "@wdio/repl": "9.16.2",
-        "@wdio/types": "9.27.1",
-        "@wdio/utils": "9.27.1",
-        "archiver": "^7.0.1",
-        "aria-query": "^5.3.0",
-        "cheerio": "^1.0.0-rc.12",
-        "css-shorthand-properties": "^1.1.1",
-        "css-value": "^0.0.1",
-        "grapheme-splitter": "^1.0.4",
-        "htmlfy": "^0.8.1",
-        "is-plain-obj": "^4.1.0",
-        "jszip": "^3.10.1",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.zip": "^4.2.0",
-        "query-selector-shadow-dom": "^1.0.1",
-        "resq": "^1.11.0",
-        "rgb2hex": "0.2.5",
-        "serialize-error": "^12.0.0",
-        "urlpattern-polyfill": "^10.0.0",
-        "webdriver": "9.27.1"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      },
-      "peerDependencies": {
-        "puppeteer-core": ">=22.x || <=24.x"
-      },
-      "peerDependenciesMeta": {
-        "puppeteer-core": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/webdriverio/node_modules/@wdio/repl": {
-      "version": "9.16.2",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/webdriverio/node_modules/htmlfy": {
-      "version": "0.8.1",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/webdriverio/node_modules/undici": {
-      "version": "6.25.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/webdriverio/node_modules/webdriver": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0",
-        "@types/ws": "^8.5.3",
-        "@wdio/config": "9.27.1",
-        "@wdio/logger": "9.18.0",
-        "@wdio/protocols": "9.27.1",
-        "@wdio/types": "9.27.1",
-        "@wdio/utils": "9.27.1",
-        "deepmerge-ts": "^7.0.3",
-        "https-proxy-agent": "^7.0.6",
-        "undici": "^6.21.3",
-        "ws": "^8.8.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "license": "BSD-2-Clause"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/whatwg-encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "license": "MIT"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/which": {
-      "version": "2.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/which-module": {
-      "version": "1.0.0",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/window-size": {
-      "version": "0.2.0",
-      "license": "MIT",
-      "bin": {
-        "window-size": "cli.js"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/wordwrapjs": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "reduce-flatten": "^2.0.0",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/workerpool": {
-      "version": "6.5.1",
-      "license": "Apache-2.0"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/wrappy": {
-      "version": "1.0.2",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/ws": {
-      "version": "8.17.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/xml": {
-      "version": "0.0.12",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/xml-naming": {
-      "version": "0.1.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/xmlbuilder": {
-      "version": "15.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/y18n": {
-      "version": "5.0.8",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/yallist": {
-      "version": "3.1.1",
-      "license": "ISC"
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/yaml": {
-      "version": "2.9.0",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/yargs": {
-      "version": "17.7.2",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/yargs-unparser": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/yargs-unparser/node_modules/decamelize": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/yargs-unparser/node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/yargs/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/yauzl": {
-      "version": "2.10.0",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/yauzl/node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/yoctocolors-cjs": {
-      "version": "2.1.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/yup": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "property-expr": "^2.0.5",
-        "tiny-case": "^1.0.3",
-        "toposort": "^2.0.2",
-        "type-fest": "^2.19.0"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/yup/node_modules/type-fest": {
-      "version": "2.19.0",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "../../packages/nuxeo-web-ui-ftest/node_modules/zip-stream": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.27.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.27.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-member-expression-to-functions": "^7.28.5",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.28.6",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.28.6",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.28.5",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "regexpu-core": "^6.3.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.8",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "debug": "^4.4.3",
-        "lodash.debounce": "^4.0.8",
-        "resolve": "^1.22.11"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.28.5",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-wrap-function": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.28.5",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/traverse": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-wrap-function": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-      "version": "7.28.5",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/plugin-transform-optional-chaining": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.13.0"
-      }
-    },
-    "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/traverse": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-import-assertions": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
-      "version": "7.18.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.29.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-remap-async-to-generator": "^7.27.1",
-        "@babel/traverse": "^7.29.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-remap-async-to-generator": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-class-properties": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.12.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-replace-supers": "^7.28.6",
-        "@babel/traverse": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/template": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.28.5",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-dotall-regex": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-duplicate-keys": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-      "version": "7.29.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-dynamic-import": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-explicit-resource-management": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/plugin-transform-destructuring": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-export-namespace-from": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-function-name": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-compilation-targets": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-json-strings": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-literals": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-member-expression-literals": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-amd": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.29.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-umd": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.29.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-new-target": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-numeric-separator": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/plugin-transform-destructuring": "^7.28.5",
-        "@babel/plugin-transform-parameters": "^7.27.7",
-        "@babel/traverse": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-object-super": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-optional-catch-binding": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.27.7",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-private-methods": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-private-property-in-object": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-property-literals": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.29.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-regexp-modifiers": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-reserved-words": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-shorthand-properties": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-sticky-regex": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-typeof-symbol": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-unicode-escapes": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-unicode-property-regex": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-unicode-regex": {
-      "version": "7.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/preset-env": {
-      "version": "7.29.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
-        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
-        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
-        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-        "@babel/plugin-syntax-import-assertions": "^7.28.6",
-        "@babel/plugin-syntax-import-attributes": "^7.28.6",
-        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-        "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-async-generator-functions": "^7.29.0",
-        "@babel/plugin-transform-async-to-generator": "^7.28.6",
-        "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-        "@babel/plugin-transform-block-scoping": "^7.28.6",
-        "@babel/plugin-transform-class-properties": "^7.28.6",
-        "@babel/plugin-transform-class-static-block": "^7.28.6",
-        "@babel/plugin-transform-classes": "^7.28.6",
-        "@babel/plugin-transform-computed-properties": "^7.28.6",
-        "@babel/plugin-transform-destructuring": "^7.28.5",
-        "@babel/plugin-transform-dotall-regex": "^7.28.6",
-        "@babel/plugin-transform-duplicate-keys": "^7.27.1",
-        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.0",
-        "@babel/plugin-transform-dynamic-import": "^7.27.1",
-        "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
-        "@babel/plugin-transform-exponentiation-operator": "^7.28.6",
-        "@babel/plugin-transform-export-namespace-from": "^7.27.1",
-        "@babel/plugin-transform-for-of": "^7.27.1",
-        "@babel/plugin-transform-function-name": "^7.27.1",
-        "@babel/plugin-transform-json-strings": "^7.28.6",
-        "@babel/plugin-transform-literals": "^7.27.1",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.28.6",
-        "@babel/plugin-transform-member-expression-literals": "^7.27.1",
-        "@babel/plugin-transform-modules-amd": "^7.27.1",
-        "@babel/plugin-transform-modules-commonjs": "^7.28.6",
-        "@babel/plugin-transform-modules-systemjs": "^7.29.0",
-        "@babel/plugin-transform-modules-umd": "^7.27.1",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
-        "@babel/plugin-transform-new-target": "^7.27.1",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
-        "@babel/plugin-transform-numeric-separator": "^7.28.6",
-        "@babel/plugin-transform-object-rest-spread": "^7.28.6",
-        "@babel/plugin-transform-object-super": "^7.27.1",
-        "@babel/plugin-transform-optional-catch-binding": "^7.28.6",
-        "@babel/plugin-transform-optional-chaining": "^7.28.6",
-        "@babel/plugin-transform-parameters": "^7.27.7",
-        "@babel/plugin-transform-private-methods": "^7.28.6",
-        "@babel/plugin-transform-private-property-in-object": "^7.28.6",
-        "@babel/plugin-transform-property-literals": "^7.27.1",
-        "@babel/plugin-transform-regenerator": "^7.29.0",
-        "@babel/plugin-transform-regexp-modifiers": "^7.28.6",
-        "@babel/plugin-transform-reserved-words": "^7.27.1",
-        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-        "@babel/plugin-transform-spread": "^7.28.6",
-        "@babel/plugin-transform-sticky-regex": "^7.27.1",
-        "@babel/plugin-transform-template-literals": "^7.27.1",
-        "@babel/plugin-transform-typeof-symbol": "^7.27.1",
-        "@babel/plugin-transform-unicode-escapes": "^7.27.1",
-        "@babel/plugin-transform-unicode-property-regex": "^7.28.6",
-        "@babel/plugin-transform-unicode-regex": "^7.27.1",
-        "@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
-        "@babel/preset-modules": "0.1.6-no-external-plugins",
-        "babel-plugin-polyfill-corejs2": "^0.4.15",
-        "babel-plugin-polyfill-corejs3": "^0.14.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.6",
-        "core-js-compat": "^3.48.0",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+      "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -10737,7 +1457,9 @@
       }
     },
     "node_modules/@babel/register": {
-      "version": "7.28.6",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.29.3.tgz",
+      "integrity": "sha512-F6C1KpIdoImKQfsD6HSxZ+mS4YY/2Q+JsqrmTC5ApVkTR2rG+nnbpjhWwzA5bDNu8mJjB3AryqDaWFLd4gCbJQ==",
       "license": "MIT",
       "dependencies": {
         "clone-deep": "^4.0.1",
@@ -10755,6 +1477,8 @@
     },
     "node_modules/@babel/template": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -10767,6 +1491,8 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -10783,6 +1509,8 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -10792,8 +1520,74 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
       ],
@@ -10806,8 +1600,346 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@inquirer/ansi": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10815,6 +1947,8 @@
     },
     "node_modules/@inquirer/checkbox": {
       "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -10837,6 +1971,8 @@
     },
     "node_modules/@inquirer/confirm": {
       "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -10856,6 +1992,8 @@
     },
     "node_modules/@inquirer/core": {
       "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -10881,6 +2019,8 @@
     },
     "node_modules/@inquirer/editor": {
       "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -10901,6 +2041,8 @@
     },
     "node_modules/@inquirer/expand": {
       "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -10921,6 +2063,8 @@
     },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
       "license": "MIT",
       "dependencies": {
         "chardet": "^2.1.1",
@@ -10940,6 +2084,8 @@
     },
     "node_modules/@inquirer/figures": {
       "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10947,6 +2093,8 @@
     },
     "node_modules/@inquirer/input": {
       "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -10966,6 +2114,8 @@
     },
     "node_modules/@inquirer/number": {
       "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -10985,6 +2135,8 @@
     },
     "node_modules/@inquirer/password": {
       "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -11005,6 +2157,8 @@
     },
     "node_modules/@inquirer/prompts": {
       "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
@@ -11032,6 +2186,8 @@
     },
     "node_modules/@inquirer/rawlist": {
       "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -11052,6 +2208,8 @@
     },
     "node_modules/@inquirer/search": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -11073,6 +2231,8 @@
     },
     "node_modules/@inquirer/select": {
       "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -11095,6 +2255,8 @@
     },
     "node_modules/@inquirer/type": {
       "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -11110,6 +2272,8 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -11125,6 +2289,8 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
       "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -11133,27 +2299,10 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "license": "MIT"
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -11169,6 +2318,8 @@
     },
     "node_modules/@jest/diff-sequences": {
       "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
       "license": "MIT",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -11176,6 +2327,8 @@
     },
     "node_modules/@jest/expect-utils": {
       "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0"
@@ -11186,6 +2339,8 @@
     },
     "node_modules/@jest/get-type": {
       "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
       "license": "MIT",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -11193,6 +2348,8 @@
     },
     "node_modules/@jest/pattern": {
       "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -11204,6 +2361,8 @@
     },
     "node_modules/@jest/schemas": {
       "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
@@ -11214,6 +2373,8 @@
     },
     "node_modules/@jest/types": {
       "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
       "license": "MIT",
       "dependencies": {
         "@jest/pattern": "30.4.0",
@@ -11228,8 +2389,25 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@jest/types/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/@jest/types/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -11244,6 +2422,8 @@
     },
     "node_modules/@jest/types/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -11254,6 +2434,8 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -11262,6 +2444,8 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -11270,6 +2454,8 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -11277,10 +2463,14 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -11289,6 +2479,8 @@
     },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
       "funding": [
         {
           "type": "github",
@@ -11303,6 +2495,8 @@
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -11311,6 +2505,8 @@
     },
     "node_modules/@promptbook/utils": {
       "version": "0.69.5",
+      "resolved": "https://registry.npmjs.org/@promptbook/utils/-/utils-0.69.5.tgz",
+      "integrity": "sha512-xm5Ti/Hp3o4xHrsK9Yy3MS6KbDxYbq485hDsFvxqaNA7equHLPdo8H8faTitTeb14QCDfLW4iwCxdVYu5sn6YQ==",
       "funding": [
         {
           "type": "individual",
@@ -11327,59 +2523,54 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "1.9.1",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "progress": "2.0.3",
-        "proxy-agent": "6.3.1",
-        "tar-fs": "3.0.4",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.2"
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "browsers": "lib/cjs/main-cli.js"
       },
       "engines": {
-        "node": ">=16.3.0"
+        "node": ">=18"
       }
     },
-    "node_modules/@puppeteer/browsers/node_modules/debug": {
-      "version": "4.3.4",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "2.1.2"
+    "node_modules/@puppeteer/browsers/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "node": ">=10"
       }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/ms": {
-      "version": "2.1.2",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
       "license": "MIT"
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -11390,14 +2581,20 @@
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
@@ -11405,6 +2602,8 @@
     },
     "node_modules/@types/istanbul-reports": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
@@ -11412,10 +2611,14 @@
     },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.17",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -11423,22 +2626,32 @@
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "license": "MIT"
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "license": "MIT"
     },
     "node_modules/@types/which": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -11446,6 +2659,8 @@
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -11453,10 +2668,14 @@
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11465,6 +2684,8 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^1.2.0"
@@ -11475,6 +2696,8 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "2.1.9",
@@ -11486,10 +2709,12 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.6",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
+        "@vitest/pretty-format": "4.1.7",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -11498,7 +2723,9 @@
       }
     },
     "node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^3.1.0"
@@ -11509,6 +2736,8 @@
     },
     "node_modules/@vitest/utils/node_modules/tinyrainbow": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -11516,6 +2745,8 @@
     },
     "node_modules/@wdio/cli": {
       "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.27.1.tgz",
+      "integrity": "sha512-FxwHq7UZs81FWHWUhk3F/Nh2U8VpKzJrrDTminj8EYquNzsBOr6gw11M4lENuQ+Cre/aS01cxZYkgTYWkPGrOw==",
       "license": "MIT",
       "dependencies": {
         "@vitest/snapshot": "^2.1.1",
@@ -11546,45 +2777,10 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/cli/node_modules/@puppeteer/browsers": {
-      "version": "2.13.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "extract-zip": "^2.0.1",
-        "progress": "^2.0.3",
-        "proxy-agent": "^6.5.0",
-        "semver": "^7.7.4",
-        "tar-fs": "^3.1.1",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/@types/node": {
-      "version": "20.19.41",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/@wdio/config": {
+    "node_modules/@wdio/config": {
       "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.27.1.tgz",
+      "integrity": "sha512-QVfSCqcpMfVum9KlpxgjaLlSLXkc53UQ2CPJU+IUVBp8LkbSyeX972HQS8V9Hnn6vSPE1dYScItg7wblnJ8RQg==",
       "license": "MIT",
       "dependencies": {
         "@wdio/logger": "9.18.0",
@@ -11599,8 +2795,24 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/cli/node_modules/@wdio/globals": {
+    "node_modules/@wdio/dot-reporter": {
       "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/dot-reporter/-/dot-reporter-9.27.1.tgz",
+      "integrity": "sha512-MF42psa0wEZp6UsBsmiS8uSkDBrVDtncBhyHi34aLkiBuZ+exftO910KKXD3c5QNJcZwV2ps8eayjuqLdFp0XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/reporter": "9.27.1",
+        "@wdio/types": "9.27.1",
+        "chalk": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/globals": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-9.27.1.tgz",
+      "integrity": "sha512-jm6gTQ6Qo3EOBY6PA09U/5Pf17WLEJM1/lTfhc6jzLFE770EuhuhbuphqrInH0hVR9WMyWtSZQ+LRCcLfcmOPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.20.0"
@@ -11618,375 +2830,10 @@
         }
       }
     },
-    "node_modules/@wdio/cli/node_modules/@wdio/logger": {
-      "version": "9.18.0",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.1.2",
-        "loglevel": "^1.6.0",
-        "loglevel-plugin-prefix": "^0.8.4",
-        "safe-regex2": "^5.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/@wdio/protocols": {
-      "version": "9.27.1",
-      "license": "MIT"
-    },
-    "node_modules/@wdio/cli/node_modules/@wdio/repl": {
-      "version": "9.16.2",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/@wdio/types": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/@wdio/utils": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@puppeteer/browsers": "^2.2.0",
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.27.1",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^7.0.3",
-        "edgedriver": "^6.1.2",
-        "geckodriver": "^6.1.0",
-        "get-port": "^7.0.0",
-        "import-meta-resolve": "^4.0.0",
-        "locate-app": "^2.2.24",
-        "mitt": "^3.0.1",
-        "safaridriver": "^1.0.0",
-        "split2": "^4.2.0",
-        "wait-port": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/edgedriver": {
-      "version": "6.3.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/logger": "^9.18.0",
-        "@zip.js/zip.js": "^2.8.11",
-        "decamelize": "^6.0.1",
-        "edge-paths": "^3.0.5",
-        "fast-xml-parser": "^5.3.3",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "which": "^6.0.0"
-      },
-      "bin": {
-        "edgedriver": "bin/edgedriver.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/expect-webdriverio": {
-      "version": "5.6.5",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vitest/snapshot": "^4.0.16",
-        "deep-eql": "^5.0.2",
-        "expect": "^30.2.0",
-        "jest-matcher-utils": "^30.2.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@wdio/globals": "^9.0.0",
-        "@wdio/logger": "^9.0.0",
-        "webdriverio": "^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@wdio/globals": {
-          "optional": false
-        },
-        "@wdio/logger": {
-          "optional": false
-        },
-        "webdriverio": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/expect-webdriverio/node_modules/@vitest/snapshot": {
-      "version": "4.1.6",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/utils": "4.1.6",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/fast-xml-parser": {
-      "version": "5.8.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.2.0",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.3.0",
-        "xml-naming": "^0.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/geckodriver": {
-      "version": "6.1.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/logger": "^9.18.0",
-        "@zip.js/zip.js": "^2.8.11",
-        "decamelize": "^6.0.1",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "modern-tar": "^0.7.2"
-      },
-      "bin": {
-        "geckodriver": "bin/geckodriver.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/isexe": {
-      "version": "4.0.0",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/pathe": {
-      "version": "2.0.3",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@wdio/cli/node_modules/proxy-agent": {
-      "version": "6.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.1.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/safaridriver": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/semver": {
-      "version": "7.8.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/serialize-error": {
-      "version": "12.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^4.31.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/strnum": {
-      "version": "2.3.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@wdio/cli/node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/undici": {
-      "version": "6.25.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/webdriver": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0",
-        "@types/ws": "^8.5.3",
-        "@wdio/config": "9.27.1",
-        "@wdio/logger": "9.18.0",
-        "@wdio/protocols": "9.27.1",
-        "@wdio/types": "9.27.1",
-        "@wdio/utils": "9.27.1",
-        "deepmerge-ts": "^7.0.3",
-        "https-proxy-agent": "^7.0.6",
-        "undici": "^6.21.3",
-        "ws": "^8.8.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/webdriverio": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.11.30",
-        "@types/sinonjs__fake-timers": "^8.1.5",
-        "@wdio/config": "9.27.1",
-        "@wdio/logger": "9.18.0",
-        "@wdio/protocols": "9.27.1",
-        "@wdio/repl": "9.16.2",
-        "@wdio/types": "9.27.1",
-        "@wdio/utils": "9.27.1",
-        "archiver": "^7.0.1",
-        "aria-query": "^5.3.0",
-        "cheerio": "^1.0.0-rc.12",
-        "css-shorthand-properties": "^1.1.1",
-        "css-value": "^0.0.1",
-        "grapheme-splitter": "^1.0.4",
-        "htmlfy": "^0.8.1",
-        "is-plain-obj": "^4.1.0",
-        "jszip": "^3.10.1",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.zip": "^4.2.0",
-        "query-selector-shadow-dom": "^1.0.1",
-        "resq": "^1.11.0",
-        "rgb2hex": "0.2.5",
-        "serialize-error": "^12.0.0",
-        "urlpattern-polyfill": "^10.0.0",
-        "webdriver": "9.27.1"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      },
-      "peerDependencies": {
-        "puppeteer-core": ">=22.x || <=24.x"
-      },
-      "peerDependenciesMeta": {
-        "puppeteer-core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/which": {
-      "version": "6.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^4.0.0"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@wdio/dot-reporter": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/reporter": "9.27.1",
-        "@wdio/types": "9.27.1",
-        "chalk": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/dot-reporter/node_modules/@types/node": {
-      "version": "20.19.41",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@wdio/dot-reporter/node_modules/@wdio/types": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
     "node_modules/@wdio/local-runner": {
       "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-9.27.1.tgz",
+      "integrity": "sha512-Uvol8Je1VrCUDZqLT1/fhrvXOGpAGcjEXd69LbhupFAVv336fGX+aonJlWV8VJyWow55xSW4zmKnaLIhpFk3Uw==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0",
@@ -12004,92 +2851,10 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/local-runner/node_modules/@puppeteer/browsers": {
-      "version": "2.13.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "extract-zip": "^2.0.1",
-        "progress": "^2.0.3",
-        "proxy-agent": "^6.5.0",
-        "semver": "^7.7.4",
-        "tar-fs": "^3.1.1",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/@types/node": {
-      "version": "20.19.41",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/@vitest/snapshot": {
-      "version": "4.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/utils": "4.1.6",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/@wdio/config": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.27.1",
-        "@wdio/utils": "9.27.1",
-        "deepmerge-ts": "^7.0.3",
-        "glob": "^10.2.2",
-        "import-meta-resolve": "^4.0.0",
-        "jiti": "^2.6.1"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/@wdio/globals": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20.0"
-      },
-      "peerDependencies": {
-        "expect-webdriverio": "^5.6.5",
-        "webdriverio": "^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "expect-webdriverio": {
-          "optional": false
-        },
-        "webdriverio": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/@wdio/logger": {
+    "node_modules/@wdio/logger": {
       "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
+      "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.1.2",
@@ -12102,12 +2867,33 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/local-runner/node_modules/@wdio/protocols": {
+    "node_modules/@wdio/mocha-framework": {
       "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-9.27.1.tgz",
+      "integrity": "sha512-HJ2FtV6qgy7Rs7xGKjyGIKMtFBlCRfxiK9jTElRlOPyQjv79BHc1+sDcQpvufunKuma35rLUCuwtbeY3HotJVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mocha": "^10.0.6",
+        "@types/node": "^20.11.28",
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.27.1",
+        "@wdio/utils": "9.27.1",
+        "mocha": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/protocols": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.27.1.tgz",
+      "integrity": "sha512-Ril46AmySoiYX9nuKqFr3SNJqquU3VmF9FzSndQlDib0G3oA4pYx9wcBXvdvkFxRjjmFwQDzmvztKrssAHymgw==",
       "license": "MIT"
     },
-    "node_modules/@wdio/local-runner/node_modules/@wdio/repl": {
+    "node_modules/@wdio/repl": {
       "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-9.16.2.tgz",
+      "integrity": "sha512-FLTF0VL6+o5BSTCO7yLSXocm3kUnu31zYwzdsz4n9s5YWt83sCtzGZlZpt7TaTzb3jVUfxuHNQDTb8UMkCu0lQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
@@ -12116,8 +2902,26 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/local-runner/node_modules/@wdio/runner": {
+    "node_modules/@wdio/reporter": {
       "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-9.27.1.tgz",
+      "integrity": "sha512-2ueVjd5hOCclfC+GV3yhaN/4Tids1mXMcpPtNTPushHIQY4gLmBqqKDe5RSXAED3bNU+DRdHq2uBiZTBd4QDJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0",
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.27.1",
+        "diff": "^8.0.2",
+        "object-inspect": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/runner": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-9.27.1.tgz",
+      "integrity": "sha512-vd/cVrI1++TAqs85CJFt0eJT3/fr1njMBV5I0GDjsHN6J0g9hemJk3VV7T4x1cBtAnCPlj22Q2Bzy4JhYN2gLg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.11.28",
@@ -12147,572 +2951,10 @@
         }
       }
     },
-    "node_modules/@wdio/local-runner/node_modules/@wdio/types": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/@wdio/utils": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@puppeteer/browsers": "^2.2.0",
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.27.1",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^7.0.3",
-        "edgedriver": "^6.1.2",
-        "geckodriver": "^6.1.0",
-        "get-port": "^7.0.0",
-        "import-meta-resolve": "^4.0.0",
-        "locate-app": "^2.2.24",
-        "mitt": "^3.0.1",
-        "safaridriver": "^1.0.0",
-        "split2": "^4.2.0",
-        "wait-port": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/edgedriver": {
-      "version": "6.3.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/logger": "^9.18.0",
-        "@zip.js/zip.js": "^2.8.11",
-        "decamelize": "^6.0.1",
-        "edge-paths": "^3.0.5",
-        "fast-xml-parser": "^5.3.3",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "which": "^6.0.0"
-      },
-      "bin": {
-        "edgedriver": "bin/edgedriver.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/expect-webdriverio": {
-      "version": "5.6.5",
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/snapshot": "^4.0.16",
-        "deep-eql": "^5.0.2",
-        "expect": "^30.2.0",
-        "jest-matcher-utils": "^30.2.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@wdio/globals": "^9.0.0",
-        "@wdio/logger": "^9.0.0",
-        "webdriverio": "^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@wdio/globals": {
-          "optional": false
-        },
-        "@wdio/logger": {
-          "optional": false
-        },
-        "webdriverio": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/fast-xml-parser": {
-      "version": "5.8.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.2.0",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.3.0",
-        "xml-naming": "^0.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/geckodriver": {
-      "version": "6.1.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/logger": "^9.18.0",
-        "@zip.js/zip.js": "^2.8.11",
-        "decamelize": "^6.0.1",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "modern-tar": "^0.7.2"
-      },
-      "bin": {
-        "geckodriver": "bin/geckodriver.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/isexe": {
-      "version": "4.0.0",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/pathe": {
-      "version": "2.0.3",
-      "license": "MIT"
-    },
-    "node_modules/@wdio/local-runner/node_modules/proxy-agent": {
-      "version": "6.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.1.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/safaridriver": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/semver": {
-      "version": "7.8.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/serialize-error": {
-      "version": "12.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^4.31.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/strnum": {
-      "version": "2.3.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@wdio/local-runner/node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/undici": {
-      "version": "6.25.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/webdriver": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0",
-        "@types/ws": "^8.5.3",
-        "@wdio/config": "9.27.1",
-        "@wdio/logger": "9.18.0",
-        "@wdio/protocols": "9.27.1",
-        "@wdio/types": "9.27.1",
-        "@wdio/utils": "9.27.1",
-        "deepmerge-ts": "^7.0.3",
-        "https-proxy-agent": "^7.0.6",
-        "undici": "^6.21.3",
-        "ws": "^8.8.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/webdriverio": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.11.30",
-        "@types/sinonjs__fake-timers": "^8.1.5",
-        "@wdio/config": "9.27.1",
-        "@wdio/logger": "9.18.0",
-        "@wdio/protocols": "9.27.1",
-        "@wdio/repl": "9.16.2",
-        "@wdio/types": "9.27.1",
-        "@wdio/utils": "9.27.1",
-        "archiver": "^7.0.1",
-        "aria-query": "^5.3.0",
-        "cheerio": "^1.0.0-rc.12",
-        "css-shorthand-properties": "^1.1.1",
-        "css-value": "^0.0.1",
-        "grapheme-splitter": "^1.0.4",
-        "htmlfy": "^0.8.1",
-        "is-plain-obj": "^4.1.0",
-        "jszip": "^3.10.1",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.zip": "^4.2.0",
-        "query-selector-shadow-dom": "^1.0.1",
-        "resq": "^1.11.0",
-        "rgb2hex": "0.2.5",
-        "serialize-error": "^12.0.0",
-        "urlpattern-polyfill": "^10.0.0",
-        "webdriver": "9.27.1"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      },
-      "peerDependencies": {
-        "puppeteer-core": ">=22.x || <=24.x"
-      },
-      "peerDependenciesMeta": {
-        "puppeteer-core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/which": {
-      "version": "6.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^4.0.0"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@wdio/mocha-framework": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mocha": "^10.0.6",
-        "@types/node": "^20.11.28",
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.27.1",
-        "@wdio/utils": "9.27.1",
-        "mocha": "^10.3.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/@puppeteer/browsers": {
-      "version": "2.13.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "extract-zip": "^2.0.1",
-        "progress": "^2.0.3",
-        "proxy-agent": "^6.5.0",
-        "semver": "^7.7.4",
-        "tar-fs": "^3.1.1",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/@types/node": {
-      "version": "20.19.41",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/@wdio/logger": {
-      "version": "9.18.0",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.1.2",
-        "loglevel": "^1.6.0",
-        "loglevel-plugin-prefix": "^0.8.4",
-        "safe-regex2": "^5.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/@wdio/types": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/@wdio/utils": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@puppeteer/browsers": "^2.2.0",
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.27.1",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^7.0.3",
-        "edgedriver": "^6.1.2",
-        "geckodriver": "^6.1.0",
-        "get-port": "^7.0.0",
-        "import-meta-resolve": "^4.0.0",
-        "locate-app": "^2.2.24",
-        "mitt": "^3.0.1",
-        "safaridriver": "^1.0.0",
-        "split2": "^4.2.0",
-        "wait-port": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/edgedriver": {
-      "version": "6.3.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/logger": "^9.18.0",
-        "@zip.js/zip.js": "^2.8.11",
-        "decamelize": "^6.0.1",
-        "edge-paths": "^3.0.5",
-        "fast-xml-parser": "^5.3.3",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "which": "^6.0.0"
-      },
-      "bin": {
-        "edgedriver": "bin/edgedriver.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/fast-xml-parser": {
-      "version": "5.8.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.2.0",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.3.0",
-        "xml-naming": "^0.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/geckodriver": {
-      "version": "6.1.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/logger": "^9.18.0",
-        "@zip.js/zip.js": "^2.8.11",
-        "decamelize": "^6.0.1",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "modern-tar": "^0.7.2"
-      },
-      "bin": {
-        "geckodriver": "bin/geckodriver.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/isexe": {
-      "version": "4.0.0",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/proxy-agent": {
-      "version": "6.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.1.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/safaridriver": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/semver": {
-      "version": "7.8.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/strnum": {
-      "version": "2.3.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/which": {
-      "version": "6.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^4.0.0"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@wdio/reporter": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0",
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.27.1",
-        "diff": "^8.0.2",
-        "object-inspect": "^1.12.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/reporter/node_modules/@types/node": {
-      "version": "20.19.41",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@wdio/reporter/node_modules/@wdio/logger": {
-      "version": "9.18.0",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.1.2",
-        "loglevel": "^1.6.0",
-        "loglevel-plugin-prefix": "^0.8.4",
-        "safe-regex2": "^5.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/reporter/node_modules/@wdio/types": {
-      "version": "9.27.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
     "node_modules/@wdio/spec-reporter": {
       "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/spec-reporter/-/spec-reporter-9.27.1.tgz",
+      "integrity": "sha512-q9UMJJbCcP+nCOojIvOIcsXnerhHICmWu94guRMRYPbW2IsG/5VM/uhzwru8SU/1WRXLtKgTjkuXXsjzjVpf2w==",
       "license": "MIT",
       "dependencies": {
         "@wdio/reporter": "9.27.1",
@@ -12725,15 +2967,10 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/spec-reporter/node_modules/@types/node": {
-      "version": "20.19.41",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@wdio/spec-reporter/node_modules/@wdio/types": {
+    "node_modules/@wdio/types": {
       "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.27.1.tgz",
+      "integrity": "sha512-EHBNCvLmvpYerln4mb/OBxzKtnavL2wdenjhwuYjzkZMOWHgm/uLXH6sLThM0y6DIbCU72Asth16fo1eDcsofA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
@@ -12742,8 +2979,35 @@
         "node": ">=18.20.0"
       }
     },
+    "node_modules/@wdio/utils": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.27.1.tgz",
+      "integrity": "sha512-s2w1tFrvmpdkZ33LYsIw4ONRdWIIm4MxkyIuibbcG1ILV5fFMS9rU59csHuWIM0KhJoEoLU+fzE3ze9O7TpWhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@puppeteer/browsers": "^2.2.0",
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.27.1",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^7.0.3",
+        "edgedriver": "^6.1.2",
+        "geckodriver": "^6.1.0",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.2.24",
+        "mitt": "^3.0.1",
+        "safaridriver": "^1.0.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
     "node_modules/@wdio/xvfb": {
       "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/xvfb/-/xvfb-9.27.1.tgz",
+      "integrity": "sha512-7qOnrAF+3o+bg0ijqIoxsXloCQZ9sG9o8Jt9btg4NiyC6mRIQoqxnQBDo0M/v4ZnmAaz/hSCDvQNU0Y/7baNZA==",
       "license": "MIT",
       "dependencies": {
         "@wdio/logger": "9.18.0"
@@ -12752,22 +3016,10 @@
         "node": ">=18"
       }
     },
-    "node_modules/@wdio/xvfb/node_modules/@wdio/logger": {
-      "version": "9.18.0",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.1.2",
-        "loglevel": "^1.6.0",
-        "loglevel-plugin-prefix": "^0.8.4",
-        "safe-regex2": "^5.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
     "node_modules/@zip.js/zip.js": {
       "version": "2.8.26",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.26.tgz",
+      "integrity": "sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA==",
       "license": "BSD-3-Clause",
       "engines": {
         "bun": ">=0.7.0",
@@ -12777,6 +3029,8 @@
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -12787,6 +3041,8 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -12794,6 +3050,8 @@
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12801,19 +3059,20 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
-      "version": "4.3.0",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -12821,6 +3080,8 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -12830,8 +3091,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/archiver": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
       "license": "MIT",
       "dependencies": {
         "archiver-utils": "^5.0.2",
@@ -12848,6 +3123,8 @@
     },
     "node_modules/archiver-utils": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
       "license": "MIT",
       "dependencies": {
         "glob": "^10.0.0",
@@ -12862,30 +3139,10 @@
         "node": ">= 14"
       }
     },
-    "node_modules/archiver-utils/node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/archiver-utils/node_modules/is-stream": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12894,62 +3151,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/archiver-utils/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/archiver/node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/archiver/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -12957,6 +3168,8 @@
     },
     "node_modules/ast-types": {
       "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
@@ -12967,24 +3180,32 @@
     },
     "node_modules/async": {
       "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
     "node_modules/async-exit-hook": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.3",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/b4a": {
-      "version": "1.8.0",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -12997,6 +3218,8 @@
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+      "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -13009,6 +3232,8 @@
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+      "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.8",
@@ -13020,6 +3245,8 @@
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
       "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+      "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.8"
@@ -13030,10 +3257,14 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.8.2",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -13046,8 +3277,9 @@
     },
     "node_modules/bare-fs": {
       "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
@@ -13069,24 +3301,27 @@
     },
     "node_modules/bare-os": {
       "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "bare": ">=1.14.0"
       }
     },
     "node_modules/bare-path": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
     },
     "node_modules/bare-stream": {
       "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "streamx": "^2.25.0",
         "teex": "^1.0.1"
@@ -13110,14 +3345,17 @@
     },
     "node_modules/bare-url": {
       "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-path": "^3.0.0"
       }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "funding": [
         {
           "type": "github",
@@ -13135,7 +3373,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.19",
+      "version": "2.10.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -13146,6 +3386,8 @@
     },
     "node_modules/basic-ftp": {
       "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -13153,6 +3395,8 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13163,10 +3407,14 @@
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -13174,6 +3422,8 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -13184,10 +3434,14 @@
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
       "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "funding": [
         {
           "type": "opencollective",
@@ -13218,7 +3472,9 @@
       }
     },
     "node_modules/buffer": {
-      "version": "5.7.1",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -13234,15 +3490,15 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-crc32": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -13250,10 +3506,14 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -13263,7 +3523,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "funding": [
         {
           "type": "opencollective",
@@ -13282,6 +3544,8 @@
     },
     "node_modules/chalk": {
       "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -13292,10 +3556,14 @@
     },
     "node_modules/chardet": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "license": "MIT"
     },
     "node_modules/cheerio": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
       "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
@@ -13319,6 +3587,8 @@
     },
     "node_modules/cheerio-select": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
@@ -13332,8 +3602,19 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cheerio/node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -13345,21 +3626,10 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/chromium-bidi": {
-      "version": "0.5.8",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "mitt": "3.0.1",
-        "urlpattern-polyfill": "10.0.0"
-      },
-      "peerDependencies": {
-        "devtools-protocol": "*"
-      }
-    },
     "node_modules/ci-info": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
       "funding": [
         {
           "type": "github",
@@ -13373,6 +3643,8 @@
     },
     "node_modules/cli-width": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
       "license": "ISC",
       "engines": {
         "node": ">= 12"
@@ -13380,6 +3652,8 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -13390,8 +3664,45 @@
         "node": ">=12"
       }
     },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -13402,6 +3713,8 @@
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -13417,6 +3730,8 @@
     },
     "node_modules/clone": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -13425,6 +3740,8 @@
     },
     "node_modules/clone-deep": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
       "license": "MIT",
       "dependencies": {
         "is-plain-object": "^2.0.4",
@@ -13437,6 +3754,8 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -13447,14 +3766,29 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/commondir": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "license": "MIT"
     },
     "node_modules/compress-commons": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
@@ -13467,30 +3801,10 @@
         "node": ">= 14"
       }
     },
-    "node_modules/compress-commons/node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/compress-commons/node_modules/is-stream": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13499,30 +3813,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/compress-commons/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.1"
@@ -13534,10 +3840,14 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "license": "Apache-2.0",
       "bin": {
         "crc32": "bin/crc32.njs"
@@ -13548,6 +3858,8 @@
     },
     "node_modules/crc32-stream": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
@@ -13557,44 +3869,10 @@
         "node": ">= 14"
       }
     },
-    "node_modules/crc32-stream/node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/crc32-stream/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/create-wdio": {
       "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/create-wdio/-/create-wdio-9.27.1.tgz",
+      "integrity": "sha512-/cpc9s3iJWYBhglj8x0DhxH4OMSAh4daYnJg0E93XTCnv+jmS+Nb88Yq+fl1hvNEziTOPn4A93+6nEfiVuwdIQ==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -13618,41 +3896,10 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/create-wdio/node_modules/commander": {
-      "version": "14.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/create-wdio/node_modules/hosted-git-info": {
-      "version": "8.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^10.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/create-wdio/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "license": "ISC"
-    },
-    "node_modules/create-wdio/node_modules/normalize-package-data": {
-      "version": "7.0.1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^8.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/create-wdio/node_modules/semver": {
       "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -13661,17 +3908,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -13682,25 +3922,10 @@
         "node": ">= 8"
       }
     },
-    "node_modules/cross-spawn/node_modules/isexe": {
-      "version": "2.0.0",
-      "license": "ISC"
-    },
-    "node_modules/cross-spawn/node_modules/which": {
-      "version": "2.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/css-select": {
       "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
@@ -13715,13 +3940,19 @@
     },
     "node_modules/css-shorthand-properties": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.2.tgz",
+      "integrity": "sha512-C2AugXIpRGQTxaCW0N7n5jD/p5irUmCrwl03TrnMFBHDbdq44CFWR2zO7rK9xPN4Eo3pUxC4vQzQgbIpzrD1PQ==",
       "license": "MIT"
     },
     "node_modules/css-value": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
+      "integrity": "sha512-FUV3xaJ63buRLgHrLQVlVgQnQdR4yqdLGaDu7g8CQcWjInDfM9plBTPI9FRfpahju1UBSaMckeb2/46ApS/V1Q=="
     },
     "node_modules/css-what": {
       "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
@@ -13732,6 +3963,8 @@
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -13739,6 +3972,8 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -13754,6 +3989,8 @@
     },
     "node_modules/decamelize": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -13764,13 +4001,26 @@
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13782,6 +4032,8 @@
     },
     "node_modules/degenerator": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "license": "MIT",
       "dependencies": {
         "ast-types": "^0.13.4",
@@ -13792,14 +4044,10 @@
         "node": ">= 14"
       }
     },
-    "node_modules/devtools-protocol": {
-      "version": "0.0.1400418",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/diff": {
       "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -13807,6 +4055,8 @@
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
@@ -13819,6 +4069,8 @@
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "funding": [
         {
           "type": "github",
@@ -13829,6 +4081,8 @@
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
@@ -13842,6 +4096,8 @@
     },
     "node_modules/domutils": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
@@ -13854,6 +4110,8 @@
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -13864,10 +4122,14 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
     },
     "node_modules/easy-table": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.2.0.tgz",
+      "integrity": "sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -13878,6 +4140,8 @@
     },
     "node_modules/edge-paths": {
       "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-3.0.5.tgz",
+      "integrity": "sha512-sB7vSrDnFa4ezWQk9nZ/n0FdpdUuC6R1EOrlU3DL+bovcNFK28rqu2emmAUjujYEJTWIgQGqgVVWUZXMnc8iWg==",
       "license": "MIT",
       "dependencies": {
         "@types/which": "^2.0.1",
@@ -13890,25 +4154,57 @@
         "url": "https://github.com/sponsors/shirshak55"
       }
     },
-    "node_modules/edge-paths/node_modules/isexe": {
-      "version": "2.0.0",
-      "license": "ISC"
-    },
-    "node_modules/edge-paths/node_modules/which": {
-      "version": "2.0.2",
-      "license": "ISC",
+    "node_modules/edgedriver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.3.0.tgz",
+      "integrity": "sha512-ggEQL+oEyIcM4nP2QC3AtCQ04o4kDNefRM3hja0odvlPSnsaxiruMxEZ93v3gDCKWYW6BXUr51PPradb+3nffw==",
+      "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "isexe": "^2.0.0"
+        "@wdio/logger": "^9.18.0",
+        "@zip.js/zip.js": "^2.8.11",
+        "decamelize": "^6.0.1",
+        "edge-paths": "^3.0.5",
+        "fast-xml-parser": "^5.3.3",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "which": "^6.0.0"
       },
       "bin": {
-        "node-which": "bin/node-which"
+        "edgedriver": "bin/edgedriver.js"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/edgedriver/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/edgedriver/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/ejs": {
       "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "license": "Apache-2.0",
       "dependencies": {
         "jake": "^10.8.5"
@@ -13921,15 +4217,21 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.340",
+      "version": "1.5.360",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.360.tgz",
+      "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.3",
@@ -13941,6 +4243,8 @@
     },
     "node_modules/encoding-sniffer/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -13951,6 +4255,8 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -13958,6 +4264,8 @@
     },
     "node_modules/entities": {
       "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -13968,6 +4276,8 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -13975,6 +4285,8 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13982,6 +4294,8 @@
     },
     "node_modules/esbuild": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -14021,6 +4335,8 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14028,6 +4344,8 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -14038,6 +4356,8 @@
     },
     "node_modules/escodegen": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^4.0.1",
@@ -14057,6 +4377,8 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -14068,6 +4390,8 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -14075,6 +4399,8 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -14082,6 +4408,8 @@
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14089,6 +4417,8 @@
     },
     "node_modules/events": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -14096,6 +4426,8 @@
     },
     "node_modules/events-universal": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
@@ -14103,6 +4435,8 @@
     },
     "node_modules/execa": {
       "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
@@ -14127,6 +4461,8 @@
     },
     "node_modules/exit-hook": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-4.0.0.tgz",
+      "integrity": "sha512-Fqs7ChZm72y40wKjOFXBKg7nJZvQJmewP5/7LtePDdnah/+FH9Hp5sgMujSCMPXlxOAW2//1jrW9pnsY7o20vQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -14137,6 +4473,8 @@
     },
     "node_modules/expect": {
       "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
       "license": "MIT",
       "dependencies": {
         "@jest/expect-utils": "30.4.1",
@@ -14150,8 +4488,83 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/expect-webdriverio": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-5.6.5.tgz",
+      "integrity": "sha512-5ot+Apo0bEvMD/nqzWymQpgyWnOdu0kVpmahLx5T7NzUc6RyifucZ24Gsfr6F6C8yRGBhmoFh7ZeY+W9kteEBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/snapshot": "^4.0.16",
+        "deep-eql": "^5.0.2",
+        "expect": "^30.2.0",
+        "jest-matcher-utils": "^30.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@wdio/globals": "^9.0.0",
+        "@wdio/logger": "^9.0.0",
+        "webdriverio": "^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@wdio/globals": {
+          "optional": false
+        },
+        "@wdio/logger": {
+          "optional": false
+        },
+        "webdriverio": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/expect-webdriverio/node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/expect-webdriverio/node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/expect-webdriverio/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
+    "node_modules/expect-webdriverio/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -14170,6 +4583,8 @@
     },
     "node_modules/extract-zip/node_modules/get-stream": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -14183,14 +4598,20 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -14203,8 +4624,32 @@
         "xml-naming": "^0.1.0"
       }
     },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -14212,6 +4657,8 @@
     },
     "node_modules/figures": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
       "license": "MIT",
       "dependencies": {
         "is-unicode-supported": "^2.0.0"
@@ -14225,6 +4672,8 @@
     },
     "node_modules/filelist": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
@@ -14232,6 +4681,8 @@
     },
     "node_modules/filelist/node_modules/minimatch": {
       "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -14242,6 +4693,8 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -14252,6 +4705,8 @@
     },
     "node_modules/find-cache-dir": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
       "license": "MIT",
       "dependencies": {
         "commondir": "^1.0.1",
@@ -14264,6 +4719,8 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -14278,6 +4735,8 @@
     },
     "node_modules/flat": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "license": "BSD-3-Clause",
       "bin": {
         "flat": "cli.js"
@@ -14285,6 +4744,8 @@
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -14299,10 +4760,15 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14314,13 +4780,38 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/geckodriver": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.1.0.tgz",
+      "integrity": "sha512-ZRXLa4ZaYTTgUO4Eefw+RsQCleugU2QLb1ME7qTYxxuRj51yAhfnXaItXNs5/vUzfIaDHuZ+YnSF005hfp07nQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/logger": "^9.18.0",
+        "@zip.js/zip.js": "^2.8.11",
+        "decamelize": "^6.0.1",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "modern-tar": "^0.7.2"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -14328,6 +4819,8 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -14335,6 +4828,8 @@
     },
     "node_modules/get-port": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -14345,6 +4840,8 @@
     },
     "node_modules/get-stream": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "license": "MIT",
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
@@ -14359,6 +4856,8 @@
     },
     "node_modules/get-uri": {
       "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "license": "MIT",
       "dependencies": {
         "basic-ftp": "^5.0.2",
@@ -14371,6 +4870,9 @@
     },
     "node_modules/glob": {
       "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -14389,6 +4891,8 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -14399,14 +4903,20 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14414,6 +4924,8 @@
     },
     "node_modules/hasown": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -14424,31 +4936,41 @@
     },
     "node_modules/he": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "license": "MIT",
       "bin": {
         "he": "bin/he"
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "7.0.2",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
+      "integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^10.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/hosted-git-info/node_modules/lru-cache": {
       "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
     "node_modules/htmlfy": {
       "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.8.1.tgz",
+      "integrity": "sha512-xWROBw9+MEGwxpotll0h672KCaLrKKiCYzsyN8ZgL9cQbVumFnyvsk2JqiB9ELAV1GLj1GG/jxZUjV9OZZi/yQ==",
       "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -14466,6 +4988,8 @@
     },
     "node_modules/htmlparser2/node_modules/entities": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -14476,6 +5000,8 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -14487,6 +5013,8 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -14498,6 +5026,8 @@
     },
     "node_modules/human-signals": {
       "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
@@ -14505,6 +5035,8 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -14519,6 +5051,8 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "funding": [
         {
           "type": "github",
@@ -14537,10 +5071,14 @@
     },
     "node_modules/immediate": {
       "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "license": "MIT"
     },
     "node_modules/import-meta-resolve": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -14549,6 +5087,9 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -14557,10 +5098,14 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
     "node_modules/inquirer": {
       "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.11.1.tgz",
+      "integrity": "sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -14585,6 +5130,8 @@
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -14592,10 +5139,14 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -14605,10 +5156,12 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -14619,6 +5172,8 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14626,6 +5181,8 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14633,6 +5190,8 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -14643,6 +5202,8 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -14650,6 +5211,8 @@
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -14660,6 +5223,8 @@
     },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -14670,6 +5235,8 @@
     },
     "node_modules/is-stream": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -14680,6 +5247,8 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -14690,10 +5259,20 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
     },
     "node_modules/isobject": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14701,6 +5280,8 @@
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -14714,6 +5295,8 @@
     },
     "node_modules/jake": {
       "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "async": "^3.2.6",
@@ -14729,6 +5312,8 @@
     },
     "node_modules/jest-diff": {
       "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
       "license": "MIT",
       "dependencies": {
         "@jest/diff-sequences": "30.4.0",
@@ -14740,8 +5325,25 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/jest-diff/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -14756,6 +5358,8 @@
     },
     "node_modules/jest-diff/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -14766,6 +5370,8 @@
     },
     "node_modules/jest-matcher-utils": {
       "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
@@ -14777,8 +5383,25 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/jest-matcher-utils/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -14793,6 +5416,8 @@
     },
     "node_modules/jest-matcher-utils/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -14803,6 +5428,8 @@
     },
     "node_modules/jest-message-util": {
       "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -14820,8 +5447,25 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-message-util/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/jest-message-util/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -14834,18 +5478,10 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/jest-message-util/node_modules/picomatch": {
-      "version": "4.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/jest-message-util/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -14856,6 +5492,8 @@
     },
     "node_modules/jest-mock": {
       "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
       "license": "MIT",
       "dependencies": {
         "@jest/types": "30.4.1",
@@ -14868,6 +5506,8 @@
     },
     "node_modules/jest-regex-util": {
       "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
       "license": "MIT",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -14875,6 +5515,8 @@
     },
     "node_modules/jest-util": {
       "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
       "license": "MIT",
       "dependencies": {
         "@jest/types": "30.4.1",
@@ -14888,8 +5530,25 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-util/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/jest-util/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -14902,18 +5561,10 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/jest-util/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -14924,6 +5575,8 @@
     },
     "node_modules/jiti": {
       "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -14931,10 +5584,14 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -14945,6 +5602,8 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -14955,6 +5614,8 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
+      "integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
       "license": "MIT",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -14962,6 +5623,8 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -14972,6 +5635,8 @@
     },
     "node_modules/jszip": {
       "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
       "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
         "lie": "~3.3.0",
@@ -14982,6 +5647,8 @@
     },
     "node_modules/jszip/node_modules/readable-stream": {
       "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -14995,10 +5662,14 @@
     },
     "node_modules/jszip/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/jszip/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -15006,6 +5677,8 @@
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15013,6 +5686,8 @@
     },
     "node_modules/lazystream": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "license": "MIT",
       "dependencies": {
         "readable-stream": "^2.0.5"
@@ -15023,6 +5698,8 @@
     },
     "node_modules/lazystream/node_modules/readable-stream": {
       "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -15036,10 +5713,14 @@
     },
     "node_modules/lazystream/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -15047,6 +5728,8 @@
     },
     "node_modules/lie": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
@@ -15054,6 +5737,8 @@
     },
     "node_modules/lines-and-columns": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
+      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -15061,6 +5746,8 @@
     },
     "node_modules/locate-app": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/locate-app/-/locate-app-2.5.0.tgz",
+      "integrity": "sha512-xIqbzPMBYArJRmPGUZD9CzV9wOqmVtQnaAn3wrj3s6WYW0bQvPI7x+sPYUGmDTYMHefVK//zc6HEYZ1qnxIK+Q==",
       "funding": [
         {
           "type": "individual",
@@ -15080,6 +5767,8 @@
     },
     "node_modules/locate-app/node_modules/type-fest": {
       "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.0.tgz",
+      "integrity": "sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -15090,6 +5779,8 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -15103,34 +5794,50 @@
     },
     "node_modules/lodash": {
       "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "license": "MIT"
     },
     "node_modules/lodash.pickby": {
       "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
       "license": "MIT"
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "license": "MIT"
     },
     "node_modules/lodash.zip": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "integrity": "sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -15143,8 +5850,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/log-symbols/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -15159,6 +5883,8 @@
     },
     "node_modules/log-symbols/node_modules/is-unicode-supported": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -15169,6 +5895,8 @@
     },
     "node_modules/log-symbols/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -15179,6 +5907,8 @@
     },
     "node_modules/loglevel": {
       "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
@@ -15190,10 +5920,14 @@
     },
     "node_modules/loglevel-plugin-prefix": {
       "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
+      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -15201,6 +5935,8 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -15208,6 +5944,8 @@
     },
     "node_modules/make-dir": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
       "license": "MIT",
       "dependencies": {
         "pify": "^4.0.1",
@@ -15219,6 +5957,8 @@
     },
     "node_modules/make-dir/node_modules/semver": {
       "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -15226,6 +5966,8 @@
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -15239,6 +5981,8 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -15246,10 +5990,14 @@
     },
     "node_modules/mitt": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "license": "MIT"
     },
     "node_modules/mocha": {
       "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.3",
@@ -15281,8 +6029,25 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/mocha/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/mocha/node_modules/chokidar": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -15305,6 +6070,8 @@
     },
     "node_modules/mocha/node_modules/cliui": {
       "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -15314,13 +6081,24 @@
     },
     "node_modules/mocha/node_modules/diff": {
       "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
     },
+    "node_modules/mocha/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/mocha/node_modules/glob": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -15338,6 +6116,8 @@
     },
     "node_modules/mocha/node_modules/minimatch": {
       "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -15346,8 +6126,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/mocha/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mocha/node_modules/readdirp": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -15356,8 +6150,24 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/mocha/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/mocha/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -15368,6 +6178,8 @@
     },
     "node_modules/mocha/node_modules/wrap-ansi": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -15383,6 +6195,8 @@
     },
     "node_modules/mocha/node_modules/yargs": {
       "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^7.0.2",
@@ -15399,6 +6213,8 @@
     },
     "node_modules/modern-tar": {
       "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
+      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -15406,10 +6222,14 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/mute-stream": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -15417,49 +6237,40 @@
     },
     "node_modules/netmask": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
+    "node_modules/node-releases": {
+      "version": "2.0.45",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.45.tgz",
+      "integrity": "sha512-iIbHXV9eBB2nB0wa7oTsrrXq+qQt+9SIlx9AX3T96YgobtEQfis5n6TJ6vV+3QP8DwdriEAcGhARaFCu37peBg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
       "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+        "node": ">=18"
       }
     },
-    "node_modules/node-releases": {
-      "version": "2.0.37",
-      "license": "MIT"
-    },
     "node_modules/normalize-package-data": {
-      "version": "6.0.2",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-7.0.1.tgz",
+      "integrity": "sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "hosted-git-info": "^7.0.0",
+        "hosted-git-info": "^8.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -15470,6 +6281,8 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15477,6 +6290,8 @@
     },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^4.0.0",
@@ -15491,6 +6306,8 @@
     },
     "node_modules/npm-run-path/node_modules/path-key": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -15501,6 +6318,8 @@
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0"
@@ -15511,6 +6330,8 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15521,6 +6342,8 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -15528,6 +6351,8 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -15541,6 +6366,8 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -15554,6 +6381,8 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -15561,6 +6390,8 @@
     },
     "node_modules/pac-proxy-agent": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
       "license": "MIT",
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
@@ -15578,6 +6409,8 @@
     },
     "node_modules/pac-resolver": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
       "license": "MIT",
       "dependencies": {
         "degenerator": "^5.0.0",
@@ -15589,14 +6422,20 @@
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
     "node_modules/pako": {
       "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parse-json": {
       "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.1.tgz",
+      "integrity": "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.21.4",
@@ -15614,6 +6453,8 @@
     },
     "node_modules/parse-json/node_modules/type-fest": {
       "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=14.16"
@@ -15624,6 +6465,8 @@
     },
     "node_modules/parse-ms": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -15634,6 +6477,8 @@
     },
     "node_modules/parse5": {
       "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -15644,6 +6489,8 @@
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
       "license": "MIT",
       "dependencies": {
         "domhandler": "^5.0.3",
@@ -15655,6 +6502,8 @@
     },
     "node_modules/parse5-parser-stream": {
       "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
       "license": "MIT",
       "dependencies": {
         "parse5": "^7.0.0"
@@ -15665,6 +6514,8 @@
     },
     "node_modules/parse5/node_modules/entities": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -15675,6 +6526,8 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15682,6 +6535,8 @@
     },
     "node_modules/path-expression-matcher": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -15695,6 +6550,8 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15702,10 +6559,14 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -15720,25 +6581,35 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
     "node_modules/pathe": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "license": "MIT"
     },
     "node_modules/pend": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -15746,6 +6617,8 @@
     },
     "node_modules/pify": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -15753,6 +6626,8 @@
     },
     "node_modules/pirates": {
       "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -15760,6 +6635,8 @@
     },
     "node_modules/pkg-dir": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
       "license": "MIT",
       "dependencies": {
         "find-up": "^3.0.0"
@@ -15770,6 +6647,8 @@
     },
     "node_modules/pkg-dir/node_modules/find-up": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "license": "MIT",
       "dependencies": {
         "locate-path": "^3.0.0"
@@ -15780,6 +6659,8 @@
     },
     "node_modules/pkg-dir/node_modules/locate-path": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "license": "MIT",
       "dependencies": {
         "p-locate": "^3.0.0",
@@ -15791,6 +6672,8 @@
     },
     "node_modules/pkg-dir/node_modules/p-limit": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -15804,6 +6687,8 @@
     },
     "node_modules/pkg-dir/node_modules/p-locate": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.0.0"
@@ -15814,6 +6699,8 @@
     },
     "node_modules/pkg-dir/node_modules/path-exists": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -15821,6 +6708,8 @@
     },
     "node_modules/pretty-format": {
       "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "30.4.1",
@@ -15832,18 +6721,10 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
       "license": "MIT",
       "dependencies": {
         "parse-ms": "^4.0.0"
@@ -15857,6 +6738,8 @@
     },
     "node_modules/process": {
       "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
@@ -15864,29 +6747,33 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/proxy-agent": {
-      "version": "6.3.1",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
         "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
+        "pac-proxy-agent": "^7.1.0",
         "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
+        "socks-proxy-agent": "^8.0.5"
       },
       "engines": {
         "node": ">= 14"
@@ -15894,108 +6781,53 @@
     },
     "node_modules/proxy-agent/node_modules/lru-cache": {
       "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "license": "ISC",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
     },
-    "node_modules/puppeteer-core": {
-      "version": "21.11.0",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@puppeteer/browsers": "1.9.1",
-        "chromium-bidi": "0.5.8",
-        "cross-fetch": "4.0.0",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.1232444",
-        "ws": "8.16.0"
-      },
-      "engines": {
-        "node": ">=16.13.2"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/debug": {
-      "version": "4.3.4",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/devtools-protocol": {
-      "version": "0.0.1232444",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/puppeteer-core/node_modules/ms": {
-      "version": "2.1.2",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.16.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/query-selector-shadow-dom": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
       "license": "MIT"
     },
     "node_modules/react-is-18": {
       "name": "react-is",
       "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
     "node_modules/react-is-19": {
       "name": "react-is",
       "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "license": "MIT"
     },
     "node_modules/read-pkg": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-8.1.0.tgz",
+      "integrity": "sha512-PORM8AgzXeskHO/WEv312k9U03B8K9JSiWF/8N9sUuFjBa+9SF2u6K7VClzXwDXab51jCd8Nd36CNM+zR97ScQ==",
       "license": "MIT",
       "dependencies": {
         "@types/normalize-package-data": "^2.4.1",
@@ -16012,6 +6844,8 @@
     },
     "node_modules/read-pkg-up": {
       "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-10.1.0.tgz",
+      "integrity": "sha512-aNtBq4jR8NawpKJQldrQcSW9y/d+KWH4v24HWkHljOZ7H0av+YTGANBzRh9A5pw7v/bLVsLVPpOhJ7gHNVy8lA==",
       "license": "MIT",
       "dependencies": {
         "find-up": "^6.3.0",
@@ -16027,6 +6861,8 @@
     },
     "node_modules/read-pkg-up/node_modules/find-up": {
       "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
       "license": "MIT",
       "dependencies": {
         "locate-path": "^7.1.0",
@@ -16041,6 +6877,8 @@
     },
     "node_modules/read-pkg-up/node_modules/locate-path": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
       "license": "MIT",
       "dependencies": {
         "p-locate": "^6.0.0"
@@ -16054,6 +6892,8 @@
     },
     "node_modules/read-pkg-up/node_modules/p-limit": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.0.0"
@@ -16067,6 +6907,8 @@
     },
     "node_modules/read-pkg-up/node_modules/p-locate": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
       "license": "MIT",
       "dependencies": {
         "p-limit": "^4.0.0"
@@ -16080,6 +6922,8 @@
     },
     "node_modules/read-pkg-up/node_modules/path-exists": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -16087,6 +6931,8 @@
     },
     "node_modules/read-pkg-up/node_modules/yocto-queue": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
@@ -16095,8 +6941,70 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-pkg/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-pkg/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/readdir-glob": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.1.0"
@@ -16104,6 +7012,8 @@
     },
     "node_modules/readdir-glob/node_modules/minimatch": {
       "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -16114,6 +7024,8 @@
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -16125,6 +7037,8 @@
     },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
+      "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
       "license": "MIT",
       "dependencies": {
         "minimatch": "^3.0.5"
@@ -16135,6 +7049,8 @@
     },
     "node_modules/recursive-readdir/node_modules/brace-expansion": {
       "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -16143,6 +7059,8 @@
     },
     "node_modules/recursive-readdir/node_modules/minimatch": {
       "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -16153,10 +7071,14 @@
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
       "license": "MIT"
     },
     "node_modules/regenerate-unicode-properties": {
       "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
+      "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
       "license": "MIT",
       "dependencies": {
         "regenerate": "^1.4.2"
@@ -16167,6 +7089,8 @@
     },
     "node_modules/regexpu-core": {
       "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
+      "integrity": "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==",
       "license": "MIT",
       "dependencies": {
         "regenerate": "^1.4.2",
@@ -16182,10 +7106,14 @@
     },
     "node_modules/regjsgen": {
       "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
       "license": "MIT"
     },
     "node_modules/regjsparser": {
       "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "jsesc": "~3.1.0"
@@ -16196,6 +7124,8 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16203,6 +7133,8 @@
     },
     "node_modules/resolve": {
       "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -16222,6 +7154,8 @@
     },
     "node_modules/resq": {
       "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resq/-/resq-1.11.0.tgz",
+      "integrity": "sha512-G10EBz+zAAy3zUd/CDoBbXRL6ia9kOo3xRHrMDsHljI0GDkhYlyjwoCx5+3eCC4swi1uCoZQhskuJkj7Gp57Bw==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^2.0.1"
@@ -16229,6 +7163,8 @@
     },
     "node_modules/ret": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -16236,10 +7172,14 @@
     },
     "node_modules/rgb2hex": {
       "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.5.tgz",
+      "integrity": "sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw==",
       "license": "MIT"
     },
     "node_modules/run-async": {
       "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
+      "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -16247,13 +7187,26 @@
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/safaridriver": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.1.tgz",
+      "integrity": "sha512-jkg4434cYgtrIF2AeY/X0Wmd2W73cK5qIEFE3hDrrQenJH/2SDJIXGvPAigfvQTcE9+H31zkiNHbUqcihEiMRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",
@@ -16272,6 +7225,8 @@
     },
     "node_modules/safe-regex2": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
       "funding": [
         {
           "type": "github",
@@ -16292,17 +7247,38 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/serialize-error": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-12.0.0.tgz",
+      "integrity": "sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.31.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"
@@ -16310,10 +7286,14 @@
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.2"
@@ -16324,6 +7304,8 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -16334,6 +7316,8 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16341,6 +7325,8 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -16351,6 +7337,8 @@
     },
     "node_modules/slash": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16358,6 +7346,8 @@
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
@@ -16365,10 +7355,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -16378,6 +7370,8 @@
     },
     "node_modules/socks-proxy-agent": {
       "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -16390,6 +7384,8 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -16397,6 +7393,8 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -16405,6 +7403,8 @@
     },
     "node_modules/spacetrim": {
       "version": "0.11.59",
+      "resolved": "https://registry.npmjs.org/spacetrim/-/spacetrim-0.11.59.tgz",
+      "integrity": "sha512-lLYsktklSRKprreOm7NXReW8YiX2VBjbgmXYEziOoGf/qsJqAEACaDvoTtUOycwjpaSh+bT8eu0KrJn7UNxiCg==",
       "funding": [
         {
           "type": "individual",
@@ -16419,6 +7419,8 @@
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
@@ -16427,10 +7429,14 @@
     },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "license": "MIT",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
@@ -16439,10 +7445,14 @@
     },
     "node_modules/spdx-license-ids": {
       "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "license": "CC0-1.0"
     },
     "node_modules/split2": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -16450,6 +7460,8 @@
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -16460,6 +7472,8 @@
     },
     "node_modules/stack-utils/node_modules/escape-string-regexp": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16467,6 +7481,8 @@
     },
     "node_modules/stream-buffers": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.3.tgz",
+      "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==",
       "license": "Unlicense",
       "engines": {
         "node": ">= 0.10.0"
@@ -16474,6 +7490,8 @@
     },
     "node_modules/streamx": {
       "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -16483,26 +7501,35 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
-      "version": "4.2.3",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -16513,18 +7540,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -16535,6 +7560,8 @@
     },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -16549,6 +7576,8 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -16559,6 +7588,8 @@
     },
     "node_modules/strip-ansi/node_modules/ansi-regex": {
       "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -16569,6 +7600,8 @@
     },
     "node_modules/strip-final-newline": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -16579,6 +7612,8 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16587,8 +7622,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -16602,6 +7651,8 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -16612,6 +7663,8 @@
     },
     "node_modules/tar-fs": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
@@ -16623,37 +7676,39 @@
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.1.7",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
       }
     },
     "node_modules/teex": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "streamx": "^2.12.5"
       }
     },
     "node_modules/text-decoder": {
       "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
       }
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/tinyrainbow": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -16661,6 +7716,8 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -16669,18 +7726,16 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.22.1",
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"
@@ -16697,6 +7752,8 @@
     },
     "node_modules/type-fest": {
       "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -16705,29 +7762,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/unbzip2-stream": {
-      "version": "1.4.3",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
-      }
-    },
     "node_modules/undici": {
-      "version": "7.25.0",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+      "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -16735,6 +7788,8 @@
     },
     "node_modules/unicode-match-property-ecmascript": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
       "license": "MIT",
       "dependencies": {
         "unicode-canonical-property-names-ecmascript": "^2.0.0",
@@ -16746,6 +7801,8 @@
     },
     "node_modules/unicode-match-property-value-ecmascript": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
+      "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -16753,6 +7810,8 @@
     },
     "node_modules/unicode-property-aliases-ecmascript": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
+      "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -16760,6 +7819,8 @@
     },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -16770,6 +7831,8 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "funding": [
         {
           "type": "opencollective",
@@ -16797,11 +7860,15 @@
       }
     },
     "node_modules/urlpattern-polyfill": {
-      "version": "10.0.0",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
       "license": "MIT"
     },
     "node_modules/userhome": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.1.tgz",
+      "integrity": "sha512-5cnLm4gseXjAclKowC4IjByaGsjtAoV6PrOQOljplNB54ReUYJP8HdAFq2muHinSDAh09PPX/uXDPfdxRHvuSA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -16809,10 +7876,14 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-correct": "^3.0.0",
@@ -16821,6 +7892,8 @@
     },
     "node_modules/wait-port": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.1.0.tgz",
+      "integrity": "sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -16834,8 +7907,25 @@
         "node": ">=10"
       }
     },
+    "node_modules/wait-port/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/wait-port/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -16850,6 +7940,8 @@
     },
     "node_modules/wait-port/node_modules/commander": {
       "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || >=14"
@@ -16857,6 +7949,8 @@
     },
     "node_modules/wait-port/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -16867,20 +7961,85 @@
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true
+    "node_modules/webdriver": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.27.1.tgz",
+      "integrity": "sha512-vr6h+RNQ75O2cofgVrdupGxtKjPEBaBYx/lHCHe0giJfAK01oL0U/yrOksJi7kmpev/daN93ldFPhlIlmWtv8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0",
+        "@types/ws": "^8.5.3",
+        "@wdio/config": "9.27.1",
+        "@wdio/logger": "9.18.0",
+        "@wdio/protocols": "9.27.1",
+        "@wdio/types": "9.27.1",
+        "@wdio/utils": "9.27.1",
+        "deepmerge-ts": "^7.0.3",
+        "https-proxy-agent": "^7.0.6",
+        "undici": "^6.21.3",
+        "ws": "^8.8.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/webdriverio": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.27.1.tgz",
+      "integrity": "sha512-iPaIU/DluYY7zfLiwXDdoLU/6ZW8eup4PNwQikrCzTfvH/ITllRhFUe6NRDTEEePSxxRTeXAn9nehCs98xWGVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.11.30",
+        "@types/sinonjs__fake-timers": "^8.1.5",
+        "@wdio/config": "9.27.1",
+        "@wdio/logger": "9.18.0",
+        "@wdio/protocols": "9.27.1",
+        "@wdio/repl": "9.16.2",
+        "@wdio/types": "9.27.1",
+        "@wdio/utils": "9.27.1",
+        "archiver": "^7.0.1",
+        "aria-query": "^5.3.0",
+        "cheerio": "^1.0.0-rc.12",
+        "css-shorthand-properties": "^1.1.1",
+        "css-value": "^0.0.1",
+        "grapheme-splitter": "^1.0.4",
+        "htmlfy": "^0.8.1",
+        "is-plain-obj": "^4.1.0",
+        "jszip": "^3.10.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.zip": "^4.2.0",
+        "query-selector-shadow-dom": "^1.0.1",
+        "resq": "^1.11.0",
+        "rgb2hex": "0.2.5",
+        "serialize-error": "^12.0.0",
+        "urlpattern-polyfill": "^10.0.0",
+        "webdriver": "9.27.1"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      },
+      "peerDependencies": {
+        "puppeteer-core": ">=22.x || <=24.x"
+      },
+      "peerDependenciesMeta": {
+        "puppeteer-core": {
+          "optional": true
+        }
+      }
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -16891,6 +8050,8 @@
     },
     "node_modules/whatwg-encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -16901,27 +8062,38 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
       "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/workerpool": {
       "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
       "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -16935,6 +8107,8 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -16948,8 +8122,45 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -16958,8 +8169,45 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -16970,10 +8218,14 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -16993,6 +8245,8 @@
     },
     "node_modules/xml-naming": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
       "funding": [
         {
           "type": "github",
@@ -17006,6 +8260,8 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -17013,10 +8269,14 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -17033,6 +8293,8 @@
     },
     "node_modules/yargs-parser": {
       "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -17040,6 +8302,8 @@
     },
     "node_modules/yargs-unparser": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "^6.0.0",
@@ -17053,6 +8317,8 @@
     },
     "node_modules/yargs-unparser/node_modules/decamelize": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -17063,13 +8329,49 @@
     },
     "node_modules/yargs-unparser/node_modules/is-plain-obj": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/yargs/node_modules/yargs-parser": {
       "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -17077,6 +8379,8 @@
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
@@ -17085,6 +8389,8 @@
     },
     "node_modules/yauzl/node_modules/buffer-crc32": {
       "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -17092,6 +8398,8 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -17102,6 +8410,8 @@
     },
     "node_modules/yoctocolors": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -17112,6 +8422,8 @@
     },
     "node_modules/yoctocolors-cjs": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -17122,6 +8434,8 @@
     },
     "node_modules/zip-stream": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
       "license": "MIT",
       "dependencies": {
         "archiver-utils": "^5.0.0",
@@ -17130,42 +8444,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/zip-stream/node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/zip-stream/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes two Dependabot alerts by updating stale lockfiles:
1. **json5 Prototype Pollution (CVE-2022-46175)** — `plugin/a11y/package-lock.json`
2. **tmp arbitrary file write (GHSA-52f5-9888-hmc6)** — `package-lock.json`

## Root Causes

### json5@0.5.1 in a11y lockfile
The a11y `package-lock.json` was stale and still resolved `babel-register` → `babel-core` → `json5@0.5.1` from the ftest package. Since `babel-register` was removed from ftest in Round 2 (#3168), regenerating the lockfile eliminates the vulnerable dependency entirely.

### tmp@0.2.3 in root lockfile
The root `package-lock.json` recorded `tmp@0.2.3` for the ftest workspace sub-tree despite the override specifying `^0.2.4`. Updated the lockfile entry to `tmp@0.2.5` which is what npm actually installs.

## Changes

- Regenerated `plugin/a11y/package-lock.json` (drops json5@0.5.1, babel-core, babel-register)
- Updated `packages/nuxeo-web-ui-ftest/node_modules/tmp` entry in root lockfile from 0.2.3 → 0.2.5

## Verification

```
$ cd plugin/a11y && npm audit → found 0 vulnerabilities
$ npm audit → 7 vulnerabilities (all from @open-wc/karma-esm chain, unfixable without migration)
```