### PR TITLE
WEBUI-2038: Remove stale tmp@0.2.3 from root lockfile (GHSA-52f5-9888-hmc6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25785,16 +25785,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "packages/nuxeo-web-ui-ftest/node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "packages/nuxeo-web-ui-ftest/node_modules/toposort": {
       "version": "2.0.2",
       "dev": true,


### PR DESCRIPTION
## Summary

Removes the stale `packages/nuxeo-web-ui-ftest/node_modules/tmp` entry from the root `package-lock.json` to eliminate the Dependabot alert for GHSA-52f5-9888-hmc6 (tmp arbitrary file/directory write via symlink).

## Problem

The root lockfile had a nested entry pinning `tmp@0.2.3` for the ftest workspace sub-tree. Despite the `"tmp": "^0.2.4"` override in both root and ftest `package.json`, npm was not updating this lockfile entry (npm limitation with `file:` linked packages).

## Fix

Removed the 10-line stale entry entirely. With it gone, npm correctly hoists `tmp@0.2.5` from root `node_modules/` (via the override). 

**Verified stable**: After removal, subsequent `rm -rf node_modules && npm install` cycles do NOT recreate the ftest sub-tree entry — npm continues to use the hoisted 0.2.5.

## Result

```
$ npm audit | grep tmp → (no matches)
$ npm audit → 7 vulnerabilities (all from @open-wc/karma-esm, unfixable without migration)
```