### PR TITLE
WEBUI-2038: Fix minimatch ReDoS via scoped override for replace package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4754,21 +4754,21 @@
       }
     },
     "node_modules/@nuxeo/nuxeo-dataviz-elements": {
-      "version": "3.1.31-rc.2",
-      "resolved": "https://packages.nuxeo.com/repository/npm-public/@nuxeo/nuxeo-dataviz-elements/-/nuxeo-dataviz-elements-3.1.31-rc.2.tgz",
-      "integrity": "sha512-8VTvdULrqNjwSlSsiewAGNdaVUwSeY3mbjRdMgeFBcuxD92iK7203/5RbvwglWFWsS58UIOXLFwguvkAWcmLjg==",
+      "version": "3.1.31-rc.3",
+      "resolved": "https://packages.nuxeo.com/repository/npm-public/@nuxeo/nuxeo-dataviz-elements/-/nuxeo-dataviz-elements-3.1.31-rc.3.tgz",
+      "integrity": "sha512-yZ4x5WirkWv8+yEC12/ct8J6cTK0C6O6XCsKVRH1TCNiEY2DA1wCcVsYdqBDqp/uLMpA4JJof9ECkCjPjsI/ew==",
       "license": "Apache-2.0",
       "dependencies": {
         "@nuxeo/moment": "2.30.1-nx.1",
-        "@nuxeo/nuxeo-elements": "^3.1.31-rc.2",
+        "@nuxeo/nuxeo-elements": "^3.1.31-rc.3",
         "@polymer/polymer": "^3.0.0",
         "moment": "2.30.1"
       }
     },
     "node_modules/@nuxeo/nuxeo-elements": {
-      "version": "3.1.31-rc.2",
-      "resolved": "https://packages.nuxeo.com/repository/npm-public/@nuxeo/nuxeo-elements/-/nuxeo-elements-3.1.31-rc.2.tgz",
-      "integrity": "sha512-TD+G7VBHpus4BaH/YuBfoSpIvxeRAuxzyN7xnpRPouV7y0YfcRrVSbju9Es5PIaWStNWenFv/UI2Ag7tMqzwZg==",
+      "version": "3.1.31-rc.3",
+      "resolved": "https://packages.nuxeo.com/repository/npm-public/@nuxeo/nuxeo-elements/-/nuxeo-elements-3.1.31-rc.3.tgz",
+      "integrity": "sha512-q5HLhF3gBqBfTeq4K5z/gFD8KycKQ9mfMC56yxoakDqAzcI0EhLcPgwEdAdjKjeva47JlLPb7XYEM/aANuHyBA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
@@ -4777,13 +4777,13 @@
       }
     },
     "node_modules/@nuxeo/nuxeo-ui-elements": {
-      "version": "3.1.31-rc.2",
-      "resolved": "https://packages.nuxeo.com/repository/npm-public/@nuxeo/nuxeo-ui-elements/-/nuxeo-ui-elements-3.1.31-rc.2.tgz",
-      "integrity": "sha512-g2WH0SOu6MmWne/xcOir+7SVkNPxbYPal0LT4h750YZX782TTsu+gkUQUlbstqcMWJiemxVmGve8f2Lscyf+gQ==",
+      "version": "3.1.31-rc.3",
+      "resolved": "https://packages.nuxeo.com/repository/npm-public/@nuxeo/nuxeo-ui-elements/-/nuxeo-ui-elements-3.1.31-rc.3.tgz",
+      "integrity": "sha512-AtykvXtzJJ0oDafWqCn1SR5CKIfExO/EFho0x+pZGy1cvQpsJCcV52DEEubgXyDTsign3YejDJbP6bomu8AFEg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@nuxeo/moment": "2.30.1-nx.1",
-        "@nuxeo/nuxeo-elements": "^3.1.31-rc.2",
+        "@nuxeo/nuxeo-elements": "^3.1.31-rc.3",
         "@nuxeo/paper-typeahead": "^0.6.0-nx.0",
         "@nuxeo/quill": "^2.0.0-dev.3-nx.3",
         "@polymer/iron-autogrow-textarea": "^3.0.1",
@@ -4882,9 +4882,9 @@
       }
     },
     "node_modules/@nuxeo/testing-helpers": {
-      "version": "3.1.31-rc.2",
-      "resolved": "https://packages.nuxeo.com/repository/npm-public/@nuxeo/testing-helpers/-/testing-helpers-3.1.31-rc.2.tgz",
-      "integrity": "sha512-607A/aI/FXzbmI104wBDms8bdn4PEnWu4aErkXjq7+QOPO7SYLArmzqZotzBUQBlR0JHVI+cDbsHlcMYpgGq7A==",
+      "version": "3.1.31-rc.3",
+      "resolved": "https://packages.nuxeo.com/repository/npm-public/@nuxeo/testing-helpers/-/testing-helpers-3.1.31-rc.3.tgz",
+      "integrity": "sha512-veHHX3FGOsWUPP7QHd1MrvWpubto4JGoVPdcjMy1OYI3eeZtlBoSuSN9zjrCiP6jMmy2/L5Z6zSBafhuDF5P4Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13282,9 +13282,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.6",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.0.tgz",
+      "integrity": "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23210,19 +23210,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/replace/node_modules/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/replace/node_modules/p-locate": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
@@ -26984,9 +26971,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.1.tgz",
-      "integrity": "sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
+      "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "uuid": "$uuid",
     "request": {
       "uuid": "^3.4.0"
+    },
+    "replace": {
+      "minimatch": "^3.1.4"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Fixes the minimatch ReDoS vulnerability (GHSA-f8q6-p94x-37v3) introduced via `replace@1.2.2 → minimatch@3.0.5`.

## Problem

`replace@1.2.2` (latest version, unmaintained) pins an exact dependency on `minimatch: "3.0.5"`, which is vulnerable to Regular Expression Denial of Service (ReDoS).

A previous global override (`"minimatch": "^3.1.4"`) was removed in #3178 because it broke `eslint-plugin-import-x` which requires minimatch v9+ (ESM).

## Fix

Adds a **scoped** npm override that only targets the `replace` package:

```json
"replace": {
  "minimatch": "^3.1.4"
}
```

This forces `replace` to use `minimatch@3.1.5` (patched) while leaving all other minimatch consumers (including eslint's minimatch v9+) untouched.

## Verification

- `npm ls minimatch` shows `replace@1.2.2 overridden → minimatch@3.1.5`
- `npm run lint` passes (eslint-plugin-import-x still works)
- No functional changes