### PR TITLE
WEBUI-2038: fix search ftest flakiness and cascade failures

### DIFF
--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/search.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/search.js
@@ -128,7 +128,18 @@ When(/^I clear the (.+) search on (.+)$/, async function (searchType, searchName
 When(/^I perform a (.+) search for (.+) on (.+)$/, async function (searchType, searchTerm, searchName) {
   const searchForm = await this.ui.searchForm(searchName);
   await searchForm.waitForVisible();
-  await driver.pause(1000);
+  // Wait for the form's internal elements to be ready (shadow DOM rendering)
+  await driver.waitUntil(
+    async () => {
+      try {
+        const el = await searchForm.el;
+        return el && (await el.isDisplayed());
+      } catch (e) {
+        return false;
+      }
+    },
+    { timeout: 10000, interval: 500 },
+  );
   await searchForm.search(searchType, searchTerm);
 });
 

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/support/browser_reset.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/support/browser_reset.js
@@ -1,0 +1,54 @@
+import { After, Status } from '@cucumber/cucumber';
+
+/**
+ * After each scenario, ensure the browser is in a clean state so that failures
+ * in one scenario/feature do not cascade to subsequent ones.
+ *
+ * Runs BEFORE other After hooks (order: higher = earlier in Cucumber).
+ * Dismisses stale alerts, clears session storage, and navigates to the login
+ * page so the next scenario starts from a known baseline.
+ */
+After({ order: 10000 }, async (scenario) => {
+  const { status } = scenario.result;
+  if (status !== Status.PASSED) {
+    // Dismiss any open alert/confirm/prompt dialogs that block further navigation
+    try {
+      await browser.dismissAlert();
+    } catch (e) {
+      // No alert open — expected in most cases
+    }
+
+    // Clear session storage to avoid stale client-side state
+    try {
+      await browser.execute(() => {
+        try {
+          window.sessionStorage.clear();
+        } catch (err) {
+          // cross-origin or restricted context
+        }
+      });
+    } catch (e) {
+      // page may be unresponsive
+    }
+
+    // Navigate to logout to reset server session, ensuring a fresh login for the next scenario
+    try {
+      const baseUrl = process.env.NUXEO_URL || '';
+      const logoutUrl = baseUrl ? `${baseUrl}/logout` : 'logout';
+      await browser.url(logoutUrl);
+      // Give the server a moment to process the logout
+      await browser.waitUntil(async () => !(await browser.$$('nuxeo-app')).length, {
+        timeout: 10000,
+        interval: 500,
+      });
+    } catch (e) {
+      // If navigation itself fails, try a hard reload as last resort
+      try {
+        await browser.reloadSession();
+        await browser.maximizeWindow();
+      } catch (err) {
+        // Nothing more we can do
+      }
+    }
+  }
+});

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/ui.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/ui.js
@@ -1,10 +1,8 @@
 import { Then, When } from '@cucumber/cucumber';
 
 When('I click the {string} button', async function (button) {
-  await driver.pause(1000);
   const drawer = await this.ui.drawer;
-  const buttonToclick = await drawer.open(button);
-  return buttonToclick;
+  await drawer.open(button);
 });
 
 When('I select {string} from the View menu', async function (option) {

--- a/packages/nuxeo-web-ui-ftest/pages/ui/drawer.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/drawer.js
@@ -76,6 +76,17 @@ export default class Drawer extends BasePage {
       const menu = await this.menu;
       const buttonToclick = await menu.$(`nuxeo-menu-icon[name='${name}']`);
       await buttonToclick.click();
+      // Wait for the opened panel to be visible after the click
+      await driver.waitUntil(
+        async () => {
+          try {
+            return await section.isDisplayed();
+          } catch (e) {
+            return false;
+          }
+        },
+        { timeout: 10000, interval: 500, timeoutMsg: `Drawer section "${name}" did not become visible after click` },
+      );
     }
     return section;
   }


### PR DESCRIPTION
## Summary

Fixes search.feature flakiness and prevents cascading failures to subsequent features when search.feature fails.

## Root Cause

1. **`drawer.open()` returned immediately after clicking** the menu icon without waiting for the panel to be visible, causing race conditions where subsequent steps tried to interact with elements not yet rendered.
2. **Arbitrary `driver.pause(1000)` calls** were not sufficient for CI environments where rendering is slower.
3. **No browser state cleanup between scenarios** meant a failed scenario left the browser in a corrupted state (open alerts, stale session, broken page), causing all subsequent features to fail at setup.

## Changes

### `packages/nuxeo-web-ui-ftest/pages/ui/drawer.js`
- `drawer.open()` now waits up to 10s for the panel section to be displayed after clicking, with proper error handling for shadow DOM elements.

### `packages/nuxeo-web-ui-ftest/features/step_definitions/ui.js`
- Removed arbitrary 1s pause from "I click the X button" step; `drawer.open()` now handles waiting deterministically.

### `packages/nuxeo-web-ui-ftest/features/step_definitions/search.js`
- Replaced static 1s pause with `driver.waitUntil` that verifies the search form element is rendered and displayed in shadow DOM before interacting with it.

### `packages/nuxeo-web-ui-ftest/features/step_definitions/support/browser_reset.js` (new)
- Adds a Cucumber `After` hook (high order = runs first) that on non-passing scenarios:
  - Dismisses any open alert/confirm/prompt dialogs
  - Clears `sessionStorage`
  - Navigates to `/logout` to reset server session
  - Falls back to `browser.reloadSession()` if navigation fails
- This ensures subsequent scenarios always start from a clean state.

## Impact

- Fixes the immediate `search.feature` timeout by ensuring panels are ready before interaction
- Prevents cascade failures (spreadsheet, tasks, trash, upload, user, user_cloud, validation, versions, video all failing after search)