### PR TITLE
WEBUI-2083: First Tab escapes an open modal to the "Skip to main content" link [LTS-2023]

### DIFF
--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -935,11 +935,20 @@ Polymer({
     let skipLinkActivated = true; // only active once after load/top
 
     const handleFirstTab = (e) => {
-      if (skipLinkActivated && e.key === 'Tab') {
-        skipLinkActivated = false; // deactivate until page cycle resets
-        e.preventDefault();
-        skipLink.focus({ preventScroll: true });
+      if (!skipLinkActivated || e.key !== 'Tab') {
+        return;
       }
+      // Another handler (e.g. a modal/overlay focus trap such as nuxeo-dialog, which runs in the
+      // capture phase) already handled this Tab to keep focus inside the dialog. Consume the
+      // first-tab state instead of jumping to the skip link, otherwise the jump is merely deferred
+      // to the next Tab and focus escapes the modal to the background skip link.
+      if (e.defaultPrevented) {
+        skipLinkActivated = false;
+        return;
+      }
+      skipLinkActivated = false; // deactivate until page cycle resets
+      e.preventDefault();
+      skipLink.focus({ preventScroll: true });
     };
 
     // Activate skip link only once after load

--- a/test/nuxeo-app.test.js
+++ b/test/nuxeo-app.test.js
@@ -1433,6 +1433,75 @@ suite('nuxeo-app', () => {
       scrollSpy.restore();
     });
 
+    // Capture the first-Tab keydown handler that skipLinkEvent registers on document,
+    // so it can be exercised in isolation without dispatching real events on the shared
+    // document (where stale listeners from other fixtures would interfere).
+    const captureFirstTabHandler = () => {
+      let handler;
+      const addEventListener = sinon.stub(document, 'addEventListener').callsFake((type, fn, opts) => {
+        if (type === 'keydown' && !handler) {
+          handler = fn;
+        }
+        return addEventListener.wrappedMethod.call(document, type, fn, opts);
+      });
+      app.skipLinkEvent();
+      addEventListener.restore();
+      return handler;
+    };
+
+    test('skipLinkEvent focuses the skip link on the first Tab after load', () => {
+      const { skipLink } = app.$;
+      if (!skipLink) {
+        return;
+      }
+      const handleFirstTab = captureFirstTabHandler();
+      const focusSpy = sinon.spy(skipLink, 'focus');
+      const event = { key: 'Tab', defaultPrevented: false, preventDefault: sinon.spy() };
+      handleFirstTab(event);
+      expect(event.preventDefault).to.have.been.called;
+      expect(focusSpy).to.have.been.calledWith({ preventScroll: true });
+      // The handler deactivates after the first Tab: a second Tab is a no-op.
+      const second = { key: 'Tab', defaultPrevented: false, preventDefault: sinon.spy() };
+      handleFirstTab(second);
+      expect(second.preventDefault).to.not.have.been.called;
+      expect(focusSpy).to.have.been.calledOnce;
+      focusSpy.restore();
+    });
+
+    test('skipLinkEvent keeps focus in the modal when the Tab was already handled', () => {
+      const { skipLink } = app.$;
+      if (!skipLink) {
+        return;
+      }
+      const handleFirstTab = captureFirstTabHandler();
+      const focusSpy = sinon.spy(skipLink, 'focus');
+      // A capture-phase focus trap (e.g. nuxeo-dialog) already called preventDefault.
+      const event = { key: 'Tab', defaultPrevented: true, preventDefault: sinon.spy() };
+      handleFirstTab(event);
+      expect(event.preventDefault).to.not.have.been.called;
+      expect(focusSpy).to.not.have.been.called;
+      // The first-tab state is consumed, so a later un-prevented Tab does not jump either.
+      const next = { key: 'Tab', defaultPrevented: false, preventDefault: sinon.spy() };
+      handleFirstTab(next);
+      expect(next.preventDefault).to.not.have.been.called;
+      expect(focusSpy).to.not.have.been.called;
+      focusSpy.restore();
+    });
+
+    test('skipLinkEvent ignores keys other than Tab', () => {
+      const { skipLink } = app.$;
+      if (!skipLink) {
+        return;
+      }
+      const handleFirstTab = captureFirstTabHandler();
+      const focusSpy = sinon.spy(skipLink, 'focus');
+      const event = { key: 'Enter', defaultPrevented: false, preventDefault: sinon.spy() };
+      handleFirstTab(event);
+      expect(event.preventDefault).to.not.have.been.called;
+      expect(focusSpy).to.not.have.been.called;
+      focusSpy.restore();
+    });
+
     test('logoToMenuNavigation moves focus from last item to logo on ArrowDown', () => {
       const logo = app.$.logo;
       const menu = app.$.menu;


### PR DESCRIPTION
## Summary

Keeps keyboard focus inside modal `nuxeo-dialog`s on the first Tab after a page load, instead of escaping to the background "Skip to main content" link.

## Problem

The app's skip-link accessibility feature (`handleFirstTab` in `nuxeo-app.js`) focuses the background skip link on the first Tab after page load. When a modal dialog is open (e.g. the create-document modal, or any modal opened from the document-actions overflow "three-dot" menu), this overrode the dialog's focus trap, so the first Tab landed on the background skip link instead of the first focusable element inside the modal.

## Fix

`handleFirstTab` now bails out and *consumes* its first-tab state when another handler has already handled the Tab (`e.defaultPrevented`). The `nuxeo-dialog` focus trap (nuxeo-elements#1427) runs in the capture phase and calls `preventDefault()` to keep focus inside the dialog; respecting `defaultPrevented` in the bubble-phase skip-link handler means focus stays trapped in the modal. Consuming the state (rather than merely returning) prevents the skip-link jump from being deferred to the next Tab.

## Related

- nuxeo/nuxeo-elements#1427 (ELEMENTS-1948: dialog focus trap, LTS-2023)