### PR TITLE
WEBUI-2094: fix node-fetch v2 "Premature close" on Node >= 19

### DIFF
--- a/packages/nuxeo-web-ui-ftest/package-lock.json
+++ b/packages/nuxeo-web-ui-ftest/package-lock.json
@@ -28,7 +28,6 @@
         "mkdirp": "^0.5.1",
         "moment": "^2.29.4",
         "multiple-cucumber-html-reporter": "^3.10.0",
-        "node-fetch": "^2.6.1",
         "nuxeo": "^4.0.3",
         "wdio-cucumberjs-json-reporter": "6.0.1",
         "webdriverio": "9.27.1"

--- a/packages/nuxeo-web-ui-ftest/package.json
+++ b/packages/nuxeo-web-ui-ftest/package.json
@@ -38,7 +38,6 @@
     "mkdirp": "^0.5.1",
     "moment": "^2.29.4",
     "multiple-cucumber-html-reporter": "^3.10.0",
-    "node-fetch": "^2.6.1",
     "nuxeo": "^4.0.3",
     "wdio-cucumberjs-json-reporter": "6.0.1",
     "webdriverio": "9.27.1"

--- a/packages/nuxeo-web-ui-ftest/scripts/test.js
+++ b/packages/nuxeo-web-ui-ftest/scripts/test.js
@@ -30,7 +30,6 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import chromeLauncher from 'chrome-launcher';
-import fetch from 'node-fetch';
 import { fileURLToPath } from 'url';
 import minimist from 'minimist';
 const { Launcher: CliLauncher } = await import('@wdio/cli');

--- a/packages/nuxeo-web-ui-ftest/wdio.conf.js
+++ b/packages/nuxeo-web-ui-ftest/wdio.conf.js
@@ -2,9 +2,23 @@ import { fileURLToPath } from 'url';
 import path from 'path';
 import chai from 'chai';
 
+import http from 'http';
+import https from 'https';
 import htmlReporter from 'multiple-cucumber-html-reporter';
 import CompatService from './wdio-compat-plugin.js';
 import ShadowService from './wdio-shadow-plugin.js';
+
+/*
+ * Workaround for node-fetch v2 "Premature close" errors on Node >= 19 (CI runs Node 22).
+ * Since Node 19 the global HTTP/HTTPS agents enable keep-alive by default, so the node-fetch
+ * used by the Nuxeo REST client in step hooks reuses a pooled socket the server has already
+ * closed, which surfaces as `FetchError: ... Premature close`. Forcing keep-alive off makes
+ * each request open a fresh socket.
+ */
+[http.globalAgent, https.globalAgent].forEach((agent) => {
+  agent.keepAlive = false;
+  agent.options.keepAlive = false;
+});
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/plugin/a11y/wdio.conf.js
+++ b/plugin/a11y/wdio.conf.js
@@ -1,5 +1,19 @@
+import http from 'http';
+import https from 'https';
 import CompatService from '@nuxeo/nuxeo-web-ui-ftest/wdio-compat-plugin.js';
 import ShadowService from '@nuxeo/nuxeo-web-ui-ftest/wdio-shadow-plugin.js';
+
+/*
+ * Workaround for node-fetch v2 "Premature close" errors on Node >= 19 (CI runs Node 22).
+ * Since Node 19 the global HTTP/HTTPS agents enable keep-alive by default, so the node-fetch
+ * used by the Nuxeo REST client in `before`/`after` hooks reuses a pooled socket the server has
+ * already closed, which surfaces as `FetchError: ... Premature close`. Forcing keep-alive off
+ * makes each request open a fresh socket.
+ */
+[http.globalAgent, https.globalAgent].forEach((agent) => {
+  agent.keepAlive = false;
+  agent.options.keepAlive = false;
+});
 
 const debug = process.env.DEBUG;
 const debugTimeout = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## Problem

The `ftest` and `a11y` pipelines intermittently fail with:

```
FetchError: Invalid response body while trying to fetch <url>: Premature close
```

This is **not** a network issue. Since **Node 19** the global HTTP/HTTPS agents enable
keep-alive by default, and **node-fetch v2** reuses a pooled socket the peer has already
closed, which surfaces as `Premature close`. CI runs Node 22, and the recent Node `22.23.x`
`http.Agent` change (CVE-2026-48931) altered socket-reuse timing, making this fire across
pipelines simultaneously.

## Changes

- **`packages/nuxeo-web-ui-ftest/wdio.conf.js`** and **`plugin/a11y/wdio.conf.js`**: disable
  keep-alive on the global HTTP/HTTPS agents so each request opens a fresh socket. This is the
  targeted mitigation for the node-fetch used by the `nuxeo` REST client in test hooks.
- **`packages/nuxeo-web-ui-ftest/scripts/test.js`**: drop `node-fetch` in favour of Node's
  built-in global `fetch` (undici), which is not affected by the bug. The two external
  Chrome-version lookups only use `response.ok` / `response.text()`, both natively supported.
- **`packages/nuxeo-web-ui-ftest/package.json`** + **`package-lock.json`**: remove the now-unused
  direct `node-fetch` dependency. It is still pulled in transitively by the `nuxeo` client, so
  the keep-alive workaround remains required until that client moves to native fetch.

## Notes

The keep-alive workaround should stay until `node-fetch` is fully removed from all paths
(upstream `nuxeo` client + the Karma/es-dev-server path in nuxeo-elements, addressed by the
WTR migration).
