### PR TITLE
WEBUI-1571: Fix queue view navigation in multi-repository configuration [lts-2025]

### DIFF
--- a/elements/routing.js
+++ b/elements/routing.js
@@ -57,6 +57,40 @@ function encodeQueryParams(path) {
   return encodepath;
 }
 
+// Returns the name of the repository whose UI context is currently being browsed.
+// In a multi-repository instance the active context is encoded in the path
+// (`.../repo/<name>/ui/`); the default repository is also served from the bare
+// `.../ui/` path, in which case we fall back to the repository flagged as default.
+function currentRepositoryName() {
+  const repositories = (Nuxeo && Nuxeo.UI && Nuxeo.UI.repositories) || [];
+  const current = repositories.find((repo) => repo.href && window.location.pathname.startsWith(repo.href));
+  return (current || repositories.find((repo) => repo.isDefault) || {}).name;
+}
+
+// When reverse routing produces an absolute URL for a document (which happens in
+// multi-repository instances), navigating to it would trigger a full page reload.
+// If that URL targets the repository we are already browsing, return the client-side
+// route (the part after the hashbang) so we can navigate without losing the current
+// search drawer/queue state. Returns null when the URL is external or points to a
+// different repository, where a context switch (full reload) is still required.
+function sameRepositoryClientPath(path) {
+  let url;
+  try {
+    url = new URL(path);
+  } catch (e) {
+    return null;
+  }
+  if (url.origin !== window.location.origin) {
+    return null;
+  }
+  const repositories = (Nuxeo && Nuxeo.UI && Nuxeo.UI.repositories) || [];
+  const target = repositories.find((repo) => repo.href && url.pathname.startsWith(repo.href));
+  if (!target || target.name !== currentRepositoryName()) {
+    return null;
+  }
+  return url.hash.replace(/^#!?/, '') || '/';
+}
+
 function _routeAdmin(selectedAdminTab, errorPath, routeData) {
   const hasPermission =
     app.currentUser.isAdministrator || app.currentUser.extendedGroups.find((grp) => grp.name === 'powerusers');
@@ -226,6 +260,11 @@ app.router = {
     }
     const isFullpath = /^http(s)?:\/\//.test(path);
     if (isFullpath) {
+      const clientPath = sameRepositoryClientPath(path);
+      if (clientPath != null) {
+        page(clientPath);
+        return;
+      }
       const isValidUrl = isTrustedDomain(path);
       if (isValidUrl) {
         const encodepath = encodeQueryParams(path);


### PR DESCRIPTION
## Problem

In a **multi-repository** instance, opening the **Queue View** of a drawer search (which selects and navigates to the first document) triggers a **full page reload**. The reload re-applies the document's repository context in the URL and **discards the search input/results**, forcing the user to re-run the search. The same reload happens every time a document is opened from the drawer.

Jira: [WEBUI-1571](https://hyland.atlassian.net/browse/WEBUI-1571)

## Root cause

Reverse routing (`nuxeo-routing-behavior._routeEntity`) builds an **absolute, repository-scoped** document URL (`https://host/nuxeo/repo/<name>/ui/#!/...`) whenever `Nuxeo.UI.repositories.length > 1` — even when the target document belongs to the repository the user is **already** browsing.

`app.router.navigate` then treats any absolute `http(s)` URL as external and navigates by creating an anchor and clicking it, which is a full page reload (as opposed to the client-side `page()` navigation used for relative paths).

## Changes

* **`elements/routing.js`**: before treating an absolute URL as external, detect whether it targets the repository currently being browsed (resolved from the path `.../repo/<name>/ui/`, falling back to the default repository on the bare `.../ui/` path). If so, navigate **client-side** via `page()` so the search drawer/queue state is preserved. Cross-repository URLs still take the full-reload path (the connection context switch requires it) and external/trusted-domain links are unaffected.

## Test plan

- [x] `npm run lint` (ESLint + Prettier) passes
- [x] `npm test` — all 2236 unit tests pass
- [ ] Functional (multi-repo instance): run default search → click **Queue View** → first document opens with the **Queue View still visible/interactable** and results preserved (no reload)
- [ ] Regression: opening a document that lives in a **different** repository still performs the expected context switch (full reload)

## Notes

Manual functional verification requires a two-repository instance (per the reproduction steps on the ticket), which cannot be exercised by CI unit tests.

Made with [Cursor](https://cursor.com)

[WEBUI-1571]: https://hyland.atlassian.net/browse/WEBUI-1571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ