### PR TITLE
test(ci): trace test names to pinpoint hung unit tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,4 +82,7 @@ jobs:
         # pretest installs Puppeteer Chromium (npm ci --ignore-scripts skips its postinstall).
         # npm test: regenerate barrels, print WTR layout notice, then web-test-runner --coverage.
         # WTR reports "1/1 test files" (load-all-tests.js); Mocha pass/fail counts are individual tests.
+        # WTR_TRACE_TESTS logs "▶ <test>" per test so the last line before a freeze names the hung test.
+        env:
+          WTR_TRACE_TESTS: '1'
         run: npm run test

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "pretest": "puppeteer browsers install chrome",
     "pretest:watch": "puppeteer browsers install chrome",
     "test": "npm run update-coverage-imports && npm run update-test-load-all && node scripts/test/unit/print-test-runner-notice.js && web-test-runner --coverage && node scripts/test/unit/inject-zero-coverage.js",
+    "test:trace": "npm run update-coverage-imports && npm run update-test-load-all && WTR_TRACE_TESTS=1 web-test-runner",
     "test:watch": "npm run update-coverage-imports && npm run update-test-load-all && node scripts/test/unit/print-test-runner-notice.js && web-test-runner --watch"
   },
   "dependencies": {

--- a/test/setup.js
+++ b/test/setup.js
@@ -131,8 +131,17 @@ if (typeof window.suiteSetup === 'function') {
 }
 
 if (typeof window.setup === 'function') {
-  window.setup(() => {
+  window.setup(function _logTestStart() {
     _testRunning = true;
+    // Trace each test as it starts so a synchronous hang (e.g. a Polymer observer recursion that
+    // freezes the event loop) leaves the offending test name as the last line in the streamed
+    // browser logs. Mocha's per-test timeout cannot interrupt a blocked loop, so without this the
+    // run just stalls until testsFinishTimeout with no clue which test froze. Opt-in via
+    // WTR_TRACE_TESTS=1 to avoid noise on normal runs.
+    if (globalThis.__WTR_TRACE_TESTS__ && this.currentTest) {
+      // eslint-disable-next-line no-console
+      console.warn(`▶ ${this.currentTest.fullTitle()}`);
+    }
   });
 }
 

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -32,14 +32,12 @@ const puppeteer = require('puppeteer');
 const rollupIstanbul = require('rollup-plugin-istanbul');
 const istanbulPlugin = fromRollup(rollupIstanbul);
 
-const chromeArgs = [
-  '--disable-gpu',
-  '--no-sandbox',
-  '--disable-dev-shm-usage',
-  '--disable-setuid-sandbox',
-];
+const chromeArgs = ['--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage', '--disable-setuid-sandbox'];
 
 const verbose = process.env.WTR_VERBOSE === '1';
+// Set WTR_TRACE_TESTS=1 to log each test name on start; the last line before a freeze names the
+// hanging test (mocha's timeout cannot interrupt a synchronous event-loop block).
+const traceTests = process.env.WTR_TRACE_TESTS === '1';
 
 const coverageEnabled = process.argv.includes('--coverage');
 
@@ -63,6 +61,8 @@ const appSources = ['elements/**/*.js', 'addons/**/elements/**/*.js'];
 
 export default {
   files: ['test/load-all-tests.js'],
+  testRunnerHtml: (testFramework) =>
+    `<html><head><script>window.__WTR_TRACE_TESTS__ = ${traceTests};</script></head><body><script type="module" src="${testFramework}"></script></body></html>`,
   plugins: [
     nuxeoTestFallbackPlugin(),
     // Istanbul instrumentation (only when --coverage) — instruments app source files so function bodies
@@ -124,6 +124,10 @@ export default {
   browserLogs: true,
   filterBrowserLogs: (log) => {
     if (verbose) {
+      return true;
+    }
+    // Always surface test-start trace lines (WTR_TRACE_TESTS=1) so a hang's last line is the culprit.
+    if (traceTests && (log.args || []).some((arg) => typeof arg === 'string' && arg.startsWith('▶'))) {
       return true;
     }
     // Stringify so we can match against object args (e.g. `{ message: 'No message', status: 404 }`)


### PR DESCRIPTION
## Motivation

A synchronous freeze in a unit test hangs the whole WTR run with no Mocha timeout firing and no indication of which test is the culprit. CI just times out after 15 min with no signal.

## Changes

Adds an opt-in test tracer behind `WTR_TRACE_TESTS=1`:
- `test/setup.js`: in the global `setup` hook, log `▶ <fullTitle>` per test when the flag is set, so the last log line before a hang names the hung test.
- `web-test-runner.config.mjs`: inject `window.__WTR_TRACE_TESTS__` from the env var and allow the `▶` browser logs through `filterBrowserLogs`.
- `package.json`: add `test:trace` script.
- `.github/workflows/test.yaml`: set `WTR_TRACE_TESTS: '1'` on the unit-tests step so a future freeze leaves the culprit as the last log line.

No behavior change when the flag is unset (verified: 0 trace lines off, full trace on; full suite passes).