### PR TITLE
WEBUI-2079: Title column width reduced when all columns are added in document listing [LTS-2025]

### DIFF
--- a/elements/nuxeo-results/nuxeo-document-content.js
+++ b/elements/nuxeo-results/nuxeo-document-content.js
@@ -156,6 +156,7 @@ Polymer({
           field="dc:title"
           sort-by="[[_displaySort(document, 'dc:title')]]"
           filter-by="title"
+          width="300px"
           flex="100"
           filter-expression="$term*"
         >

--- a/elements/nuxeo-results/nuxeo-results.js
+++ b/elements/nuxeo-results/nuxeo-results.js
@@ -1171,8 +1171,7 @@ Polymer({
         // This approach is future-proof: to add support for new customizable column properties,
         // just update the two sections marked with "EXTEND HERE" below.
 
-        // Capture layout-declared width once per column (mirrors hiddenBack). Only attributes
-        // explicitly set in the layout count; column.width's property default ('150px') is ignored.
+        // Remember each column's layout-declared width (from the `width` attribute), captured once.
         view.columns.forEach((column) => {
           if (
             column &&
@@ -1197,7 +1196,10 @@ Polymer({
             case 'order':
               return idx;
             case 'width':
-              return column._declaredWidth !== undefined ? column._declaredWidth : null;
+              if (column._declaredWidth !== undefined) {
+                return column._declaredWidth;
+              }
+              return null;
             case 'filterValue':
               return '';
             default:

--- a/elements/nuxeo-results/nuxeo-results.js
+++ b/elements/nuxeo-results/nuxeo-results.js
@@ -1177,9 +1177,13 @@ Polymer({
             column &&
             column._declaredWidth === undefined &&
             typeof column.hasAttribute === 'function' &&
+            typeof column.getAttribute === 'function' &&
             column.hasAttribute('width')
           ) {
-            column._declaredWidth = column.getAttribute('width');
+            const declaredWidth = column.getAttribute('width');
+            if (declaredWidth) {
+              column._declaredWidth = declaredWidth;
+            }
           }
         });
 

--- a/elements/nuxeo-results/nuxeo-results.js
+++ b/elements/nuxeo-results/nuxeo-results.js
@@ -1200,10 +1200,7 @@ Polymer({
             case 'order':
               return idx;
             case 'width':
-              if (column._declaredWidth !== undefined) {
-                return column._declaredWidth;
-              }
-              return null;
+              return column._declaredWidth || null;
             case 'filterValue':
               return '';
             default:

--- a/elements/nuxeo-results/nuxeo-results.js
+++ b/elements/nuxeo-results/nuxeo-results.js
@@ -1171,6 +1171,19 @@ Polymer({
         // This approach is future-proof: to add support for new customizable column properties,
         // just update the two sections marked with "EXTEND HERE" below.
 
+        // Capture layout-declared width once per column (mirrors hiddenBack). Only attributes
+        // explicitly set in the layout count; column.width's property default ('150px') is ignored.
+        view.columns.forEach((column) => {
+          if (
+            column &&
+            column._declaredWidth === undefined &&
+            typeof column.hasAttribute === 'function' &&
+            column.hasAttribute('width')
+          ) {
+            column._declaredWidth = column.getAttribute('width');
+          }
+        });
+
         /**
          * Returns the default value for a given column property.
          *
@@ -1184,7 +1197,7 @@ Polymer({
             case 'order':
               return idx;
             case 'width':
-              return null;
+              return column._declaredWidth !== undefined ? column._declaredWidth : null;
             case 'filterValue':
               return '';
             default:

--- a/test/nuxeo-results.test.js
+++ b/test/nuxeo-results.test.js
@@ -1490,6 +1490,77 @@ suite('nuxeo-results', () => {
       expect(() => results._applyPrefsToView(null, { any: true })).to.not.throw();
     });
 
+    test('_applyPrefsToView reset preserves layout-declared width attribute (WEBUI-2079)', () => {
+      // Column elements that expose hasAttribute/getAttribute (mimics a real DOM custom element).
+      // Title-like column has an explicit width="300px" attribute; the other has none.
+      // Set current widths to non-default values so view.set is invoked on reset.
+      const titleCol = {
+        hidden: false,
+        order: 0,
+        width: '120px',
+        hasAttribute: (name) => name === 'width',
+        getAttribute: (name) => (name === 'width' ? '300px' : null),
+      };
+      const otherCol = {
+        hidden: false,
+        order: 1,
+        width: '120px',
+        hasAttribute: () => false,
+        getAttribute: () => null,
+      };
+      const view = {
+        columns: [titleCol, otherCol],
+        sortOrder: [],
+        set: sinon.spy(),
+      };
+
+      results._applyPrefsToView(view, {});
+
+      // Declared width is captured on the column with an explicit width attribute only.
+      expect(titleCol._declaredWidth).to.equal('300px');
+      expect(otherCol._declaredWidth).to.be.undefined;
+
+      // Reset writes the captured declared width back; the other column resets to null (unchanged behavior).
+      expect(view.set.calledWith('columns.0.width', '300px')).to.be.true;
+      expect(view.set.calledWith('columns.1.width', null)).to.be.true;
+    });
+
+    test('_applyPrefsToView reset is idempotent and does not re-capture _declaredWidth', () => {
+      let getAttributeCalls = 0;
+      const col = {
+        hidden: false,
+        order: 0,
+        width: '300px',
+        hasAttribute: () => true,
+        getAttribute: () => {
+          getAttributeCalls += 1;
+          return '300px';
+        },
+      };
+      const view = { columns: [col], sortOrder: [], set: sinon.spy() };
+
+      results._applyPrefsToView(view, {});
+      const callsAfterFirst = getAttributeCalls;
+
+      // Mutate width at runtime to simulate a Polymer property change; getAttribute must not be re-read.
+      col.width = '500px';
+      results._applyPrefsToView(view, {});
+
+      expect(getAttributeCalls).to.equal(callsAfterFirst);
+      expect(col._declaredWidth).to.equal('300px');
+    });
+
+    test('_applyPrefsToView reset skips _declaredWidth capture for non-DOM mock columns', () => {
+      // Plain JS mock columns (no hasAttribute) must continue to reset width to null.
+      const col = { hidden: false, order: 0, width: 120 };
+      const view = { columns: [col], sortOrder: [], set: sinon.spy() };
+
+      expect(() => results._applyPrefsToView(view, {})).to.not.throw();
+
+      expect(col._declaredWidth).to.be.undefined;
+      expect(view.set.calledWith('columns.0.width', null)).to.be.true;
+    });
+
     test('_debounceSave stores debouncer object', () => {
       results._debounceSave('_prefsSaveDebouncer', () => {});
       expect(results._prefsSaveDebouncer).to.exist;


### PR DESCRIPTION
## Summary

LTS-2025 forward-port of [#3270](https://github.com/nuxeo/nuxeo-web-ui/pull/3270). Restores a usable Title column width in the default Folderish content view when all 12 columns are enabled.

## Root cause

Two upstream changes combined into this regression in 3.1.29:

1. **ELEMENTS-1735** raised the `data-table-column` default `width` from `100px` → `150px`.
2. **ELEMENTS-1918 / WEBUI-1759** introduced column-preference persistence (`width`/`order`/`hidden` saved to `/preferences` + localStorage).

The empty-prefs reset path in `_applyPrefsToView` (introduced with the preservation feature) resets every column width to `null`. With `width=null`, the cell falls back to the host CSS default (`flex: 1 0 120px`, `flex-shrink: 0`). With 12 columns × 120 px basis ≈ 1440 px on viewports that cannot fit it, the table overflows horizontally and the Title column is pinned to its basis with no leftover space to grow into, regardless of `flex=100`.

## Fix

Two minimal, scoped changes (clean cherry-pick from the LTS-2023 branch):

1. **`elements/nuxeo-results/nuxeo-document-content.js`** — declare `width="300px"` on the Title column. Cell takes the declarative-width branch (`flex-basis: 300px; flex-grow: 100; flex-shrink: ''`), so Title is at least 300 px wide.
2. **`elements/nuxeo-results/nuxeo-results.js`** — in `_applyPrefsToView`, capture each column's layout-declared `width` attribute once into `column._declaredWidth` (mirrors the existing `hiddenBack` pattern, gated by `hasAttribute('width')` so the property default `'150px'` is ignored), and use it as the reset-to-defaults value instead of `null`.

## Scope / risk

- Only the **empty-prefs reset branch** of `_applyPrefsToView` is modified. The non-empty branch (`view.settings = newSettings`) and the `set settings()` backward-compat heuristic in `iron-data-table.js` are untouched.
- The new logic only affects columns that explicitly declare a `width="..."` HTML attribute in the layout. Grepped the entire codebase incl. addons and `@nuxeo` packages — **the only such column is the Title column added by this PR.**
- All other columns, tables, content views, search views, addons, persisted-prefs flows, save/restore flows, and grid mode are byte-for-byte identical.
- Capture is stable: `data-table-column.js` does not declare `reflectToAttribute: true` on `width`, so `getAttribute('width')` always returns the original layout value regardless of runtime property changes.
- Idempotent: `_declaredWidth` is captured once per column instance and reset writes via `view.set` only when the current value differs.

## Tests

Three new cases in `test/nuxeo-results.test.js`:

- declared-width capture and reset behavior (WEBUI-2079)
- idempotency — `_declaredWidth` is not re-captured on repeated calls
- mock-column fallback — plain JS columns without `hasAttribute` continue to reset to `null`

Full `nuxeo-results.test.js` suite: **156/156 passing** on lts-2025.

## Verification

For fresh users / after clearing localStorage + server-side `/preferences`, the Title column renders at ≥ 300 px when all 12 columns are enabled.

For users with stale saved prefs from the regression window (3.1.29+), they must clear their saved prefs once to pick up the new default — the persisted-prefs flow is intentionally left untouched to avoid the risk of overwriting any user-resized widths.

## Linked

JIRA: [WEBUI-2079](https://hyland.atlassian.net/browse/WEBUI-2079)
LTS-2023 PR: [#3270](https://github.com/nuxeo/nuxeo-web-ui/pull/3270)

[WEBUI-2079]: https://hyland.atlassian.net/browse/WEBUI-2079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ