### PR TITLE
WEBUI-230: Fix navigation flow when refreshing a document after a task completion ( lts 2023 )

### DIFF
--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -1034,7 +1034,7 @@ Polymer({
         .then((task) => {
           const targetDoc = task?.targetDocumentIds?.[0];
           if (task?.state === 'ended' && targetDoc?.uid) {
-            this._loadDocument({ uid: targetDoc.uid, path: targetDoc.path, page: 'browse' })
+            this._loadDocument({ uid: targetDoc.uid, path: targetDoc.path, page: 'browse' }, { applyState: false })
               .then((doc) => {
                 this._navigateAfterTaskProcessed(doc);
               })
@@ -1075,10 +1075,6 @@ Polymer({
   },
 
   _handleTaskLoadError(error) {
-    if (error?.name === 'AbortError') {
-      this.loading = false;
-      return;
-    }
     if (error.status === 403) {
       this._fetchTaskCount();
       this.navigateTo('tasks');
@@ -1089,10 +1085,6 @@ Polymer({
   },
 
   _handleDocumentRefreshError(err) {
-    if (err?.name === 'AbortError') {
-      this.loading = false;
-      return;
-    }
     if (err?.['entity-type'] === 'exception' && err.status === 403) {
       this.navigateTo('tasks');
     } else {
@@ -1132,7 +1124,7 @@ Polymer({
    * If the document is successfuly retrieved, it is retuned by the method, except if the document representes a saved
    * search, in which case `undefined` is returned.
    */
-  _loadDocument(docParam) {
+  _loadDocument(docParam, { applyState = true } = {}) {
     this.loading = true;
     this.docId = docParam.uid;
     this.docPath = docParam.path;
@@ -1148,17 +1140,23 @@ Polymer({
         this.loading = false;
         return;
       }
-      if (this.docId && !doc.isVersion) {
-        this.docId = '';
-        this.docPath = doc.path;
+      if (applyState) {
+        this._applyDocumentFromLoad(doc);
       }
-      this.currentParent = this.hasFacet(doc, 'Folderish')
-        ? doc
-        : doc.contextParameters.breadcrumb.entries.slice(-2, -1)[0];
-      this.set('currentDocument', doc);
       this.loading = false;
       return doc;
     });
+  },
+
+  _applyDocumentFromLoad(doc) {
+    if (this.docId && !doc.isVersion) {
+      this.docId = '';
+      this.docPath = doc.path;
+    }
+    this.currentParent = this.hasFacet(doc, 'Folderish')
+      ? doc
+      : doc.contextParameters.breadcrumb.entries.slice(-2, -1)[0];
+    this.set('currentDocument', doc);
   },
 
   load(page, uid, path, action) {
@@ -1426,7 +1424,8 @@ Polymer({
     const taskProcessed = e?.type === 'workflowTaskProcessed';
     // let's refresh the current document since it might have been changed (ex: state and version)
     if (this.currentDocument) {
-      this._loadDocument(this.currentDocument)
+      const loadOptions = taskProcessed ? { applyState: false } : {};
+      this._loadDocument(this.currentDocument, loadOptions)
         .then((doc) => {
           if (taskProcessed) {
             this._navigateAfterTaskProcessed(doc);

--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -1032,15 +1032,49 @@ Polymer({
       this.$.task
         .get()
         .then((task) => {
+          const targetDoc = task && task.targetDocumentIds && task.targetDocumentIds[0];
+          if (task && task.state === 'ended' && targetDoc && targetDoc.uid) {
+            this._loadDocument({ uid: targetDoc.uid, path: targetDoc.path, page: 'browse' })
+              .then((doc) => {
+                const pendingTasks = doc && doc.contextParameters && doc.contextParameters.pendingTasks;
+                if (pendingTasks && pendingTasks.length > 0 && pendingTasks[0].id) {
+                  this.navigateTo('tasks', pendingTasks[0].id);
+                } else if (doc) {
+                  this.show('browse');
+                  this.navigateTo(doc);
+                }
+                this.loading = false;
+              })
+              .catch((error) => {
+                if (error && error.name === 'AbortError') {
+                  this.loading = false;
+                  return;
+                }
+                if (error.status === 403) {
+                  this._fetchTaskCount();
+                  this.navigateTo('tasks');
+                } else {
+                  this.showError(error.status, this.i18n('browse.error'), error.message);
+                }
+                this.loading = false;
+              });
+            return;
+          }
           this._defineTaskAndNavigate(task);
           this.loading = false;
         })
         .catch((error) => {
+          if (error && error.name === 'AbortError') {
+            this.loading = false;
+            return;
+          }
           if (error.status === 403) {
             this._fetchTaskCount();
             this.navigateTo('tasks');
-            this.loading = false;
+          } else {
+            this.showError(error.status, this.i18n('browse.error'), error.message);
           }
+          this.loading = false;
         });
     } else {
       this._defineTaskAndNavigate();
@@ -1373,20 +1407,35 @@ Polymer({
     });
   },
 
-  _refreshAndFetchTasks() {
+  _refreshAndFetchTasks(e) {
+    const taskProcessed = e && e.type === 'workflowTaskProcessed';
     // let's refresh the current document since it might have been changed (ex: state and version)
     if (this.currentDocument) {
       this._loadDocument(this.currentDocument)
-        .then(() => {
-          this.show('browse');
+        .then((doc) => {
+          if (taskProcessed) {
+            const pendingTasks = doc && doc.contextParameters && doc.contextParameters.pendingTasks;
+            if (pendingTasks && pendingTasks.length > 0 && pendingTasks[0].id) {
+              this.navigateTo('tasks', pendingTasks[0].id);
+            } else if (doc) {
+              this.show('browse');
+              this.navigateTo(doc);
+            }
+          } else {
+            this.show('browse');
+          }
         })
         .catch((err) => {
-          if (err['entity-type'] && err['entity-type'] === 'exception' && err.status === 403) {
+          if (err && err.name === 'AbortError') {
             this.loading = false;
+            return;
+          }
+          if (err['entity-type'] && err['entity-type'] === 'exception' && err.status === 403) {
             this.navigateTo('tasks');
           } else {
             this.showError(err.status, this.i18n('browse.error'), err.message);
           }
+          this.loading = false;
         });
     }
     this._fetchTaskCount();

--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -1037,7 +1037,6 @@ Polymer({
             this._loadDocument({ uid: targetDoc.uid, path: targetDoc.path, page: 'browse' })
               .then((doc) => {
                 this._navigateAfterTaskProcessed(doc);
-                this.loading = false;
               })
               .catch((error) => {
                 this._handleTaskLoadError(error);
@@ -1061,13 +1060,18 @@ Polymer({
   },
 
   _navigateAfterTaskProcessed(doc) {
-    const pendingTasks = doc?.contextParameters?.pendingTasks;
-    if (pendingTasks?.length > 0 && pendingTasks[0]?.id) {
-      this.navigateTo('tasks', pendingTasks[0].id);
-    } else if (doc) {
-      this.show('browse');
-      this.navigateTo(doc);
+    if (!doc) {
+      this.loading = false;
+      return;
     }
+    const nextTaskId = doc.contextParameters?.pendingTasks?.find((task) => task?.id)?.id;
+    if (nextTaskId) {
+      this.navigateTo('tasks', nextTaskId);
+      return;
+    }
+    this.show('browse');
+    this.navigateTo(doc);
+    this.loading = false;
   },
 
   _handleTaskLoadError(error) {

--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -1075,11 +1075,11 @@ Polymer({
   },
 
   _handleTaskLoadError(error) {
-    if (error.status === 403) {
+    if (error?.status === 403) {
       this._fetchTaskCount();
       this.navigateTo('tasks');
     } else {
-      this.showError(error.status, this.i18n('browse.error'), error.message);
+      this.showError(error?.status, this.i18n('browse.error'), error?.message);
     }
     this.loading = false;
   },
@@ -1088,7 +1088,7 @@ Polymer({
     if (err?.['entity-type'] === 'exception' && err.status === 403) {
       this.navigateTo('tasks');
     } else {
-      this.showError(err.status, this.i18n('browse.error'), err.message);
+      this.showError(err?.status, this.i18n('browse.error'), err?.message);
     }
     this.loading = false;
   },

--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -1032,31 +1032,15 @@ Polymer({
       this.$.task
         .get()
         .then((task) => {
-          const targetDoc = task && task.targetDocumentIds && task.targetDocumentIds[0];
-          if (task && task.state === 'ended' && targetDoc && targetDoc.uid) {
+          const targetDoc = task?.targetDocumentIds?.[0];
+          if (task?.state === 'ended' && targetDoc?.uid) {
             this._loadDocument({ uid: targetDoc.uid, path: targetDoc.path, page: 'browse' })
               .then((doc) => {
-                const pendingTasks = doc && doc.contextParameters && doc.contextParameters.pendingTasks;
-                if (pendingTasks && pendingTasks.length > 0 && pendingTasks[0].id) {
-                  this.navigateTo('tasks', pendingTasks[0].id);
-                } else if (doc) {
-                  this.show('browse');
-                  this.navigateTo(doc);
-                }
+                this._navigateAfterTaskProcessed(doc);
                 this.loading = false;
               })
               .catch((error) => {
-                if (error && error.name === 'AbortError') {
-                  this.loading = false;
-                  return;
-                }
-                if (error.status === 403) {
-                  this._fetchTaskCount();
-                  this.navigateTo('tasks');
-                } else {
-                  this.showError(error.status, this.i18n('browse.error'), error.message);
-                }
-                this.loading = false;
+                this._handleTaskLoadError(error);
               });
             return;
           }
@@ -1064,17 +1048,7 @@ Polymer({
           this.loading = false;
         })
         .catch((error) => {
-          if (error && error.name === 'AbortError') {
-            this.loading = false;
-            return;
-          }
-          if (error.status === 403) {
-            this._fetchTaskCount();
-            this.navigateTo('tasks');
-          } else {
-            this.showError(error.status, this.i18n('browse.error'), error.message);
-          }
-          this.loading = false;
+          this._handleTaskLoadError(error);
         });
     } else {
       this._defineTaskAndNavigate();
@@ -1084,6 +1058,43 @@ Polymer({
   _defineTaskAndNavigate(task) {
     this.currentTask = task;
     this.show('tasks');
+  },
+
+  _navigateAfterTaskProcessed(doc) {
+    const pendingTasks = doc?.contextParameters?.pendingTasks;
+    if (pendingTasks?.length > 0 && pendingTasks[0]?.id) {
+      this.navigateTo('tasks', pendingTasks[0].id);
+    } else if (doc) {
+      this.show('browse');
+      this.navigateTo(doc);
+    }
+  },
+
+  _handleTaskLoadError(error) {
+    if (error?.name === 'AbortError') {
+      this.loading = false;
+      return;
+    }
+    if (error.status === 403) {
+      this._fetchTaskCount();
+      this.navigateTo('tasks');
+    } else {
+      this.showError(error.status, this.i18n('browse.error'), error.message);
+    }
+    this.loading = false;
+  },
+
+  _handleDocumentRefreshError(err) {
+    if (err?.name === 'AbortError') {
+      this.loading = false;
+      return;
+    }
+    if (err?.['entity-type'] === 'exception' && err.status === 403) {
+      this.navigateTo('tasks');
+    } else {
+      this.showError(err.status, this.i18n('browse.error'), err.message);
+    }
+    this.loading = false;
   },
 
   _getSavedSearchForm() {
@@ -1408,34 +1419,19 @@ Polymer({
   },
 
   _refreshAndFetchTasks(e) {
-    const taskProcessed = e && e.type === 'workflowTaskProcessed';
+    const taskProcessed = e?.type === 'workflowTaskProcessed';
     // let's refresh the current document since it might have been changed (ex: state and version)
     if (this.currentDocument) {
       this._loadDocument(this.currentDocument)
         .then((doc) => {
           if (taskProcessed) {
-            const pendingTasks = doc && doc.contextParameters && doc.contextParameters.pendingTasks;
-            if (pendingTasks && pendingTasks.length > 0 && pendingTasks[0].id) {
-              this.navigateTo('tasks', pendingTasks[0].id);
-            } else if (doc) {
-              this.show('browse');
-              this.navigateTo(doc);
-            }
+            this._navigateAfterTaskProcessed(doc);
           } else {
             this.show('browse');
           }
         })
         .catch((err) => {
-          if (err && err.name === 'AbortError') {
-            this.loading = false;
-            return;
-          }
-          if (err['entity-type'] && err['entity-type'] === 'exception' && err.status === 403) {
-            this.navigateTo('tasks');
-          } else {
-            this.showError(err.status, this.i18n('browse.error'), err.message);
-          }
-          this.loading = false;
+          this._handleDocumentRefreshError(err);
         });
     }
     this._fetchTaskCount();

--- a/test/nuxeo-app.test.js
+++ b/test/nuxeo-app.test.js
@@ -775,25 +775,32 @@ suite('nuxeo-app', () => {
   });
 
   suite('loadTask with id', () => {
+    let navigateTo;
+
+    setup(() => {
+      navigateTo = sinon.stub(app, 'navigateTo');
+    });
+
+    teardown(() => {
+      navigateTo.restore();
+    });
+
     test('loadTask fetches task and navigates on success', async () => {
       const task = { id: 't1', name: 'Review' };
       sinon.stub(app.$.task, 'get').resolves(task);
       app.loadTask('t1');
-      await Promise.resolve();
-      await Promise.resolve();
+      await flush();
       expect(app.currentTask).to.equal(task);
       expect(app.page).to.equal('tasks');
       app.$.task.get.restore();
     });
 
     test('loadTask navigates to tasks on 403', async () => {
-      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
       sinon.stub(app.$.task, 'get').rejects({ status: 403 });
       sinon.stub(app, '_fetchTaskCount');
       app.loadTask('t1');
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(app.navigateTo).to.have.been.calledWith('tasks');
+      await flush();
+      expect(navigateTo).to.have.been.calledWith('tasks');
       expect(app.loading).to.be.false;
       app.$.task.get.restore();
       app._fetchTaskCount.restore();
@@ -806,8 +813,7 @@ suite('nuxeo-app', () => {
       sinon.stub(app, 'showError');
       app.loading = true;
       app.loadTask('t1');
-      await Promise.resolve();
-      await Promise.resolve();
+      await flush();
       expect(app.showError).to.not.have.been.called;
       expect(app.loading).to.be.false;
       app.$.task.get.restore();
@@ -819,8 +825,7 @@ suite('nuxeo-app', () => {
       sinon.stub(app, 'showError');
       app.loading = true;
       app.loadTask('t1');
-      await Promise.resolve();
-      await Promise.resolve();
+      await flush();
       expect(app.showError).to.have.been.calledWith(500, 'browse.error', 'server error');
       expect(app.loading).to.be.false;
       app.$.task.get.restore();
@@ -836,8 +841,7 @@ suite('nuxeo-app', () => {
       sinon.stub(app, '_loadDocument').rejects(abortError);
       sinon.stub(app, 'showError');
       app.loadTask('t1');
-      await Promise.resolve();
-      await Promise.resolve();
+      await flush();
       expect(app.showError).to.not.have.been.called;
       expect(app.loading).to.be.false;
       app.$.task.get.restore();
@@ -855,11 +859,9 @@ suite('nuxeo-app', () => {
       };
       sinon.stub(app.$.task, 'get').resolves(task);
       sinon.stub(app, '_loadDocument').resolves(doc);
-      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
       app.loadTask('t1');
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(app.navigateTo).to.have.been.calledWith('tasks', 'task-next');
+      await flush();
+      expect(navigateTo).to.have.been.calledWith('tasks', 'task-next');
       expect(app.loading).to.be.false;
       app.$.task.get.restore();
       app._loadDocument.restore();
@@ -872,12 +874,10 @@ suite('nuxeo-app', () => {
       sinon.stub(app.$.task, 'get').resolves(task);
       sinon.stub(app, '_loadDocument').resolves(doc);
       sinon.stub(app, 'show');
-      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
       app.loadTask('t1');
-      await Promise.resolve();
-      await Promise.resolve();
+      await flush();
       expect(app.show).to.have.been.calledWith('browse');
-      expect(app.navigateTo).to.have.been.calledWith(doc);
+      expect(navigateTo).to.have.been.calledWith(doc);
       expect(app.loading).to.be.false;
       app.$.task.get.restore();
       app._loadDocument.restore();
@@ -890,8 +890,7 @@ suite('nuxeo-app', () => {
       sinon.stub(app, '_loadDocument');
       sinon.stub(app, '_defineTaskAndNavigate');
       app.loadTask('t1');
-      await Promise.resolve();
-      await Promise.resolve();
+      await flush();
       expect(app._loadDocument).to.not.have.been.called;
       expect(app._defineTaskAndNavigate).to.have.been.calledWith(task);
       expect(app.loading).to.be.false;
@@ -911,10 +910,8 @@ suite('nuxeo-app', () => {
       sinon.stub(app.$.task, 'get').resolves(task);
       sinon.stub(app, '_loadDocument').resolves(doc);
       sinon.stub(app, '_defineTaskAndNavigate');
-      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
       app.loadTask('t1');
-      await Promise.resolve();
-      await Promise.resolve();
+      await flush();
       expect(app._defineTaskAndNavigate).to.not.have.been.called;
       app.$.task.get.restore();
       app._loadDocument.restore();
@@ -927,11 +924,9 @@ suite('nuxeo-app', () => {
       sinon.stub(app.$.task, 'get').resolves(task);
       sinon.stub(app, '_loadDocument').rejects({ status: 403 });
       sinon.stub(app, '_fetchTaskCount');
-      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
       app.loadTask('t1');
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(app.navigateTo).to.have.been.calledWith('tasks');
+      await flush();
+      expect(navigateTo).to.have.been.calledWith('tasks');
       expect(app._fetchTaskCount).to.have.been.called;
       expect(app.loading).to.be.false;
       app.$.task.get.restore();
@@ -946,8 +941,7 @@ suite('nuxeo-app', () => {
       sinon.stub(app, '_loadDocument').rejects({ status: 500, message: 'server error' });
       sinon.stub(app, 'showError');
       app.loadTask('t1');
-      await Promise.resolve();
-      await Promise.resolve();
+      await flush();
       expect(app.showError).to.have.been.calledWith(500, 'browse.error', 'server error');
       expect(app.loading).to.be.false;
       app.$.task.get.restore();
@@ -962,13 +956,11 @@ suite('nuxeo-app', () => {
       sinon.stub(app.$.task, 'get').resolves(task);
       sinon.stub(app, '_loadDocument').resolves(doc);
       sinon.stub(app, 'show');
-      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
       app.loadTask('t1');
-      await Promise.resolve();
-      await Promise.resolve();
+      await flush();
       expect(app.show).to.have.been.calledWith('browse');
-      expect(app.navigateTo).to.have.been.calledWith(doc);
-      expect(app.navigateTo).to.not.have.been.calledWith('tasks', sinon.match.any);
+      expect(navigateTo).to.have.been.calledWith(doc);
+      expect(navigateTo).to.not.have.been.calledWith('tasks', sinon.match.any);
       app.$.task.get.restore();
       app._loadDocument.restore();
       app.show.restore();
@@ -981,12 +973,10 @@ suite('nuxeo-app', () => {
       sinon.stub(app.$.task, 'get').resolves(task);
       sinon.stub(app, '_loadDocument').resolves(doc);
       sinon.stub(app, 'show');
-      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
       app.loadTask('t1');
-      await Promise.resolve();
-      await Promise.resolve();
+      await flush();
       expect(app.show).to.have.been.calledWith('browse');
-      expect(app.navigateTo).to.have.been.calledWith(doc);
+      expect(navigateTo).to.have.been.calledWith(doc);
       app.$.task.get.restore();
       app._loadDocument.restore();
       app.show.restore();
@@ -1192,6 +1182,15 @@ suite('nuxeo-app', () => {
   suite('_refreshAndFetchTasks', () => {
     const workflowTaskProcessed = { type: 'workflowTaskProcessed' };
     const workflowStarted = { type: 'workflowStarted' };
+    let navigateTo;
+
+    setup(() => {
+      navigateTo = sinon.stub(app, 'navigateTo');
+    });
+
+    teardown(() => {
+      navigateTo.restore();
+    });
 
     test('navigates to next pending task when document has pending tasks', async () => {
       const doc = {
@@ -1201,14 +1200,13 @@ suite('nuxeo-app', () => {
       };
       app.currentDocument = doc;
       sinon.stub(app, '_loadDocument').resolves(doc);
-      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
       sinon.stub(app, '_fetchTaskCount');
       sinon.stub(app, '_resetTaskSelection');
       sinon.stub(app, '$$').returns({ visible: false });
       app._refreshAndFetchTasks(workflowTaskProcessed);
-      await Promise.resolve();
+      await flush();
       expect(app._loadDocument).to.have.been.calledWith(doc);
-      expect(app.navigateTo).to.have.been.calledWith('tasks', 'task-next');
+      expect(navigateTo).to.have.been.calledWith('tasks', 'task-next');
       expect(app._fetchTaskCount).to.have.been.called;
       app._loadDocument.restore();
       app._fetchTaskCount.restore();
@@ -1221,14 +1219,13 @@ suite('nuxeo-app', () => {
       app.currentDocument = doc;
       sinon.stub(app, '_loadDocument').resolves(doc);
       sinon.stub(app, 'show');
-      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
       sinon.stub(app, '_fetchTaskCount');
       sinon.stub(app, '_resetTaskSelection');
       sinon.stub(app, '$$').returns({ visible: false });
       app._refreshAndFetchTasks(workflowTaskProcessed);
-      await Promise.resolve();
+      await flush();
       expect(app.show).to.have.been.calledWith('browse');
-      expect(app.navigateTo).to.have.been.calledWith(doc);
+      expect(navigateTo).to.have.been.calledWith(doc);
       app._loadDocument.restore();
       app.show.restore();
       app._fetchTaskCount.restore();
@@ -1245,14 +1242,13 @@ suite('nuxeo-app', () => {
       app.currentDocument = doc;
       sinon.stub(app, '_loadDocument').resolves(doc);
       sinon.stub(app, 'show');
-      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
       sinon.stub(app, '_fetchTaskCount');
       sinon.stub(app, '_resetTaskSelection');
       sinon.stub(app, '$$').returns({ visible: false });
       app._refreshAndFetchTasks(workflowStarted);
-      await Promise.resolve();
+      await flush();
       expect(app.show).to.have.been.calledWith('browse');
-      expect(app.navigateTo).to.not.have.been.called;
+      expect(navigateTo).to.not.have.been.called;
       app._loadDocument.restore();
       app.show.restore();
       app._fetchTaskCount.restore();
@@ -1281,15 +1277,14 @@ suite('nuxeo-app', () => {
       app.currentDocument = doc;
       sinon.stub(app, '_loadDocument').resolves(doc);
       sinon.stub(app, 'show');
-      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
       sinon.stub(app, '_fetchTaskCount');
       sinon.stub(app, '_resetTaskSelection');
       sinon.stub(app, '$$').returns({ visible: false });
       app._refreshAndFetchTasks(workflowTaskProcessed);
-      await Promise.resolve();
+      await flush();
       expect(app.show).to.have.been.calledWith('browse');
-      expect(app.navigateTo).to.have.been.calledWith(doc);
-      expect(app.navigateTo).to.not.have.been.calledWith('tasks', sinon.match.any);
+      expect(navigateTo).to.have.been.calledWith(doc);
+      expect(navigateTo).to.not.have.been.calledWith('tasks', sinon.match.any);
       app._loadDocument.restore();
       app.show.restore();
       app._fetchTaskCount.restore();
@@ -1306,14 +1301,13 @@ suite('nuxeo-app', () => {
       app.currentDocument = doc;
       sinon.stub(app, '_loadDocument').resolves(doc);
       sinon.stub(app, 'show');
-      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
       sinon.stub(app, '_fetchTaskCount');
       sinon.stub(app, '_resetTaskSelection');
       sinon.stub(app, '$$').returns({ visible: false });
       app._refreshAndFetchTasks(workflowTaskProcessed);
-      await Promise.resolve();
+      await flush();
       expect(app.show).to.not.have.been.called;
-      expect(app.navigateTo).to.have.been.calledWith('tasks', 'task-next');
+      expect(navigateTo).to.have.been.calledWith('tasks', 'task-next');
       app._loadDocument.restore();
       app.show.restore();
       app._fetchTaskCount.restore();
@@ -1325,14 +1319,13 @@ suite('nuxeo-app', () => {
       app.currentDocument = { uid: '1', path: '/p' };
       sinon.stub(app, '_loadDocument').resolves(null);
       sinon.stub(app, 'show');
-      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
       sinon.stub(app, '_fetchTaskCount');
       sinon.stub(app, '_resetTaskSelection');
       sinon.stub(app, '$$').returns({ visible: false });
       app._refreshAndFetchTasks(workflowTaskProcessed);
-      await Promise.resolve();
+      await flush();
       expect(app.show).to.not.have.been.called;
-      expect(app.navigateTo).to.not.have.been.called;
+      expect(navigateTo).to.not.have.been.called;
       app._loadDocument.restore();
       app.show.restore();
       app._fetchTaskCount.restore();
@@ -1622,9 +1615,18 @@ suite('nuxeo-app', () => {
   });
 
   suite('_refreshAndFetchTasks errors', () => {
+    let navigateTo;
+
+    setup(() => {
+      navigateTo = sinon.stub(app, 'navigateTo');
+    });
+
+    teardown(() => {
+      navigateTo.restore();
+    });
+
     test('navigates to tasks on 403 when refreshing document', async () => {
       app.currentDocument = { uid: '1' };
-      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
       sinon
         .stub(app, '_loadDocument')
         .returns(Promise.reject({ 'entity-type': 'exception', status: 403, message: 'denied' }));
@@ -1632,9 +1634,8 @@ suite('nuxeo-app', () => {
       sinon.stub(app, '_resetTaskSelection');
       sinon.stub(app, '$$').returns({ visible: true, $: { tasks: { fetch: sinon.spy() } } });
       app._refreshAndFetchTasks();
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(app.navigateTo).to.have.been.calledWith('tasks');
+      await flush();
+      expect(navigateTo).to.have.been.calledWith('tasks');
       expect(app.loading).to.be.false;
       app._loadDocument.restore();
       app._fetchTaskCount.restore();
@@ -1653,8 +1654,7 @@ suite('nuxeo-app', () => {
       sinon.stub(app, '$$').returns({ visible: false });
       app.loading = true;
       app._refreshAndFetchTasks({ type: 'workflowTaskProcessed' });
-      await Promise.resolve();
-      await Promise.resolve();
+      await flush();
       expect(app.showError).to.not.have.been.called;
       expect(app.loading).to.be.false;
       app._loadDocument.restore();
@@ -1673,8 +1673,7 @@ suite('nuxeo-app', () => {
       sinon.stub(app, '$$').returns({ visible: false });
       app.loading = true;
       app._refreshAndFetchTasks();
-      await Promise.resolve();
-      await Promise.resolve();
+      await flush();
       expect(app.showError).to.have.been.calledWith(500, 'browse.error', 'server error');
       expect(app.loading).to.be.false;
       app._loadDocument.restore();

--- a/test/nuxeo-app.test.js
+++ b/test/nuxeo-app.test.js
@@ -818,6 +818,15 @@ suite('nuxeo-app', () => {
       app.showError.restore();
     });
 
+    test('_handleTaskLoadError resets loading on a null error without throwing', () => {
+      sinon.stub(app, 'showError');
+      app.loading = true;
+      app._handleTaskLoadError(null);
+      expect(app.loading).to.be.false;
+      expect(app.showError).to.have.been.calledWith(undefined, 'browse.error', undefined);
+      app.showError.restore();
+    });
+
     test('loadTask redirects to next pending task when task is ended', async () => {
       const targetDoc = { uid: 'doc-1', path: '/ws/file' };
       const task = { id: 't1', state: 'ended', targetDocumentIds: [targetDoc] };
@@ -835,8 +844,6 @@ suite('nuxeo-app', () => {
         { applyState: false },
       );
       expect(navigateTo).to.have.been.calledWith('tasks', 'task-next');
-      // navigateTo is stubbed so loadTask is not re-entered; loading stays true until then
-      expect(app.loading).to.be.true;
       app.$.task.get.restore();
       app._loadDocument.restore();
     });

--- a/test/nuxeo-app.test.js
+++ b/test/nuxeo-app.test.js
@@ -806,20 +806,6 @@ suite('nuxeo-app', () => {
       app._fetchTaskCount.restore();
     });
 
-    test('loadTask ignores aborted task fetch', async () => {
-      const abortError = new Error('The user aborted a request.');
-      abortError.name = 'AbortError';
-      sinon.stub(app.$.task, 'get').rejects(abortError);
-      sinon.stub(app, 'showError');
-      app.loading = true;
-      app.loadTask('t1');
-      await flush();
-      expect(app.showError).to.not.have.been.called;
-      expect(app.loading).to.be.false;
-      app.$.task.get.restore();
-      app.showError.restore();
-    });
-
     test('loadTask shows error and resets loading on task fetch failure', async () => {
       sinon.stub(app.$.task, 'get').rejects({ status: 500, message: 'server error' });
       sinon.stub(app, 'showError');
@@ -829,23 +815,6 @@ suite('nuxeo-app', () => {
       expect(app.showError).to.have.been.calledWith(500, 'browse.error', 'server error');
       expect(app.loading).to.be.false;
       app.$.task.get.restore();
-      app.showError.restore();
-    });
-
-    test('loadTask ignores aborted document load when task is ended', async () => {
-      const targetDoc = { uid: 'doc-1', path: '/ws/file' };
-      const task = { id: 't1', state: 'ended', targetDocumentIds: [targetDoc] };
-      const abortError = new Error('The user aborted a request.');
-      abortError.name = 'AbortError';
-      sinon.stub(app.$.task, 'get').resolves(task);
-      sinon.stub(app, '_loadDocument').rejects(abortError);
-      sinon.stub(app, 'showError');
-      app.loadTask('t1');
-      await flush();
-      expect(app.showError).to.not.have.been.called;
-      expect(app.loading).to.be.false;
-      app.$.task.get.restore();
-      app._loadDocument.restore();
       app.showError.restore();
     });
 
@@ -861,6 +830,10 @@ suite('nuxeo-app', () => {
       sinon.stub(app, '_loadDocument').resolves(doc);
       app.loadTask('t1');
       await flush();
+      expect(app._loadDocument).to.have.been.calledWith(
+        { uid: 'doc-1', path: '/ws/file', page: 'browse' },
+        { applyState: false },
+      );
       expect(navigateTo).to.have.been.calledWith('tasks', 'task-next');
       // navigateTo is stubbed so loadTask is not re-entered; loading stays true until then
       expect(app.loading).to.be.true;
@@ -1241,7 +1214,7 @@ suite('nuxeo-app', () => {
       sinon.stub(app, '$$').returns({ visible: false });
       app._refreshAndFetchTasks(workflowTaskProcessed);
       await flush();
-      expect(app._loadDocument).to.have.been.calledWith(doc);
+      expect(app._loadDocument).to.have.been.calledWith(doc, { applyState: false });
       expect(navigateTo).to.have.been.calledWith('tasks', 'task-next');
       expect(app._fetchTaskCount).to.have.been.called;
       app._loadDocument.restore();
@@ -1738,27 +1711,6 @@ suite('nuxeo-app', () => {
       expect(navigateTo).to.have.been.calledWith('tasks');
       expect(app.loading).to.be.false;
       app._loadDocument.restore();
-      app._fetchTaskCount.restore();
-      app._resetTaskSelection.restore();
-      app.$$.restore();
-    });
-
-    test('ignores aborted document reload on workflowTaskProcessed', async () => {
-      const abortError = new Error('The user aborted a request.');
-      abortError.name = 'AbortError';
-      app.currentDocument = { uid: '1', path: '/p' };
-      sinon.stub(app, '_loadDocument').rejects(abortError);
-      sinon.stub(app, 'showError');
-      sinon.stub(app, '_fetchTaskCount');
-      sinon.stub(app, '_resetTaskSelection');
-      sinon.stub(app, '$$').returns({ visible: false });
-      app.loading = true;
-      app._refreshAndFetchTasks({ type: 'workflowTaskProcessed' });
-      await flush();
-      expect(app.showError).to.not.have.been.called;
-      expect(app.loading).to.be.false;
-      app._loadDocument.restore();
-      app.showError.restore();
       app._fetchTaskCount.restore();
       app._resetTaskSelection.restore();
       app.$$.restore();

--- a/test/nuxeo-app.test.js
+++ b/test/nuxeo-app.test.js
@@ -798,6 +798,199 @@ suite('nuxeo-app', () => {
       app.$.task.get.restore();
       app._fetchTaskCount.restore();
     });
+
+    test('loadTask ignores aborted task fetch', async () => {
+      const abortError = new Error('The user aborted a request.');
+      abortError.name = 'AbortError';
+      sinon.stub(app.$.task, 'get').rejects(abortError);
+      sinon.stub(app, 'showError');
+      app.loading = true;
+      app.loadTask('t1');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(app.showError).to.not.have.been.called;
+      expect(app.loading).to.be.false;
+      app.$.task.get.restore();
+      app.showError.restore();
+    });
+
+    test('loadTask shows error and resets loading on task fetch failure', async () => {
+      sinon.stub(app.$.task, 'get').rejects({ status: 500, message: 'server error' });
+      sinon.stub(app, 'showError');
+      app.loading = true;
+      app.loadTask('t1');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(app.showError).to.have.been.calledWith(500, 'browse.error', 'server error');
+      expect(app.loading).to.be.false;
+      app.$.task.get.restore();
+      app.showError.restore();
+    });
+
+    test('loadTask ignores aborted document load when task is ended', async () => {
+      const targetDoc = { uid: 'doc-1', path: '/ws/file' };
+      const task = { id: 't1', state: 'ended', targetDocumentIds: [targetDoc] };
+      const abortError = new Error('The user aborted a request.');
+      abortError.name = 'AbortError';
+      sinon.stub(app.$.task, 'get').resolves(task);
+      sinon.stub(app, '_loadDocument').rejects(abortError);
+      sinon.stub(app, 'showError');
+      app.loadTask('t1');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(app.showError).to.not.have.been.called;
+      expect(app.loading).to.be.false;
+      app.$.task.get.restore();
+      app._loadDocument.restore();
+      app.showError.restore();
+    });
+
+    test('loadTask redirects to next pending task when task is ended', async () => {
+      const targetDoc = { uid: 'doc-1', path: '/ws/file' };
+      const task = { id: 't1', state: 'ended', targetDocumentIds: [targetDoc] };
+      const doc = {
+        uid: 'doc-1',
+        path: '/ws/file',
+        contextParameters: { pendingTasks: [{ id: 'task-next' }] },
+      };
+      sinon.stub(app.$.task, 'get').resolves(task);
+      sinon.stub(app, '_loadDocument').resolves(doc);
+      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
+      app.loadTask('t1');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(app.navigateTo).to.have.been.calledWith('tasks', 'task-next');
+      expect(app.loading).to.be.false;
+      app.$.task.get.restore();
+      app._loadDocument.restore();
+    });
+
+    test('loadTask redirects to document when ended task has no pending follow-up', async () => {
+      const targetDoc = { uid: 'doc-1', path: '/ws/file' };
+      const task = { id: 't1', state: 'ended', targetDocumentIds: [targetDoc] };
+      const doc = { uid: 'doc-1', path: '/ws/file', contextParameters: { pendingTasks: [] } };
+      sinon.stub(app.$.task, 'get').resolves(task);
+      sinon.stub(app, '_loadDocument').resolves(doc);
+      sinon.stub(app, 'show');
+      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
+      app.loadTask('t1');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(app.show).to.have.been.calledWith('browse');
+      expect(app.navigateTo).to.have.been.calledWith(doc);
+      expect(app.loading).to.be.false;
+      app.$.task.get.restore();
+      app._loadDocument.restore();
+      app.show.restore();
+    });
+
+    test('loadTask ended task without target document uses standard task navigation', async () => {
+      const task = { id: 't1', state: 'ended', targetDocumentIds: [] };
+      sinon.stub(app.$.task, 'get').resolves(task);
+      sinon.stub(app, '_loadDocument');
+      sinon.stub(app, '_defineTaskAndNavigate');
+      app.loadTask('t1');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(app._loadDocument).to.not.have.been.called;
+      expect(app._defineTaskAndNavigate).to.have.been.calledWith(task);
+      expect(app.loading).to.be.false;
+      app.$.task.get.restore();
+      app._loadDocument.restore();
+      app._defineTaskAndNavigate.restore();
+    });
+
+    test('loadTask ended task does not call _defineTaskAndNavigate when redirecting', async () => {
+      const targetDoc = { uid: 'doc-1', path: '/ws/file' };
+      const task = { id: 't1', state: 'ended', targetDocumentIds: [targetDoc] };
+      const doc = {
+        uid: 'doc-1',
+        path: '/ws/file',
+        contextParameters: { pendingTasks: [{ id: 'task-next' }] },
+      };
+      sinon.stub(app.$.task, 'get').resolves(task);
+      sinon.stub(app, '_loadDocument').resolves(doc);
+      sinon.stub(app, '_defineTaskAndNavigate');
+      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
+      app.loadTask('t1');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(app._defineTaskAndNavigate).to.not.have.been.called;
+      app.$.task.get.restore();
+      app._loadDocument.restore();
+      app._defineTaskAndNavigate.restore();
+    });
+
+    test('loadTask ended task navigates to tasks on document load 403', async () => {
+      const targetDoc = { uid: 'doc-1', path: '/ws/file' };
+      const task = { id: 't1', state: 'ended', targetDocumentIds: [targetDoc] };
+      sinon.stub(app.$.task, 'get').resolves(task);
+      sinon.stub(app, '_loadDocument').rejects({ status: 403 });
+      sinon.stub(app, '_fetchTaskCount');
+      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
+      app.loadTask('t1');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(app.navigateTo).to.have.been.calledWith('tasks');
+      expect(app._fetchTaskCount).to.have.been.called;
+      expect(app.loading).to.be.false;
+      app.$.task.get.restore();
+      app._loadDocument.restore();
+      app._fetchTaskCount.restore();
+    });
+
+    test('loadTask ended task shows error on document load failure', async () => {
+      const targetDoc = { uid: 'doc-1', path: '/ws/file' };
+      const task = { id: 't1', state: 'ended', targetDocumentIds: [targetDoc] };
+      sinon.stub(app.$.task, 'get').resolves(task);
+      sinon.stub(app, '_loadDocument').rejects({ status: 500, message: 'server error' });
+      sinon.stub(app, 'showError');
+      app.loadTask('t1');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(app.showError).to.have.been.calledWith(500, 'browse.error', 'server error');
+      expect(app.loading).to.be.false;
+      app.$.task.get.restore();
+      app._loadDocument.restore();
+      app.showError.restore();
+    });
+
+    test('loadTask ended task with pending task missing id falls back to document browse', async () => {
+      const targetDoc = { uid: 'doc-1', path: '/ws/file' };
+      const task = { id: 't1', state: 'ended', targetDocumentIds: [targetDoc] };
+      const doc = { uid: 'doc-1', path: '/ws/file', contextParameters: { pendingTasks: [{}] } };
+      sinon.stub(app.$.task, 'get').resolves(task);
+      sinon.stub(app, '_loadDocument').resolves(doc);
+      sinon.stub(app, 'show');
+      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
+      app.loadTask('t1');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(app.show).to.have.been.calledWith('browse');
+      expect(app.navigateTo).to.have.been.calledWith(doc);
+      expect(app.navigateTo).to.not.have.been.calledWith('tasks', sinon.match.any);
+      app.$.task.get.restore();
+      app._loadDocument.restore();
+      app.show.restore();
+    });
+
+    test('loadTask ended task with missing contextParameters falls back to document browse', async () => {
+      const targetDoc = { uid: 'doc-1', path: '/ws/file' };
+      const task = { id: 't1', state: 'ended', targetDocumentIds: [targetDoc] };
+      const doc = { uid: 'doc-1', path: '/ws/file' };
+      sinon.stub(app.$.task, 'get').resolves(task);
+      sinon.stub(app, '_loadDocument').resolves(doc);
+      sinon.stub(app, 'show');
+      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
+      app.loadTask('t1');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(app.show).to.have.been.calledWith('browse');
+      expect(app.navigateTo).to.have.been.calledWith(doc);
+      app.$.task.get.restore();
+      app._loadDocument.restore();
+      app.show.restore();
+    });
   });
 
   suite('drawer toggle', () => {
@@ -997,18 +1190,149 @@ suite('nuxeo-app', () => {
   });
 
   suite('_refreshAndFetchTasks', () => {
-    test('refreshes document and fetches tasks when currentDocument is set', async () => {
-      const doc = { uid: '1', path: '/p' };
+    const workflowTaskProcessed = { type: 'workflowTaskProcessed' };
+    const workflowStarted = { type: 'workflowStarted' };
+
+    test('navigates to next pending task when document has pending tasks', async () => {
+      const doc = {
+        uid: '1',
+        path: '/p',
+        contextParameters: { pendingTasks: [{ id: 'task-next' }] },
+      };
+      app.currentDocument = doc;
+      sinon.stub(app, '_loadDocument').resolves(doc);
+      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
+      sinon.stub(app, '_fetchTaskCount');
+      sinon.stub(app, '_resetTaskSelection');
+      sinon.stub(app, '$$').returns({ visible: false });
+      app._refreshAndFetchTasks(workflowTaskProcessed);
+      await Promise.resolve();
+      expect(app._loadDocument).to.have.been.calledWith(doc);
+      expect(app.navigateTo).to.have.been.calledWith('tasks', 'task-next');
+      expect(app._fetchTaskCount).to.have.been.called;
+      app._loadDocument.restore();
+      app._fetchTaskCount.restore();
+      app._resetTaskSelection.restore();
+      app.$$.restore();
+    });
+
+    test('navigates to document when no pending tasks remain', async () => {
+      const doc = { uid: '1', path: '/p', contextParameters: { pendingTasks: [] } };
       app.currentDocument = doc;
       sinon.stub(app, '_loadDocument').resolves(doc);
       sinon.stub(app, 'show');
+      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
+      sinon.stub(app, '_fetchTaskCount');
+      sinon.stub(app, '_resetTaskSelection');
+      sinon.stub(app, '$$').returns({ visible: false });
+      app._refreshAndFetchTasks(workflowTaskProcessed);
+      await Promise.resolve();
+      expect(app.show).to.have.been.calledWith('browse');
+      expect(app.navigateTo).to.have.been.calledWith(doc);
+      app._loadDocument.restore();
+      app.show.restore();
+      app._fetchTaskCount.restore();
+      app._resetTaskSelection.restore();
+      app.$$.restore();
+    });
+
+    test('shows browse without navigating on workflowStarted', async () => {
+      const doc = {
+        uid: '1',
+        path: '/p',
+        contextParameters: { pendingTasks: [{ id: 'task-next' }] },
+      };
+      app.currentDocument = doc;
+      sinon.stub(app, '_loadDocument').resolves(doc);
+      sinon.stub(app, 'show');
+      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
+      sinon.stub(app, '_fetchTaskCount');
+      sinon.stub(app, '_resetTaskSelection');
+      sinon.stub(app, '$$').returns({ visible: false });
+      app._refreshAndFetchTasks(workflowStarted);
+      await Promise.resolve();
+      expect(app.show).to.have.been.calledWith('browse');
+      expect(app.navigateTo).to.not.have.been.called;
+      app._loadDocument.restore();
+      app.show.restore();
+      app._fetchTaskCount.restore();
+      app._resetTaskSelection.restore();
+      app.$$.restore();
+    });
+
+    test('does not load document when currentDocument is missing', async () => {
+      app.currentDocument = null;
+      sinon.stub(app, '_loadDocument');
       sinon.stub(app, '_fetchTaskCount');
       sinon.stub(app, '_resetTaskSelection');
       sinon.stub(app, '$$').returns({ visible: false });
       app._refreshAndFetchTasks();
-      await Promise.resolve();
-      expect(app._loadDocument).to.have.been.calledWith(doc);
+      expect(app._loadDocument).to.not.have.been.called;
       expect(app._fetchTaskCount).to.have.been.called;
+      expect(app._resetTaskSelection).to.have.been.called;
+      app._loadDocument.restore();
+      app._fetchTaskCount.restore();
+      app._resetTaskSelection.restore();
+      app.$$.restore();
+    });
+
+    test('shows browse when pending task has no id', async () => {
+      const doc = { uid: '1', path: '/p', contextParameters: { pendingTasks: [{ name: 'orphan' }] } };
+      app.currentDocument = doc;
+      sinon.stub(app, '_loadDocument').resolves(doc);
+      sinon.stub(app, 'show');
+      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
+      sinon.stub(app, '_fetchTaskCount');
+      sinon.stub(app, '_resetTaskSelection');
+      sinon.stub(app, '$$').returns({ visible: false });
+      app._refreshAndFetchTasks(workflowTaskProcessed);
+      await Promise.resolve();
+      expect(app.show).to.have.been.calledWith('browse');
+      expect(app.navigateTo).to.have.been.calledWith(doc);
+      expect(app.navigateTo).to.not.have.been.calledWith('tasks', sinon.match.any);
+      app._loadDocument.restore();
+      app.show.restore();
+      app._fetchTaskCount.restore();
+      app._resetTaskSelection.restore();
+      app.$$.restore();
+    });
+
+    test('does not call show when navigating to pending task', async () => {
+      const doc = {
+        uid: '1',
+        path: '/p',
+        contextParameters: { pendingTasks: [{ id: 'task-next' }] },
+      };
+      app.currentDocument = doc;
+      sinon.stub(app, '_loadDocument').resolves(doc);
+      sinon.stub(app, 'show');
+      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
+      sinon.stub(app, '_fetchTaskCount');
+      sinon.stub(app, '_resetTaskSelection');
+      sinon.stub(app, '$$').returns({ visible: false });
+      app._refreshAndFetchTasks(workflowTaskProcessed);
+      await Promise.resolve();
+      expect(app.show).to.not.have.been.called;
+      expect(app.navigateTo).to.have.been.calledWith('tasks', 'task-next');
+      app._loadDocument.restore();
+      app.show.restore();
+      app._fetchTaskCount.restore();
+      app._resetTaskSelection.restore();
+      app.$$.restore();
+    });
+
+    test('does not show browse when document reload returns no document', async () => {
+      app.currentDocument = { uid: '1', path: '/p' };
+      sinon.stub(app, '_loadDocument').resolves(null);
+      sinon.stub(app, 'show');
+      Object.defineProperty(app, 'navigateTo', { value: sinon.stub(), configurable: true, writable: true });
+      sinon.stub(app, '_fetchTaskCount');
+      sinon.stub(app, '_resetTaskSelection');
+      sinon.stub(app, '$$').returns({ visible: false });
+      app._refreshAndFetchTasks(workflowTaskProcessed);
+      await Promise.resolve();
+      expect(app.show).to.not.have.been.called;
+      expect(app.navigateTo).to.not.have.been.called;
       app._loadDocument.restore();
       app.show.restore();
       app._fetchTaskCount.restore();
@@ -1313,6 +1637,48 @@ suite('nuxeo-app', () => {
       expect(app.navigateTo).to.have.been.calledWith('tasks');
       expect(app.loading).to.be.false;
       app._loadDocument.restore();
+      app._fetchTaskCount.restore();
+      app._resetTaskSelection.restore();
+      app.$$.restore();
+    });
+
+    test('ignores aborted document reload on workflowTaskProcessed', async () => {
+      const abortError = new Error('The user aborted a request.');
+      abortError.name = 'AbortError';
+      app.currentDocument = { uid: '1', path: '/p' };
+      sinon.stub(app, '_loadDocument').rejects(abortError);
+      sinon.stub(app, 'showError');
+      sinon.stub(app, '_fetchTaskCount');
+      sinon.stub(app, '_resetTaskSelection');
+      sinon.stub(app, '$$').returns({ visible: false });
+      app.loading = true;
+      app._refreshAndFetchTasks({ type: 'workflowTaskProcessed' });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(app.showError).to.not.have.been.called;
+      expect(app.loading).to.be.false;
+      app._loadDocument.restore();
+      app.showError.restore();
+      app._fetchTaskCount.restore();
+      app._resetTaskSelection.restore();
+      app.$$.restore();
+    });
+
+    test('shows error on non-403 failure when refreshing document', async () => {
+      app.currentDocument = { uid: '1' };
+      sinon.stub(app, '_loadDocument').rejects({ status: 500, message: 'server error' });
+      sinon.stub(app, 'showError');
+      sinon.stub(app, '_fetchTaskCount');
+      sinon.stub(app, '_resetTaskSelection');
+      sinon.stub(app, '$$').returns({ visible: false });
+      app.loading = true;
+      app._refreshAndFetchTasks();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(app.showError).to.have.been.calledWith(500, 'browse.error', 'server error');
+      expect(app.loading).to.be.false;
+      app._loadDocument.restore();
+      app.showError.restore();
       app._fetchTaskCount.restore();
       app._resetTaskSelection.restore();
       app.$$.restore();

--- a/test/nuxeo-app.test.js
+++ b/test/nuxeo-app.test.js
@@ -961,7 +961,6 @@ suite('nuxeo-app', () => {
       app.loadTask('t1');
       await flush();
       expect(navigateTo).to.have.been.calledWith('tasks', 'task-next');
-      expect(app.loading).to.be.true;
       app.$.task.get.restore();
       app._loadDocument.restore();
     });

--- a/test/nuxeo-app.test.js
+++ b/test/nuxeo-app.test.js
@@ -862,7 +862,8 @@ suite('nuxeo-app', () => {
       app.loadTask('t1');
       await flush();
       expect(navigateTo).to.have.been.calledWith('tasks', 'task-next');
-      expect(app.loading).to.be.false;
+      // navigateTo is stubbed so loadTask is not re-entered; loading stays true until then
+      expect(app.loading).to.be.true;
       app.$.task.get.restore();
       app._loadDocument.restore();
     });
@@ -961,9 +962,28 @@ suite('nuxeo-app', () => {
       expect(app.show).to.have.been.calledWith('browse');
       expect(navigateTo).to.have.been.calledWith(doc);
       expect(navigateTo).to.not.have.been.calledWith('tasks', sinon.match.any);
+      expect(app.loading).to.be.false;
       app.$.task.get.restore();
       app._loadDocument.restore();
       app.show.restore();
+    });
+
+    test('loadTask ended task skips pending tasks without id and navigates to next valid task', async () => {
+      const targetDoc = { uid: 'doc-1', path: '/ws/file' };
+      const task = { id: 't1', state: 'ended', targetDocumentIds: [targetDoc] };
+      const doc = {
+        uid: 'doc-1',
+        path: '/ws/file',
+        contextParameters: { pendingTasks: [{ name: 'orphan' }, { id: 'task-next' }] },
+      };
+      sinon.stub(app.$.task, 'get').resolves(task);
+      sinon.stub(app, '_loadDocument').resolves(doc);
+      app.loadTask('t1');
+      await flush();
+      expect(navigateTo).to.have.been.calledWith('tasks', 'task-next');
+      expect(app.loading).to.be.true;
+      app.$.task.get.restore();
+      app._loadDocument.restore();
     });
 
     test('loadTask ended task with missing contextParameters falls back to document browse', async () => {
@@ -1347,6 +1367,26 @@ suite('nuxeo-app', () => {
       expect(navigateTo).to.not.have.been.calledWith('tasks', sinon.match.any);
       app._loadDocument.restore();
       app.show.restore();
+      app._fetchTaskCount.restore();
+      app._resetTaskSelection.restore();
+      app.$$.restore();
+    });
+
+    test('navigates to first pending task with id when earlier entries lack id', async () => {
+      const doc = {
+        uid: '1',
+        path: '/p',
+        contextParameters: { pendingTasks: [{ name: 'orphan' }, { id: 'task-next' }] },
+      };
+      app.currentDocument = doc;
+      sinon.stub(app, '_loadDocument').resolves(doc);
+      sinon.stub(app, '_fetchTaskCount');
+      sinon.stub(app, '_resetTaskSelection');
+      sinon.stub(app, '$$').returns({ visible: false });
+      app._refreshAndFetchTasks(workflowTaskProcessed);
+      await flush();
+      expect(navigateTo).to.have.been.calledWith('tasks', 'task-next');
+      app._loadDocument.restore();
       app._fetchTaskCount.restore();
       app._resetTaskSelection.restore();
       app.$$.restore();

--- a/test/nuxeo-app.test.js
+++ b/test/nuxeo-app.test.js
@@ -981,6 +981,22 @@ suite('nuxeo-app', () => {
       app._loadDocument.restore();
       app.show.restore();
     });
+
+    test('loadTask ended task does not navigate when document reload returns no document', async () => {
+      const targetDoc = { uid: 'doc-1', path: '/ws/file' };
+      const task = { id: 't1', state: 'ended', targetDocumentIds: [targetDoc] };
+      sinon.stub(app.$.task, 'get').resolves(task);
+      sinon.stub(app, '_loadDocument').resolves(null);
+      sinon.stub(app, 'show');
+      app.loadTask('t1');
+      await flush();
+      expect(app.show).to.not.have.been.called;
+      expect(navigateTo).to.not.have.been.called;
+      expect(app.loading).to.be.false;
+      app.$.task.get.restore();
+      app._loadDocument.restore();
+      app.show.restore();
+    });
   });
 
   suite('drawer toggle', () => {
@@ -1249,6 +1265,50 @@ suite('nuxeo-app', () => {
       await flush();
       expect(app.show).to.have.been.calledWith('browse');
       expect(navigateTo).to.not.have.been.called;
+      app._loadDocument.restore();
+      app.show.restore();
+      app._fetchTaskCount.restore();
+      app._resetTaskSelection.restore();
+      app.$$.restore();
+    });
+
+    test('shows browse without navigating on workflowAbandoned', async () => {
+      const doc = {
+        uid: '1',
+        path: '/p',
+        contextParameters: { pendingTasks: [{ id: 'task-next' }] },
+      };
+      app.currentDocument = doc;
+      sinon.stub(app, '_loadDocument').resolves(doc);
+      sinon.stub(app, 'show');
+      sinon.stub(app, '_fetchTaskCount');
+      sinon.stub(app, '_resetTaskSelection');
+      sinon.stub(app, '$$').returns({ visible: false });
+      app._refreshAndFetchTasks({ type: 'workflowAbandoned' });
+      await flush();
+      expect(app.show).to.have.been.calledWith('browse');
+      expect(navigateTo).to.not.have.been.called;
+      app._loadDocument.restore();
+      app.show.restore();
+      app._fetchTaskCount.restore();
+      app._resetTaskSelection.restore();
+      app.$$.restore();
+    });
+
+    test('refreshes document and shows browse when called without event', async () => {
+      const doc = { uid: '1', path: '/p' };
+      app.currentDocument = doc;
+      sinon.stub(app, '_loadDocument').resolves(doc);
+      sinon.stub(app, 'show');
+      sinon.stub(app, '_fetchTaskCount');
+      sinon.stub(app, '_resetTaskSelection');
+      sinon.stub(app, '$$').returns({ visible: false });
+      app._refreshAndFetchTasks();
+      await flush();
+      expect(app._loadDocument).to.have.been.calledWith(doc);
+      expect(app.show).to.have.been.calledWith('browse');
+      expect(navigateTo).to.not.have.been.called;
+      expect(app._fetchTaskCount).to.have.been.called;
       app._loadDocument.restore();
       app.show.restore();
       app._fetchTaskCount.restore();


### PR DESCRIPTION
Redirect ended tasks and post-process workflow refreshes to the next pending task or document browse view instead of showing an already-processed task.

https://hyland.atlassian.net/browse/WEBUI-230