### PR TITLE
WEBUI-1857: redirect anonymous user to login on a private-document 403 [lts-2025]

### DIFF
--- a/elements/behaviors/nuxeo-anonymous-behavior.js
+++ b/elements/behaviors/nuxeo-anonymous-behavior.js
@@ -1,0 +1,93 @@
+/**
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Anonymous authentication flow (WEBUI-1857).
+ *
+ * When anonymous authentication is enabled and an anonymous user opens a permalink to a document they
+ * are not allowed to read, the document load fails with a 403. Without this behavior the app shows a
+ * dead-end "Permission Denied" error page, and the only way forward is to manually log out of the
+ * anonymous session, log back in with a real account and open the permalink again.
+ *
+ * Instead, this behavior detects that specific case (the current user is anonymous AND the failure is a
+ * 403) and sends the user through the Nuxeo logout endpoint, preserving the URL they tried to open. The
+ * anonymous user has an established (stateful) session, so redirecting straight to `login.jsp` would not
+ * help — Nuxeo treats the anonymous user as logged in and bounces back to the requested page. Going
+ * through `/logout` invalidates the anonymous session and, because the user was anonymous, Nuxeo forwards
+ * to the login form (with `forceAnonymousLogin=true`) while carrying the `requestedUrl` across. After
+ * authenticating with a real account the user lands back on the requested document.
+ *
+ * The Web UI route lives in the URL fragment (e.g. `#!/doc/<uid>`), which browsers do not send to the
+ * server, so it is stored in the `nuxeo.start.url.fragment` cookie — the same cookie `nuxeo-connection`
+ * uses for its form-auth 401 redirect — and restored by Nuxeo on the post-login redirect.
+ *
+ * Expects the host to provide a `currentUser` property and a `nxcon` `<nuxeo-connection>` in its
+ * template (`this.$.nxcon`), used to resolve the server base URL. Behavior methods are mixed into the
+ * host, so the host's `load()` catch can call them directly.
+ *
+ * @polymerBehavior Nuxeo.AnonymousBehavior
+ */
+export const NuxeoAnonymousBehavior = {
+  /** True when the connected user is the configured anonymous user. */
+  _isAnonymousUser() {
+    return Boolean(this.currentUser && this.currentUser.isAnonymous);
+  },
+
+  /**
+   * True when `err` is a 403 raised for an anonymous user, i.e. a permission error that could be
+   * resolved by authenticating with a real account.
+   */
+  _isAnonymousForbidden(err) {
+    return this._isAnonymousUser() && Boolean(err) && Number(err.status) === 403;
+  },
+
+  /**
+   * Send the anonymous user through the logout endpoint (which invalidates the anonymous session and
+   * forwards to the login form), preserving the URL they tried to open so that, after logging in with a
+   * real account, they are returned to the requested document.
+   */
+  _redirectAnonymousToLogin() {
+    // one-shot guard: a burst of 403s (e.g. document + its enrichers) must not stack redirects
+    if (this._anonymousLoginRedirecting) {
+      return;
+    }
+    this._anonymousLoginRedirecting = true;
+    // The Web UI route lives in the URL fragment, which is never sent to the server. Nuxeo restores it
+    // after login from the `nuxeo.start.url.fragment` cookie: while redirecting an unauthenticated
+    // request to the login page, NuxeoAuthenticationFilter emits a script that (re)writes this cookie
+    // from `window.location.hash`. We set it here too (mirroring nuxeo-connection's 401 handling), and
+    // — crucially — re-append the fragment to the logout URL below so it survives the redirect chain and
+    // the server captures the correct value instead of overwriting the cookie with an empty hash.
+    document.cookie = `nuxeo.start.url.fragment=${globalThis.location.hash.substring(1) || ''}; path=/`;
+    const baseUrl = (this.$ && this.$.nxcon && this.$.nxcon.url) || this.url || '';
+    // `requestedUrl` must be context-relative: an absolute URL would get the context path prepended by
+    // the server, producing a broken redirect. Logging out invalidates the anonymous session and, since
+    // the user was anonymous, Nuxeo forwards to `login.jsp?forceAnonymousLogin=true&requestedUrl=...`.
+    // Browsers carry a fragment across redirects whose Location has none, so appending it here keeps the
+    // requested route alive until the server records it in the cookie.
+    const requestedUrl = `${globalThis.location.pathname}${globalThis.location.search}`;
+    const logoutUrl = `${baseUrl}/logout?requestedUrl=${encodeURIComponent(requestedUrl)}${globalThis.location.hash}`;
+    this._redirect(logoutUrl);
+  },
+
+  // Seam for the actual navigation (kept separate so it can be stubbed in tests). Use replace() so the
+  // dead-end permission page is not left as a navigable history/bfcache entry after the redirect.
+  _redirect(url) {
+    globalThis.location.replace(url);
+  },
+};

--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -53,6 +53,7 @@ import './nuxeo-app/nuxeo-offline-banner.js';
 import './nuxeo-app/nuxeo-expired-session.js';
 import './nuxeo-document-creation/nuxeo-document-creation-behavior.js';
 import { NuxeoAppDrawerResizeBehavior } from './behaviors/nuxeo-app-drawer-resize-behavior.js';
+import { NuxeoAnonymousBehavior } from './behaviors/nuxeo-anonymous-behavior.js';
 import '@nuxeo/nuxeo-elements/nuxeo-page-provider.js';
 import '@nuxeo/nuxeo-elements/nuxeo-task-page-provider.js';
 import '@nuxeo/nuxeo-ui-elements/nuxeo-data-table/iron-data-table.js';
@@ -626,7 +627,7 @@ Polymer({
   `,
 
   is: 'nuxeo-app',
-  behaviors: [RoutingBehavior, FormatBehavior, FiltersBehavior, NuxeoAppDrawerResizeBehavior],
+  behaviors: [RoutingBehavior, FormatBehavior, FiltersBehavior, NuxeoAppDrawerResizeBehavior, NuxeoAnonymousBehavior],
   importMeta: import.meta,
   properties: {
     productName: {
@@ -1122,6 +1123,12 @@ Polymer({
       })
       .catch((err) => {
         if (err && err.name === 'AbortError') {
+          return;
+        }
+        // WEBUI-1857: an anonymous user hitting a 403 is redirected to the login page (preserving the
+        // permalink) instead of being shown a dead-end permission error page.
+        if (this._isAnonymousForbidden(err)) {
+          this._redirectAnonymousToLogin();
           return;
         }
         this.showError(err.status, this.i18n('browse.error'), err.message);

--- a/test/nuxeo-anonymous-behavior.test.js
+++ b/test/nuxeo-anonymous-behavior.test.js
@@ -1,0 +1,137 @@
+/**
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { fixture, flush, html } from '@nuxeo/testing-helpers';
+import '../elements/nuxeo-app.js';
+
+suite('nuxeo-anonymous-behavior', () => {
+  let app;
+
+  setup(async () => {
+    app = await fixture(html`<nuxeo-app></nuxeo-app>`);
+    sinon.stub(app, 'i18n').callsFake((key) => key);
+    if (app.$ && app.$.userWorkspace) {
+      sinon.stub(app.$.userWorkspace, 'execute').resolves({ path: '/user-workspace' });
+    }
+    if (app.$ && app.$.tasksProvider) {
+      sinon.stub(app.$.tasksProvider, 'fetch').resolves({ resultsCount: 0 });
+    }
+    await flush();
+  });
+
+  suite('_isAnonymousUser', () => {
+    test('is false when there is no current user', () => {
+      app.currentUser = null;
+      expect(app._isAnonymousUser()).to.be.false;
+    });
+
+    test('is false for an authenticated (non-anonymous) user', () => {
+      app.currentUser = { id: 'jdoe', isAnonymous: false, properties: {} };
+      expect(app._isAnonymousUser()).to.be.false;
+    });
+
+    test('is true for the anonymous user', () => {
+      app.currentUser = { id: 'Anonymous', isAnonymous: true, properties: {} };
+      expect(app._isAnonymousUser()).to.be.true;
+    });
+  });
+
+  suite('_isAnonymousForbidden', () => {
+    test('is true for an anonymous user and a 403 error', () => {
+      app.currentUser = { id: 'Anonymous', isAnonymous: true, properties: {} };
+      expect(app._isAnonymousForbidden({ status: 403 })).to.be.true;
+    });
+
+    test('coerces string status codes', () => {
+      app.currentUser = { id: 'Anonymous', isAnonymous: true, properties: {} };
+      expect(app._isAnonymousForbidden({ status: '403' })).to.be.true;
+    });
+
+    test('is false for an anonymous user and a non-403 error', () => {
+      app.currentUser = { id: 'Anonymous', isAnonymous: true, properties: {} };
+      expect(app._isAnonymousForbidden({ status: 404 })).to.be.false;
+    });
+
+    test('is false for an authenticated user even on a 403', () => {
+      app.currentUser = { id: 'jdoe', isAnonymous: false, properties: {} };
+      expect(app._isAnonymousForbidden({ status: 403 })).to.be.false;
+    });
+
+    test('is false when there is no error', () => {
+      app.currentUser = { id: 'Anonymous', isAnonymous: true, properties: {} };
+      expect(app._isAnonymousForbidden(undefined)).to.be.false;
+    });
+  });
+
+  suite('_redirectAnonymousToLogin', () => {
+    test('redirects through the logout endpoint preserving the requested URL', () => {
+      const redirect = sinon.stub(app, '_redirect');
+      app._redirectAnonymousToLogin();
+      expect(redirect.calledOnce).to.be.true;
+      const url = redirect.firstCall.args[0];
+      expect(url).to.contain('/logout?requestedUrl=');
+      // requestedUrl must be the context-relative path (no origin), url-encoded
+      const expected = encodeURIComponent(`${globalThis.location.pathname}${globalThis.location.search}`);
+      expect(url).to.contain(`requestedUrl=${expected}`);
+      // the fragment (Web UI route) is re-appended so it survives the logout redirect chain
+      expect(url.endsWith(globalThis.location.hash)).to.be.true;
+    });
+
+    test('stores the current URL fragment in a cookie for post-login restore', () => {
+      sinon.stub(app, '_redirect');
+      app._redirectAnonymousToLogin();
+      expect(document.cookie).to.contain('nuxeo.start.url.fragment');
+    });
+
+    test('is guarded so repeated 403s only trigger a single redirect', () => {
+      const redirect = sinon.stub(app, '_redirect');
+      app._redirectAnonymousToLogin();
+      app._redirectAnonymousToLogin();
+      app._redirectAnonymousToLogin();
+      expect(redirect.calledOnce).to.be.true;
+    });
+  });
+
+  suite('load() integration', () => {
+    test('redirects to login (not the error page) when an anonymous user gets a 403', async () => {
+      app.currentUser = { id: 'Anonymous', isAnonymous: true, properties: {} };
+      const redirect = sinon.stub(app, '_redirect');
+      const showError = sinon.stub(app, 'showError');
+      sinon
+        .stub(app, '_loadDocument')
+        .rejects({ status: 403, message: "Privilege 'Read' is not granted to 'Anonymous'" });
+      app.load('browse', 'some-uid', '', 'view');
+      await flush();
+      // allow the rejected promise chain to settle
+      await Promise.resolve();
+      expect(redirect.calledOnce).to.be.true;
+      expect(showError.called).to.be.false;
+    });
+
+    test('shows the error page when an authenticated user gets a 403', async () => {
+      app.currentUser = { id: 'jdoe', isAnonymous: false, properties: {} };
+      const redirect = sinon.stub(app, '_redirect');
+      const showError = sinon.stub(app, 'showError');
+      sinon.stub(app, '_loadDocument').rejects({ status: 403, message: 'forbidden' });
+      app.load('browse', 'some-uid', '', 'view');
+      await flush();
+      await Promise.resolve();
+      expect(redirect.called).to.be.false;
+      expect(showError.calledOnce).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Problem
With anonymous authentication enabled, an anonymous user who opens a permalink to a document they are not allowed to read gets a dead-end "403 – Permission Denied" page. The only way forward is to manually log out of the anonymous session, log back in with a real account, and reopen the permalink. Jira: [WEBUI-1857](https://hyland.atlassian.net/browse/WEBUI-1857)

## Root cause
`nuxeo-app`'s document `load()` sends every failure (including a 403 for an anonymous user) to `showError`, rendering the permission-error page. There was no handling to recognise that an *anonymous* 403 is recoverable by authenticating with a real account.

Redirecting an anonymous user straight to `login.jsp` does not work either: the anonymous session already carries `USERIDENT_KEY`, so Nuxeo treats them as logged in and bounces back to the requested page.

## Changes
* **`elements/behaviors/nuxeo-anonymous-behavior.js`** (new): `NuxeoAnonymousBehavior` detects an anonymous 403 and routes the user through the Nuxeo **logout** endpoint, which invalidates the anonymous session and — because the user was anonymous — forwards to the login form (`forceAnonymousLogin=true`) while preserving `requestedUrl`. The Web UI route lives in the URL fragment (not sent to the server), so it is re-appended to the logout URL and stored in the `nuxeo.start.url.fragment` cookie (the same cookie `nuxeo-connection` uses for its form-auth 401 redirect); Nuxeo restores it after login so the user lands back on the requested document.
* **`elements/nuxeo-app.js`**: compose the new behavior and, in the `load()` catch, redirect on an anonymous 403 instead of showing the dead-end error page. Authenticated users still get the normal error page.
* **`test/nuxeo-anonymous-behavior.test.js`** (new): unit tests for the anonymity/403 detection, the logout redirect (URL, requestedUrl, fragment, one-shot guard) and the `load()` integration (anonymous 403 redirects; authenticated 403 still shows the error page).

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (2256 passed, incl. new behavior tests)
- [x] Manual/E2E against a Nuxeo instance with anonymous auth: anonymous opens a restricted permalink → redirected to the login page (`requestedUrl` preserved) → after logging in with a real account, lands back on the exact document. Before/after screenshots and videos captured.

## Notes
Self-contained client logic is kept in a Polymer behavior rather than inlined into the already-large `nuxeo-app.js`. Backport to `maintenance-3.1.x` is opened as a separate PR.

Made with [Cursor](https://cursor.com)

[WEBUI-1857]: https://hyland.atlassian.net/browse/WEBUI-1857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ