### PR TITLE
ELEMENTS-1856: link documents in Nuxeo Drive synchronization roots [lts-2025]

### DIFF
--- a/addons/nuxeo-drive/elements/nuxeo-drive-sync-roots-management.js
+++ b/addons/nuxeo-drive/elements/nuxeo-drive-sync-roots-management.js
@@ -19,6 +19,7 @@ Contributors:
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
+import { RoutingBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-routing-behavior.js';
 
 /**
 An element listing Nuxeo Drive synchronization roots.
@@ -66,6 +67,15 @@ Polymer({
         overflow: hidden;
       }
 
+      .cell a {
+        color: var(--nuxeo-primary-color, #0066ff);
+        text-decoration: underline;
+      }
+
+      .cell a:hover {
+        color: var(--nuxeo-link-hover-color, var(--nuxeo-primary-color, #0066ff));
+      }
+
       paper-icon-button:hover ::content iron-icon {
         color: var(--nuxeo-action-hover, #00adff);
       }
@@ -96,8 +106,8 @@ Polymer({
         </div>
         <template is="dom-repeat" items="[[roots]]" as="doc">
           <div class="row">
-            <div class="cell flex-1">[[doc.title]]</div>
-            <div class="cell flex-3">[[doc.path]]</div>
+            <div class="cell flex-1"><a href$="[[urlFor(doc)]]">[[doc.title]]</a></div>
+            <div class="cell flex-3"><a href$="[[urlFor(doc)]]">[[doc.path]]</a></div>
             <div class="cell actions">
               <paper-icon-button
                 icon="icons:clear"
@@ -123,7 +133,7 @@ Polymer({
     },
   },
 
-  behaviors: [I18nBehavior],
+  behaviors: [I18nBehavior, RoutingBehavior],
 
   _handleRoots(e) {
     this.roots = e.detail.response.entries;

--- a/addons/nuxeo-drive/elements/nuxeo-drive-sync-roots-management.js
+++ b/addons/nuxeo-drive/elements/nuxeo-drive-sync-roots-management.js
@@ -107,7 +107,7 @@ Polymer({
         <template is="dom-repeat" items="[[roots]]" as="doc">
           <div class="row">
             <div class="cell flex-1"><a href$="[[urlFor(doc)]]">[[doc.title]]</a></div>
-            <div class="cell flex-3">[[doc.path]]</div>
+            <div class="cell flex-3"><a href$="[[urlFor(doc)]]">[[doc.path]]</a></div>
             <div class="cell actions">
               <paper-icon-button
                 icon="icons:clear"

--- a/addons/nuxeo-drive/elements/nuxeo-drive-sync-roots-management.js
+++ b/addons/nuxeo-drive/elements/nuxeo-drive-sync-roots-management.js
@@ -107,7 +107,7 @@ Polymer({
         <template is="dom-repeat" items="[[roots]]" as="doc">
           <div class="row">
             <div class="cell flex-1"><a href$="[[urlFor(doc)]]">[[doc.title]]</a></div>
-            <div class="cell flex-3"><a href$="[[urlFor(doc)]]">[[doc.path]]</a></div>
+            <div class="cell flex-3">[[doc.path]]</div>
             <div class="cell actions">
               <paper-icon-button
                 icon="icons:clear"

--- a/addons/nuxeo-drive/test/nuxeo-drive-sync-roots-management.test.js
+++ b/addons/nuxeo-drive/test/nuxeo-drive-sync-roots-management.test.js
@@ -95,7 +95,7 @@ suite('nuxeo-drive-sync-roots-management', () => {
       });
     });
 
-    test('should render each root title (only) as a link to the document', async () => {
+    test('should render each root title and path as links to the document', async () => {
       element.roots = [
         { uid: 'root1', title: 'Root 1', path: '/root1', type: 'Folder' },
         { uid: 'root2', title: 'Root 2', path: '/root2', type: 'Folder' },
@@ -103,17 +103,18 @@ suite('nuxeo-drive-sync-roots-management', () => {
       await flush();
       const rows = element.shadowRoot.querySelectorAll('.table .row');
       expect(rows).to.have.lengthOf(2);
-      // Only the title cell links to the document; the path stays plain text.
-      const links = element.shadowRoot.querySelectorAll('.table .row .cell a');
-      expect(links).to.have.lengthOf(2);
-      expect(links[0].textContent.trim()).to.equal('Root 1');
-      expect(links[1].textContent.trim()).to.equal('Root 2');
-      expect(links[0].getAttribute('href')).to.equal('/ui/#!/browse/root1');
-      expect(links[1].getAttribute('href')).to.equal('/ui/#!/browse/root2');
-      // The path cell renders the text without an anchor.
-      const pathCell = rows[0].querySelector('.cell.flex-3');
-      expect(pathCell.querySelector('a')).to.be.null;
-      expect(pathCell.textContent.trim()).to.equal('/root1');
+      // Both the title and path cells link to the document.
+      rows.forEach((row, i) => {
+        const titleLink = row.querySelector('.cell.flex-1 a');
+        const pathLink = row.querySelector('.cell.flex-3 a');
+        const href = `/ui/#!/browse${element.roots[i].path}`;
+        expect(titleLink).to.be.ok;
+        expect(pathLink).to.be.ok;
+        expect(titleLink.textContent.trim()).to.equal(element.roots[i].title);
+        expect(pathLink.textContent.trim()).to.equal(element.roots[i].path);
+        expect(titleLink.getAttribute('href')).to.equal(href);
+        expect(pathLink.getAttribute('href')).to.equal(href);
+      });
       expect(element.urlFor).to.have.been.calledWith(element.roots[0]);
       expect(element.urlFor).to.have.been.calledWith(element.roots[1]);
     });

--- a/addons/nuxeo-drive/test/nuxeo-drive-sync-roots-management.test.js
+++ b/addons/nuxeo-drive/test/nuxeo-drive-sync-roots-management.test.js
@@ -86,7 +86,7 @@ suite('nuxeo-drive-sync-roots-management', () => {
   });
 
   suite('document links', () => {
-    // urlFor is a Polymer computed from router; shadow it with a stub for unit tests.
+    // urlFor is a routing helper method provided by RoutingBehavior; shadow it with a stub for unit tests.
     setup(() => {
       Object.defineProperty(element, 'urlFor', {
         value: sinon.stub().callsFake((doc) => `/ui/#!/browse${doc.path}`),

--- a/addons/nuxeo-drive/test/nuxeo-drive-sync-roots-management.test.js
+++ b/addons/nuxeo-drive/test/nuxeo-drive-sync-roots-management.test.js
@@ -112,7 +112,7 @@ suite('nuxeo-drive-sync-roots-management', () => {
       expect(links[1].getAttribute('href')).to.equal('/ui/#!/browse/root2');
       // The path cell renders the text without an anchor.
       const pathCell = rows[0].querySelector('.cell.flex-3');
-      expect(pathCell.querySelector('a')).to.equal(null);
+      expect(pathCell.querySelector('a')).to.be.null;
       expect(pathCell.textContent.trim()).to.equal('/root1');
       expect(element.urlFor).to.have.been.calledWith(element.roots[0]);
       expect(element.urlFor).to.have.been.calledWith(element.roots[1]);

--- a/addons/nuxeo-drive/test/nuxeo-drive-sync-roots-management.test.js
+++ b/addons/nuxeo-drive/test/nuxeo-drive-sync-roots-management.test.js
@@ -95,7 +95,7 @@ suite('nuxeo-drive-sync-roots-management', () => {
       });
     });
 
-    test('should render each root title and path as links to the document', async () => {
+    test('should render each root title (only) as a link to the document', async () => {
       element.roots = [
         { uid: 'root1', title: 'Root 1', path: '/root1', type: 'Folder' },
         { uid: 'root2', title: 'Root 2', path: '/root2', type: 'Folder' },
@@ -103,15 +103,17 @@ suite('nuxeo-drive-sync-roots-management', () => {
       await flush();
       const rows = element.shadowRoot.querySelectorAll('.table .row');
       expect(rows).to.have.lengthOf(2);
-      // Each row links both the title cell and the path cell to the document.
-      const [titleLink1, pathLink1] = rows[0].querySelectorAll('.cell a');
-      const [titleLink2, pathLink2] = rows[1].querySelectorAll('.cell a');
-      expect(titleLink1.textContent.trim()).to.equal('Root 1');
-      expect(pathLink1.textContent.trim()).to.equal('/root1');
-      expect(titleLink1.getAttribute('href')).to.equal('/ui/#!/browse/root1');
-      expect(pathLink1.getAttribute('href')).to.equal('/ui/#!/browse/root1');
-      expect(titleLink2.getAttribute('href')).to.equal('/ui/#!/browse/root2');
-      expect(pathLink2.getAttribute('href')).to.equal('/ui/#!/browse/root2');
+      // Only the title cell links to the document; the path stays plain text.
+      const links = element.shadowRoot.querySelectorAll('.table .row .cell a');
+      expect(links).to.have.lengthOf(2);
+      expect(links[0].textContent.trim()).to.equal('Root 1');
+      expect(links[1].textContent.trim()).to.equal('Root 2');
+      expect(links[0].getAttribute('href')).to.equal('/ui/#!/browse/root1');
+      expect(links[1].getAttribute('href')).to.equal('/ui/#!/browse/root2');
+      // The path cell renders the text without an anchor.
+      const pathCell = rows[0].querySelector('.cell.flex-3');
+      expect(pathCell.querySelector('a')).to.equal(null);
+      expect(pathCell.textContent.trim()).to.equal('/root1');
       expect(element.urlFor).to.have.been.calledWith(element.roots[0]);
       expect(element.urlFor).to.have.been.calledWith(element.roots[1]);
     });

--- a/addons/nuxeo-drive/test/nuxeo-drive-sync-roots-management.test.js
+++ b/addons/nuxeo-drive/test/nuxeo-drive-sync-roots-management.test.js
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { fixture, html, login } from '@nuxeo/testing-helpers';
+import { fixture, flush, html, login } from '@nuxeo/testing-helpers';
 import '../elements/nuxeo-drive-sync-roots-management.js';
 
 suite('nuxeo-drive-sync-roots-management', () => {
@@ -82,6 +82,38 @@ suite('nuxeo-drive-sync-roots-management', () => {
       const executeStub = sinon.stub(element.$.roots, 'execute').returns(Promise.resolve());
       element.refresh();
       expect(executeStub).to.have.been.calledWith(element);
+    });
+  });
+
+  suite('document links', () => {
+    // urlFor is a Polymer computed from router; shadow it with a stub for unit tests.
+    setup(() => {
+      Object.defineProperty(element, 'urlFor', {
+        value: sinon.stub().callsFake((doc) => `/ui/#!/browse${doc.path}`),
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    test('should render each root title and path as links to the document', async () => {
+      element.roots = [
+        { uid: 'root1', title: 'Root 1', path: '/root1', type: 'Folder' },
+        { uid: 'root2', title: 'Root 2', path: '/root2', type: 'Folder' },
+      ];
+      await flush();
+      const rows = element.shadowRoot.querySelectorAll('.table .row');
+      expect(rows).to.have.lengthOf(2);
+      // Each row links both the title cell and the path cell to the document.
+      const [titleLink1, pathLink1] = rows[0].querySelectorAll('.cell a');
+      const [titleLink2, pathLink2] = rows[1].querySelectorAll('.cell a');
+      expect(titleLink1.textContent.trim()).to.equal('Root 1');
+      expect(pathLink1.textContent.trim()).to.equal('/root1');
+      expect(titleLink1.getAttribute('href')).to.equal('/ui/#!/browse/root1');
+      expect(pathLink1.getAttribute('href')).to.equal('/ui/#!/browse/root1');
+      expect(titleLink2.getAttribute('href')).to.equal('/ui/#!/browse/root2');
+      expect(pathLink2.getAttribute('href')).to.equal('/ui/#!/browse/root2');
+      expect(element.urlFor).to.have.been.calledWith(element.roots[0]);
+      expect(element.urlFor).to.have.been.calledWith(element.roots[1]);
     });
   });
 });


### PR DESCRIPTION
## Problem
In the Nuxeo Drive user settings, the **Synchronization Roots** table listed each root's title and path as plain text, giving no way to navigate to the underlying document. Jira: [ELEMENTS-1856](https://hyland.atlassian.net/browse/ELEMENTS-1856)

## Root cause
`nuxeo-drive-sync-roots-management` rendered `[[doc.title]]` and `[[doc.path]]` as static text, with no routing helper wired in.

## Changes
* **`addons/nuxeo-drive/elements/nuxeo-drive-sync-roots-management.js`**: add `RoutingBehavior` and wrap both the title and path cells in `<a href$="[[urlFor(doc)]]">`, so each root links to its document using the same reverse-routing helper as the rest of Web UI. Style the links underlined and in the primary accent colour (`--nuxeo-primary-color`) so they clearly read as links.
* **`addons/nuxeo-drive/test/nuxeo-drive-sync-roots-management.test.js`**: add coverage asserting both the title and path cells render as anchors pointing at the document.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (2244 unit tests)
- [x] Manual: on a live instance, Drive → Synchronization Roots shows title + path as underlined/highlighted links that navigate to the document (verified via deep-shadow-DOM probe + screenshot; hrefs resolve to `/nuxeo/ui/#!/browse/...`)

## Notes
Backport pair: also opened against `maintenance-3.1.x`.

Made with [Cursor](https://cursor.com)

[ELEMENTS-1856]: https://hyland.atlassian.net/browse/ELEMENTS-1856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ