### PR TITLE
WEBUI-2113: Fix form-data high CVE-2026-12143 [lts-2025]

### DIFF
--- a/packages/nuxeo-web-ui-ftest/package-lock.json
+++ b/packages/nuxeo-web-ui-ftest/package-lock.json
@@ -6011,9 +6011,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",


### PR DESCRIPTION
## Problem
Dependabot flagged a **high**-severity CRLF-injection advisory (CVSS 7.5 / 8.7) in the transitive runtime dependency `form-data@4.0.5` in the `nuxeo-web-ui-ftest` sub-package. `form-data` concatenated `field` name and `filename` directly into the `Content-Disposition` header without escaping CR (`\r`), LF (`\n`), or `"`, so untrusted field names/filenames could inject headers or smuggle extra multipart parts. Jira: [WEBUI-2113](https://hyland.atlassian.net/browse/WEBUI-2113) · [Dependabot #334](https://github.com/nuxeo/nuxeo-web-ui/security/dependabot/334) · GHSA-hmw2-7cc7-3qxx · CVE-2026-12143

## Root cause
`form-data` `>= 4.0.0, < 4.0.6` is vulnerable (CWE-93); the fix (escaping CR/LF/`"` per the WHATWG multipart algorithm) landed in `4.0.6`. It is a transitive dependency pulled in via `nuxeo` (`^4.0.0`).

## Changes
* **`packages/nuxeo-web-ui-ftest/package-lock.json`**: bump `form-data` `4.0.5` → `4.0.6` (patched). The consumer range (`^4.0.0`) already accepts `4.0.6`, so `package.json` is unchanged and no other tree entries move — surgical lockfile-only diff. Integrity hash verified against the npm registry.

## Test plan
- [ ] CI (`lint`, `unit-test`, `ftests`, `build`) passes — no source changed
- [x] Sub-package lockfile is valid JSON; `form-data@4.0.6` integrity matches the npm registry

## Notes
Lockfile-only change scoped to the functional-test sub-package (`packages/nuxeo-web-ui-ftest`), which uses `npm ci` in CI. Backported as a matched pair — companion PR #3285 targets `maintenance-3.1.x`.

Made with [Cursor](https://cursor.com)

[WEBUI-2113]: https://hyland.atlassian.net/browse/WEBUI-2113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ