### PR TITLE
ELEMENTS-1616: request grid/list thumbnails with crossorigin [maintenance-3.1.x]

### DIFF
--- a/elements/nuxeo-data-grid/nuxeo-document-grid-thumbnail.js
+++ b/elements/nuxeo-data-grid/nuxeo-document-grid-thumbnail.js
@@ -217,7 +217,7 @@ Polymer({
 
     <div class="bubbleBox grid-box" selection-mode$="[[selectionMode]]">
       <div class="thumbnailContainer" on-tap="handleClick" tabindex="0">
-        <img src="[[_thumbnail(doc)]]" alt$="[[doc.title]]" />
+        <img crossorigin="anonymous" src="[[_thumbnail(doc)]]" alt$="[[doc.title]]" />
       </div>
       <template is="dom-if" if="[[_hasDocument(doc)]]">
         <a class="title" href$="[[urlFor(doc)]]" on-tap="handleClick" on-keydown="_handleKeydown" tabindex="0">

--- a/elements/nuxeo-data-list/nuxeo-document-list-item.js
+++ b/elements/nuxeo-data-list/nuxeo-document-list-item.js
@@ -226,7 +226,7 @@ Polymer({
     <div class="listBox grid-box" selection-mode$="[[selectionMode]]">
       <div class="horizontal layout">
         <div class="vignette thumbnailContainer" on-tap="handleClick" on-keydown="_handleKeydown">
-          <img src="[[_thumbnail(doc)]]" alt$="[[doc.title]]" />
+          <img crossorigin="anonymous" src="[[_thumbnail(doc)]]" alt$="[[doc.title]]" />
         </div>
         <div class="dataContainer flex" on-tap="handleClick" on-keydown="_handleKeydown">
           <div class="horizontal layout center" tabindex="0">

--- a/test/nuxeo-document-grid-thumbnail.test.js
+++ b/test/nuxeo-document-grid-thumbnail.test.js
@@ -44,6 +44,15 @@ suite('nuxeo-document-grid-thumbnail', () => {
     test('should default selectedItems to empty array', () => {
       expect(element.selectedItems).to.deep.equal([]);
     });
+
+    // ELEMENTS-1616: consistent crossorigin across all elements that render the
+    // same thumbnail URL, otherwise a plain <img> poisons Chrome's cache and the
+    // crossorigin <img> (list/thumbnail view) fails to load under S3 direct download.
+    test('renders the thumbnail img with crossorigin="anonymous"', () => {
+      const img = element.shadowRoot.querySelector('.thumbnailContainer img');
+      expect(img).to.be.ok;
+      expect(img.getAttribute('crossorigin')).to.equal('anonymous');
+    });
   });
 
   suite('_thumbnail', () => {

--- a/test/nuxeo-document-list-item.test.js
+++ b/test/nuxeo-document-list-item.test.js
@@ -45,13 +45,12 @@ suite('nuxeo-document-list-item', () => {
       expect(element.selectedItems).to.deep.equal([]);
     });
 
-    // ELEMENTS-1616: consistent crossorigin across all elements that render the
-    // same thumbnail URL, otherwise a plain <img> poisons Chrome's cache and the
-    // crossorigin <img> (list/thumbnail view) fails to load under S3 direct download.
-    test('renders the thumbnail img with crossorigin="anonymous"', () => {
-      const img = element.shadowRoot.querySelector('.thumbnailContainer img');
-      expect(img).to.be.ok;
-      expect(img.getAttribute('crossorigin')).to.equal('anonymous');
+    // ELEMENTS-1616: the list-item thumbnail must request the same URL with CORS
+    // so it stays consistent with the grid/preview <img> and avoids Chrome's
+    // cross-origin image cache poisoning under S3 direct download.
+    test('requests its thumbnail with CORS enabled', () => {
+      const thumbnail = element.shadowRoot.querySelector('.thumbnailContainer img');
+      expect(thumbnail.crossOrigin).to.equal('anonymous');
     });
   });
 

--- a/test/nuxeo-document-list-item.test.js
+++ b/test/nuxeo-document-list-item.test.js
@@ -44,6 +44,15 @@ suite('nuxeo-document-list-item', () => {
     test('should default selectedItems to empty array', () => {
       expect(element.selectedItems).to.deep.equal([]);
     });
+
+    // ELEMENTS-1616: consistent crossorigin across all elements that render the
+    // same thumbnail URL, otherwise a plain <img> poisons Chrome's cache and the
+    // crossorigin <img> (list/thumbnail view) fails to load under S3 direct download.
+    test('renders the thumbnail img with crossorigin="anonymous"', () => {
+      const img = element.shadowRoot.querySelector('.thumbnailContainer img');
+      expect(img).to.be.ok;
+      expect(img.getAttribute('crossorigin')).to.equal('anonymous');
+    });
   });
 
   suite('_thumbnail', () => {

--- a/test/nuxeo-document-list-item.test.js
+++ b/test/nuxeo-document-list-item.test.js
@@ -50,7 +50,8 @@ suite('nuxeo-document-list-item', () => {
     // cross-origin image cache poisoning under S3 direct download.
     test('requests its thumbnail with CORS enabled', () => {
       const thumbnail = element.shadowRoot.querySelector('.thumbnailContainer img');
-      expect(thumbnail.crossOrigin).to.equal('anonymous');
+      expect(thumbnail).to.be.ok;
+      expect(thumbnail.getAttribute('crossorigin')).to.equal('anonymous');
     });
   });
 


### PR DESCRIPTION
## Problem
Under S3 direct download in Chrome, document thumbnails fail to load with a CORS error when switching between grid and list views. Jira: [ELEMENTS-1616](https://hyland.atlassian.net/browse/ELEMENTS-1616)

## Root cause
`nuxeo-document-grid-thumbnail` and `nuxeo-document-list-item` render the thumbnail URL with a plain `<img>` (no `crossorigin`). Chrome caches that cross-origin response **without** CORS headers, so the `<img crossorigin>` in `nuxeo-document-thumbnail` (nuxeo-elements) reuses the poisoned cache entry and is blocked by the CORS check → broken thumbnail.

## Changes
* **`elements/nuxeo-data-grid/nuxeo-document-grid-thumbnail.js`**: render the thumbnail with `crossorigin="anonymous"`.
* **`elements/nuxeo-data-list/nuxeo-document-list-item.js`**: render the thumbnail with `crossorigin="anonymous"`.
* **tests**: assert both elements render `<img crossorigin="anonymous">`.

Makes every element that renders the same thumbnail URL consistent, so the first request always caches with CORS headers. Paired with the `nuxeo-elements` PR (nuxeo/nuxeo-elements#1498 / #1499). Safe for same-origin (default) deployments.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (2245 unit tests, incl. new crossorigin assertions)
- [ ] Manual: S3 direct download, grid → list view thumbnails load in Chrome

## Notes
Requires bucket CORS for cross-origin (S3) setups (already required for direct download). Paired PRs in `nuxeo-elements`. Backport pair: `lts-2025` + `maintenance-3.1.x` (Jira fixVersions also list `3.0.x` — flagged for a possible `maintenance-3.0.x` backport).


[ELEMENTS-1616]: https://hyland.atlassian.net/browse/ELEMENTS-1616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ