### PR TITLE
WEBUI-2108: Enhance nuxeo-document-storage to handle null documents and add unit tests [LTS-2025]

### DIFF
--- a/elements/nuxeo-document-storage/nuxeo-document-storage.js
+++ b/elements/nuxeo-document-storage/nuxeo-document-storage.js
@@ -43,6 +43,7 @@ Polymer({
         id="storage"
         name="[[_storageName]]"
         value="{{documents}}"
+        on-iron-localstorage-load="_normalizeLoadedValue"
         on-iron-localstorage-load-empty="initialize"
       >
       </iron-localstorage>
@@ -69,6 +70,15 @@ Polymer({
     this.documents = [];
   },
 
+  // iron-localstorage fires 'load' with a null value when the stored entry is missing or
+  // holds unparseable JSON. Normalize to an empty array so consumers never operate on a
+  // null list; setting documents also re-persists a valid value, healing the corrupted entry.
+  _normalizeLoadedValue() {
+    if (!Array.isArray(this.documents)) {
+      this.initialize();
+    }
+  },
+
   add(doc) {
     if (this.contains(doc)) {
       return;
@@ -84,6 +94,10 @@ Polymer({
     };
     if (doc.contextParameters && doc.contextParameters.thumbnail && doc.contextParameters.thumbnail.url) {
       document.contextParameters = { thumbnail: { url: doc.contextParameters.thumbnail.url } };
+    }
+    // guard against a null/undefined value persisted in localStorage, which would make unshift throw
+    if (!Array.isArray(this.documents)) {
+      this.documents = [];
     }
     return this.unshift('documents', document);
   },
@@ -117,6 +131,9 @@ Polymer({
   },
 
   _indexOf(doc) {
+    if (!Array.isArray(this.documents)) {
+      return -1;
+    }
     return this.documents.findIndex((e) => e.uid === doc.uid);
   },
 

--- a/elements/nuxeo-recent-documents/nuxeo-recent-documents.js
+++ b/elements/nuxeo-recent-documents/nuxeo-recent-documents.js
@@ -130,7 +130,7 @@ Polymer({
 
   add(doc) {
     this.$.storage.add(doc);
-    if (this.documents.length > this.maxSize) {
+    if (this.documents && this.documents.length > this.maxSize) {
       this.splice('documents', -1, 1);
     }
   },

--- a/test/nuxeo-document-storage.test.js
+++ b/test/nuxeo-document-storage.test.js
@@ -22,15 +22,17 @@ suite('nuxeo-document-storage', () => {
   let server;
   let element;
 
-  const doc = (uid, extra = {}) => {return {
-    'entity-type': 'document',
-    uid,
-    path: `/default-domain/${uid}`,
-    repository: 'default',
-    title: `Doc ${uid}`,
-    type: 'File',
-    ...extra,
-  }};
+  const doc = (uid, extra = {}) => {
+    return {
+      'entity-type': 'document',
+      uid,
+      path: `/default-domain/${uid}`,
+      repository: 'default',
+      title: `Doc ${uid}`,
+      type: 'File',
+      ...extra,
+    };
+  };
 
   setup(async () => {
     server = await login();
@@ -167,6 +169,26 @@ suite('nuxeo-document-storage', () => {
       element.documents = null;
       element.initialize();
       expect(element.documents).to.be.an('array').that.is.empty;
+    });
+  });
+
+  suite('_normalizeLoadedValue', () => {
+    test('should initialize documents when the loaded value is null', () => {
+      element.documents = null;
+      element._normalizeLoadedValue();
+      expect(element.documents).to.be.an('array').that.is.empty;
+    });
+
+    test('should initialize documents when the loaded value is not an array', () => {
+      element.documents = 'corrupted';
+      element._normalizeLoadedValue();
+      expect(element.documents).to.be.an('array').that.is.empty;
+    });
+
+    test('should keep the loaded value when it is already an array', () => {
+      element.documents = [doc('1')];
+      element._normalizeLoadedValue();
+      expect(element.documents.map((d) => d.uid)).to.deep.equal(['1']);
     });
   });
 });

--- a/test/nuxeo-document-storage.test.js
+++ b/test/nuxeo-document-storage.test.js
@@ -1,0 +1,172 @@
+/**
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { fixture, html, login } from '@nuxeo/testing-helpers';
+import '../elements/nuxeo-document-storage/nuxeo-document-storage.js';
+
+suite('nuxeo-document-storage', () => {
+  let server;
+  let element;
+
+  const doc = (uid, extra = {}) => {return {
+    'entity-type': 'document',
+    uid,
+    path: `/default-domain/${uid}`,
+    repository: 'default',
+    title: `Doc ${uid}`,
+    type: 'File',
+    ...extra,
+  }};
+
+  setup(async () => {
+    server = await login();
+    element = await fixture(html`<nuxeo-document-storage name="test-storage"></nuxeo-document-storage>`);
+  });
+
+  teardown(() => {
+    server.restore();
+  });
+
+  suite('add', () => {
+    test('should add a document to an empty list', () => {
+      element.documents = [];
+      element.add(doc('1'));
+      expect(element.documents).to.have.lengthOf(1);
+      expect(element.documents[0].uid).to.equal('1');
+    });
+
+    test('should prepend documents (most recent first)', () => {
+      element.documents = [];
+      element.add(doc('1'));
+      element.add(doc('2'));
+      expect(element.documents.map((d) => d.uid)).to.deep.equal(['2', '1']);
+    });
+
+    test('should not add a duplicate document', () => {
+      element.documents = [doc('1')];
+      element.add(doc('1'));
+      expect(element.documents).to.have.lengthOf(1);
+    });
+
+    test('should keep only whitelisted thumbnail context parameters', () => {
+      element.documents = [];
+      element.add(doc('1', { contextParameters: { thumbnail: { url: 'http://x/thumb.png' }, extra: 'drop' } }));
+      expect(element.documents[0].contextParameters).to.deep.equal({ thumbnail: { url: 'http://x/thumb.png' } });
+    });
+
+    test('should not throw and should initialize the list when documents is null', () => {
+      element.documents = null;
+      expect(() => element.add(doc('1'))).to.not.throw();
+      expect(element.documents).to.be.an('array').with.lengthOf(1);
+      expect(element.documents[0].uid).to.equal('1');
+    });
+
+    test('should not throw and should initialize the list when documents is undefined', () => {
+      element.documents = undefined;
+      expect(() => element.add(doc('1'))).to.not.throw();
+      expect(element.documents).to.be.an('array').with.lengthOf(1);
+    });
+  });
+
+  suite('contains', () => {
+    test('should return true when the document is stored', () => {
+      element.documents = [doc('1')];
+      expect(element.contains(doc('1'))).to.be.true;
+    });
+
+    test('should return false when the document is not stored', () => {
+      element.documents = [doc('1')];
+      expect(element.contains(doc('2'))).to.be.false;
+    });
+
+    test('should return a falsy value and not throw when documents is null', () => {
+      element.documents = null;
+      expect(() => element.contains(doc('1'))).to.not.throw();
+      expect(element.contains(doc('1'))).to.not.be.ok;
+    });
+  });
+
+  suite('_indexOf', () => {
+    test('should return the index of a stored document', () => {
+      element.documents = [doc('1'), doc('2')];
+      expect(element._indexOf(doc('2'))).to.equal(1);
+    });
+
+    test('should return -1 when the document is not stored', () => {
+      element.documents = [doc('1')];
+      expect(element._indexOf(doc('2'))).to.equal(-1);
+    });
+
+    test('should return -1 and not throw when documents is null', () => {
+      element.documents = null;
+      expect(() => element._indexOf(doc('1'))).to.not.throw();
+      expect(element._indexOf(doc('1'))).to.equal(-1);
+    });
+  });
+
+  suite('remove', () => {
+    test('should remove a stored document', () => {
+      element.documents = [doc('1'), doc('2')];
+      element.remove(doc('1'));
+      expect(element.documents.map((d) => d.uid)).to.deep.equal(['2']);
+    });
+
+    test('should not throw when documents is null', () => {
+      element.documents = null;
+      expect(() => element.remove(doc('1'))).to.not.throw();
+    });
+  });
+
+  suite('update', () => {
+    test('should update properties of a stored document', () => {
+      element.documents = [doc('1')];
+      element.update(doc('1'), { title: 'Renamed' });
+      expect(element.documents[0].title).to.equal('Renamed');
+    });
+
+    test('should not throw when documents is null', () => {
+      element.documents = null;
+      expect(() => element.update(doc('1'), { title: 'Renamed' })).to.not.throw();
+    });
+  });
+
+  suite('get', () => {
+    test('should return a stored document', () => {
+      element.documents = [doc('1')];
+      expect(element.get(doc('1')).uid).to.equal('1');
+    });
+
+    test('should return null when the document is not stored', () => {
+      element.documents = [doc('1')];
+      expect(element.get(doc('2'))).to.be.null;
+    });
+
+    test('should return null and not throw when documents is null', () => {
+      element.documents = null;
+      expect(() => element.get(doc('1'))).to.not.throw();
+      expect(element.get(doc('1'))).to.be.null;
+    });
+  });
+
+  suite('initialize', () => {
+    test('should reset documents to an empty array', () => {
+      element.documents = null;
+      element.initialize();
+      expect(element.documents).to.be.an('array').that.is.empty;
+    });
+  });
+});

--- a/test/nuxeo-recent-documents.test.js
+++ b/test/nuxeo-recent-documents.test.js
@@ -90,6 +90,22 @@ suite('nuxeo-recent-documents', () => {
     });
   });
 
+  suite('add', () => {
+    test('should not throw when storage leaves documents null', () => {
+      element.documents = null;
+      sinon.stub(element.$.storage, 'add');
+      expect(() => element.add({ uid: '1', type: 'File' })).to.not.throw();
+    });
+
+    test('should trim the list to maxSize', () => {
+      element.maxSize = 2;
+      element.documents = [{ uid: '1' }, { uid: '2' }, { uid: '3' }];
+      sinon.stub(element.$.storage, 'add');
+      element.add({ uid: '4' });
+      expect(element.documents).to.have.lengthOf(2);
+    });
+  });
+
   suite('_currentDocumentChanged', () => {
     test('should not process trashed documents', () => {
       element.isTrashed.returns(true);

--- a/test/nuxeo-recent-documents.test.js
+++ b/test/nuxeo-recent-documents.test.js
@@ -97,12 +97,13 @@ suite('nuxeo-recent-documents', () => {
       expect(() => element.add({ uid: '1', type: 'File' })).to.not.throw();
     });
 
-    test('should trim the list to maxSize', () => {
+    test('should trim the list to maxSize after a document is added', () => {
       element.maxSize = 2;
-      element.documents = [{ uid: '1' }, { uid: '2' }, { uid: '3' }];
-      sinon.stub(element.$.storage, 'add');
+      element.documents = [{ uid: '1' }, { uid: '2' }];
+      // simulate the real storage side effect of prepending the added document
+      sinon.stub(element.$.storage, 'add').callsFake((doc) => element.unshift('documents', doc));
       element.add({ uid: '4' });
-      expect(element.documents).to.have.lengthOf(2);
+      expect(element.documents.map((d) => d.uid)).to.deep.equal(['4', '1']);
     });
   });
 


### PR DESCRIPTION
https://hyland.atlassian.net/browse/WEBUI-2108


- Added _normalizeLoadedValue method to ensure documents is always an array, preventing null-related errors.
- Updated add and _indexOf methods to handle cases where documents may be null or undefined.
- Introduced unit tests for nuxeo-document-storage to cover various scenarios including adding documents, handling duplicates, and managing null values.
- Modified nuxeo-recent-documents to check for null documents before accessing length.