### PR TITLE
WEBUI-1898: Refresh group/user details after changing user attributes

### DIFF
--- a/elements/nuxeo-admin/nuxeo-user-group-management-page.js
+++ b/elements/nuxeo-admin/nuxeo-user-group-management-page.js
@@ -107,9 +107,14 @@ Polymer({
     }
     if (this.entity && this.entity.id && this.entity.type) {
       if (this.entity.type === 'group') {
+        // Reset before assigning so the `groupname` observer on nuxeo-group-management always
+        // re-fires and re-fetches members, even when returning to the group already selected
+        // (e.g. after editing one of its users). Otherwise the member list stays stale.
+        management.selectedGroup = null;
         management.selectedGroup = this.entity.id;
         management.page = 'manage-group';
       } else if (this.entity.type === 'user') {
+        management.selectedUser = null;
         management.selectedUser = this.entity.id;
         management.page = 'manage-user';
       }

--- a/test/nuxeo-user-group-management-page.test.js
+++ b/test/nuxeo-user-group-management-page.test.js
@@ -115,6 +115,59 @@ suite('nuxeo-user-group-management-page', () => {
       element.$$.restore();
     });
 
+    test('should reset selectedGroup before reassigning so the observer re-fetches (WEBUI-1898)', () => {
+      const assigned = [];
+      const management = { page: null };
+      Object.defineProperty(management, 'selectedGroup', {
+        get() {
+          return this._selectedGroup;
+        },
+        set(v) {
+          this._selectedGroup = v;
+          assigned.push(v);
+        },
+      });
+      // Simulate returning to a group that is already selected.
+      management.selectedGroup = 'admins';
+      assigned.length = 0;
+      element.visible = true;
+      sinon.stub(element, '$$').withArgs('nuxeo-user-group-management').returns(management);
+      element.entity = { type: 'group', id: 'admins' };
+      // Ignore assignments from the observer fired by the line above; assert on an explicit call.
+      assigned.length = 0;
+      element._entityChanged();
+      // null reset then reassignment forces the groupname observer to fire again.
+      expect(assigned).to.deep.equal([null, 'admins']);
+      expect(management.selectedGroup).to.equal('admins');
+      expect(management.page).to.equal('manage-group');
+      element.$$.restore();
+    });
+
+    test('should reset selectedUser before reassigning so the observer re-fetches (WEBUI-1898)', () => {
+      const assigned = [];
+      const management = { page: null };
+      Object.defineProperty(management, 'selectedUser', {
+        get() {
+          return this._selectedUser;
+        },
+        set(v) {
+          this._selectedUser = v;
+          assigned.push(v);
+        },
+      });
+      management.selectedUser = 'jdoe';
+      assigned.length = 0;
+      element.visible = true;
+      sinon.stub(element, '$$').withArgs('nuxeo-user-group-management').returns(management);
+      element.entity = { type: 'user', id: 'jdoe' };
+      assigned.length = 0;
+      element._entityChanged();
+      expect(assigned).to.deep.equal([null, 'jdoe']);
+      expect(management.selectedUser).to.equal('jdoe');
+      expect(management.page).to.equal('manage-user');
+      element.$$.restore();
+    });
+
     test('should reset to search page when entity is empty', () => {
       const searchEl = { _searchTermChanged: sinon.spy() };
       const management = { $$: sinon.stub().withArgs('nuxeo-user-group-search').returns(searchEl) };


### PR DESCRIPTION
## Problem
In Administration > Users & Groups, open a group's member list, click a member to view the user, edit the user's email and save, then go back to the group. The group's member list still shows the **old** (stale) email — the updated attributes are not reflected.

Jira: [WEBUI-1898](https://hyland.atlassian.net/browse/WEBUI-1898)

## Root cause
`nuxeo-user-group-management-page._entityChanged()` assigns `management.selectedGroup = this.entity.id` (and `selectedUser` for users) directly. `selectedGroup` is bound to `nuxeo-group-management.groupname`, whose observer `_fetch()` re-fetches the group and its members. When you navigate back to the **same** group, `selectedGroup` is set to the value it already holds, so the `groupname` observer never fires and the cached member list is kept.

The internal `_manageUser`/`_manageGroup` handlers in `nuxeo-user-group-management.js` already avoid this by doing `selected = null; selected = id` to force the observer; the page wrapper's `_entityChanged` omitted that reset.

## Changes
- `elements/nuxeo-admin/nuxeo-user-group-management-page.js`: reset `selectedGroup`/`selectedUser` to `null` before reassigning in `_entityChanged`, so the child observer always re-fires and re-fetches fresh data on return.
- `test/nuxeo-user-group-management-page.test.js`: added tests asserting the null-reset assignment sequence for both group and user navigation.

## Test plan
- `npm run lint` — passes.
- `npm test` — 2250 unit tests pass (added 2).
- Manual (throwaway Nuxeo 2025 container, dev build A/B): create user + group, view group members, edit the user's email, return to the group. Before: stale email shown. After: refreshed email shown. Before/after screenshots + screen recordings captured for QA.

## Notes
- Minimal, client-only change in the `nuxeo-web-ui` routing wrapper; no `nuxeo-elements` change required.
- Applies to both `lts-2025` and `maintenance-3.1.x` (companion PR opened).

Made with [Cursor](https://cursor.com)

[WEBUI-1898]: https://hyland.atlassian.net/browse/WEBUI-1898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ