### PR TITLE
WEBUI-2116: Upgrade http-proxy-middleware to 2.0.10 (CVE-2026-55602)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16375,9 +16375,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
Resolves Dependabot alert #373 — GHSA-64mm-vxmg-q3vj / CVE-2026-55602 (medium), a `router` host+path substring-matching backend routing bypass in `http-proxy-middleware`.

Bumps `http-proxy-middleware` **2.0.9 → 2.0.10** (patched). It is a **dev-only transitive dependency** via `webpack-dev-server` (range `^2.0.9`), so this is a `package-lock.json`-only change and the package is **not shipped in the application bundle**.

## Impact
No runtime/end-user impact — the package is only used by the local dev server (`npm start`).

## Sanity
- CI: `npm ci` + `npm run lint` + `npm test` (lint verified locally)
- `npm start` dev server boots and proxies to the Nuxeo backend
- Dependabot alert #373 auto-closes on merge

Jira: https://hyland.atlassian.net/browse/WEBUI-2116

🤖 Generated with [Claude Code](https://claude.com/claude-code)