### PR TITLE
WEBUI-1904: Add option to disable the workflow Delegate button [LTS-2023]

### DIFF
--- a/elements/workflow/nuxeo-document-task.js
+++ b/elements/workflow/nuxeo-document-task.js
@@ -153,6 +153,7 @@ Polymer({
                   dialog-confirm
                   on-tap="_toggleAssignmentDialog"
                   data-args="delegate"
+                  hidden$="[[_isDelegationDisabled(task)]]"
                   >[[i18n('tasks.delegate')]]</paper-button
                 >
               </div>
@@ -326,6 +327,15 @@ Polymer({
 
   _delegatedActorsExist(delegatedActors) {
     return !!delegatedActors && delegatedActors.length > 0;
+  },
+
+  /**
+   * The delegate button stays visible unless the workflow node explicitly disables it
+   * (taskInfo.allowDelegate === false). Legacy nodes with no persisted value keep the
+   * button visible, preserving the previous always-available behavior.
+   */
+  _isDelegationDisabled(task) {
+    return !!task && !!task.taskInfo && task.taskInfo.allowDelegate === false;
   },
 
   _computeLayoutVisibility(task) {

--- a/test/nuxeo-document-task.test.js
+++ b/test/nuxeo-document-task.test.js
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { fixture, html, login } from '@nuxeo/testing-helpers';
+import { fixture, flush, html, login } from '@nuxeo/testing-helpers';
 import '../elements/workflow/nuxeo-document-task.js';
 
 suite('nuxeo-document-task', () => {
@@ -73,6 +73,64 @@ suite('nuxeo-document-task', () => {
 
     test('should return false when delegated actors is null', () => {
       expect(element._delegatedActorsExist(null)).to.not.be.ok;
+    });
+  });
+
+  suite('_isDelegationDisabled', () => {
+    test('should return true when allowDelegate is explicitly false', () => {
+      expect(element._isDelegationDisabled({ taskInfo: { allowDelegate: false } })).to.be.true;
+    });
+
+    test('should return false when allowDelegate is true', () => {
+      expect(element._isDelegationDisabled({ taskInfo: { allowDelegate: true } })).to.be.false;
+    });
+
+    test('should return false when allowDelegate is undefined (legacy node)', () => {
+      expect(element._isDelegationDisabled({ taskInfo: {} })).to.be.false;
+    });
+
+    test('should return false when taskInfo is missing', () => {
+      expect(element._isDelegationDisabled({})).to.be.false;
+    });
+
+    test('should return false when task is falsy', () => {
+      expect(element._isDelegationDisabled(null)).to.be.false;
+    });
+  });
+
+  suite('delegate button visibility', () => {
+    const buildTask = (taskInfo) => {
+      return {
+        id: 't1',
+        state: 'opened',
+        nodeName: 'Task1',
+        workflowModelName: 'SerialDocumentReview',
+        taskInfo,
+      };
+    };
+
+    const getDelegateButton = async (taskInfo) => {
+      element.task = buildTask(taskInfo);
+      await flush();
+      return element.shadowRoot.querySelector('#delegateBtn');
+    };
+
+    test('should show the delegate button when allowDelegate is true', async () => {
+      const btn = await getDelegateButton({ allowDelegate: true });
+      expect(btn).to.be.ok;
+      expect(btn.hidden).to.be.false;
+    });
+
+    test('should show the delegate button for legacy nodes without allowDelegate', async () => {
+      const btn = await getDelegateButton({});
+      expect(btn).to.be.ok;
+      expect(btn.hidden).to.be.false;
+    });
+
+    test('should hide the delegate button when allowDelegate is false', async () => {
+      const btn = await getDelegateButton({ allowDelegate: false });
+      expect(btn).to.be.ok;
+      expect(btn.hidden).to.be.true;
     });
   });
 

--- a/test/nuxeo-document-task.test.js
+++ b/test/nuxeo-document-task.test.js
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { fixture, flush, html, login } from '@nuxeo/testing-helpers';
+import { fixture, flush as flushRender, html, login } from '@nuxeo/testing-helpers';
 import '../elements/workflow/nuxeo-document-task.js';
 
 suite('nuxeo-document-task', () => {
@@ -111,7 +111,7 @@ suite('nuxeo-document-task', () => {
 
     const getDelegateButton = async (taskInfo) => {
       element.task = buildTask(taskInfo);
-      await flush();
+      await flushRender();
       return element.shadowRoot.querySelector('#delegateBtn');
     };
 


### PR DESCRIPTION
## Problem
The workflow **Reassign** button can be enabled/disabled per workflow node (via `task.taskInfo.allowTaskReassignment`), but the **Delegate** button was hardcoded to always be visible. Customers with restricted delegation processes had no way to hide it, causing user confusion and support tickets. Jira: [WEBUI-1904](https://hyland.atlassian.net/browse/WEBUI-1904)

## Root cause
In `elements/workflow/nuxeo-document-task.js` the `#delegateBtn` `paper-button` had no visibility binding, unlike `#reassignBtn` which is gated on `task.taskInfo.allowTaskReassignment`.

## Changes
* **`elements/workflow/nuxeo-document-task.js`**: gate `#delegateBtn` with `hidden$="[[_isDelegationDisabled(task)]]"` and add the `_isDelegationDisabled(task)` helper. The server/Studio side (NXS-7237) emits `task.taskInfo.allowDelegate`. A helper is used instead of a plain negation so the change is **backward-compatible**: the button stays visible by default and is hidden only when `allowDelegate` is explicitly `false` (legacy nodes with no persisted value keep the previous always-available behavior).
* **`test/nuxeo-document-task.test.js`**: unit tests for `_isDelegationDisabled` plus rendered DOM tests asserting the button shows for `true`/legacy-absent and hides for `false`.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (2256 tests)
- [ ] Functional/E2E verification against a server that emits `taskInfo.allowDelegate` (tracked in NXS-7331): Delegate hidden when the node has `allowDelegate=false`, visible otherwise.

## Notes
Front-end consumption of the server/Studio work in NXS-7237 (Resolved, validated in UAT). Backport of the `lts-2025` PR (#3311). Property name and backward-compatible default confirmed by the server team on the ticket.

Made with [Cursor](https://cursor.com)

[WEBUI-1904]: https://hyland.atlassian.net/browse/WEBUI-1904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ