### PR TITLE
WEBUI-2138: include custom schema columns in Web UI CSV export

### DIFF
--- a/elements/fetch-types.js
+++ b/elements/fetch-types.js
@@ -1,9 +1,14 @@
-let typesCache;
+let typesPromise;
 
-export const _fetchTypes = async (resource) => {
-  if (!typesCache) {
+export const _fetchTypes = (resource) => {
+  if (!typesPromise) {
     resource.path = 'config/types';
-    typesCache = await resource.get();
+    // cache the in-flight promise so concurrent callers share a single config/types request;
+    // clear it on failure so a later call can retry
+    typesPromise = resource.get().catch((e) => {
+      typesPromise = undefined;
+      throw e;
+    });
   }
-  return typesCache;
+  return typesPromise;
 };

--- a/elements/fetch-types.js
+++ b/elements/fetch-types.js
@@ -1,0 +1,9 @@
+let typesCache;
+
+export const _fetchTypes = async (resource) => {
+  if (!typesCache) {
+    resource.path = 'config/types';
+    typesCache = await resource.get();
+  }
+  return typesCache;
+};

--- a/elements/nuxeo-csv-export/nuxeo-csv-export-button.js
+++ b/elements/nuxeo-csv-export/nuxeo-csv-export-button.js
@@ -110,6 +110,8 @@ Polymer({
   ready() {
     this.$.btn.addEventListener('poll-start', this._onPollStart.bind(this));
     this.$.btn.addEventListener('response', this._onResponse.bind(this));
+    // resolve once the local DOM (`this.$.types`) exists, in case `provider` was data-bound before `ready`
+    this._resolveSchemas();
   },
 
   _providerChanged(provider, oldProvider) {
@@ -132,6 +134,9 @@ Polymer({
    * `provider`'s schemas when the result types or their configuration are not available.
    */
   async _resolveSchemas() {
+    // track the latest resolution so a slower in-flight call cannot overwrite a newer one with a stale type set
+    const token = (this._resolveToken || 0) + 1;
+    this._resolveToken = token;
     const provider = this.provider;
     if (!provider) {
       this._resolvedSchemas = undefined;
@@ -153,8 +158,8 @@ Polymer({
         // keep the provider's display schemas when the types configuration cannot be fetched
       }
     }
-    // ignore stale resolutions if the provider changed while awaiting the types configuration
-    if (this.provider === provider) {
+    // ignore stale resolutions superseded by a newer call (provider change or a rapid page change)
+    if (this._resolveToken === token) {
       this._resolvedSchemas = schemas.size > 0 ? [...schemas].join(',') : undefined;
     }
   },

--- a/elements/nuxeo-csv-export/nuxeo-csv-export-button.js
+++ b/elements/nuxeo-csv-export/nuxeo-csv-export-button.js
@@ -165,7 +165,7 @@ Polymer({
         });
       } catch (e) {
         // keep the provider's display schemas when the types configuration cannot be fetched
-        console.warn(`nuxeo-csv-export-button: could not resolve schemas from config/types: ${e}`);
+        console.warn('nuxeo-csv-export-button: could not resolve schemas from config/types', e);
       }
     }
     // ignore stale resolutions superseded by a newer call (provider change or a rapid page change)

--- a/elements/nuxeo-csv-export/nuxeo-csv-export-button.js
+++ b/elements/nuxeo-csv-export/nuxeo-csv-export-button.js
@@ -18,11 +18,13 @@ limitations under the License.
 import '@polymer/polymer/polymer-legacy.js';
 
 import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
+import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-operation-button.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
 import { FiltersBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-filters-behavior.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { _fetchTypes } from '../fetch-types.js';
 
 /**
 `nuxeo-csv-export-button`
@@ -31,11 +33,12 @@ import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 */
 Polymer({
   _template: html`
+    <nuxeo-resource id="types"></nuxeo-resource>
     <nuxeo-operation-button
       id="btn"
       operation="Bulk.RunAction"
       input="[[provider]]"
-      params="[[_params(provider, schemas, fields)]]"
+      params="[[_params(provider, schemas, fields, _resolvedSchemas)]]"
       icon="nuxeo:csv-export"
       label="csvExportButton.label"
       show-label$="[[showLabel]]"
@@ -56,6 +59,7 @@ Polymer({
      */
     provider: {
       type: Object,
+      observer: '_providerChanged',
     },
     /**
      * The interval to poll for the result, in milliseconds.
@@ -92,6 +96,15 @@ Polymer({
       type: Object,
       notify: true,
     },
+
+    /**
+     * The schemas to export, resolved from the document types present in the `provider` results unioned with the
+     * `provider`'s display schemas. Used when neither `schemas` nor the `provider`'s schemas are enough to cover the
+     * custom schemas of the exported documents. Computed internally, do not set.
+     */
+    _resolvedSchemas: {
+      type: String,
+    },
   },
 
   ready() {
@@ -99,14 +112,75 @@ Polymer({
     this.$.btn.addEventListener('response', this._onResponse.bind(this));
   },
 
+  _providerChanged(provider, oldProvider) {
+    if (!this._onProviderPageChanged) {
+      this._onProviderPageChanged = () => this._resolveSchemas();
+    }
+    if (oldProvider && oldProvider.removeEventListener) {
+      oldProvider.removeEventListener('current-page-changed', this._onProviderPageChanged);
+    }
+    if (provider && provider.addEventListener) {
+      provider.addEventListener('current-page-changed', this._onProviderPageChanged);
+    }
+    this._resolveSchemas();
+  },
+
+  /**
+   * Resolves the list of schemas to export from the document types present in the current `provider` results, so that
+   * each exported document's own schemas (including custom ones) are included, without hardcoding schema names. The
+   * `provider`'s display schemas are always kept so no currently exported column is lost. Falls back gracefully to the
+   * `provider`'s schemas when the result types or their configuration are not available.
+   */
+  async _resolveSchemas() {
+    const provider = this.provider;
+    if (!provider) {
+      this._resolvedSchemas = undefined;
+      return;
+    }
+    const schemas = new Set(this._toList(provider.schemas));
+    const types = [...new Set((provider.currentPage || []).map((doc) => doc && doc.type).filter(Boolean))];
+    if (types.length > 0 && this.$ && this.$.types) {
+      try {
+        const config = await this._fetchTypes();
+        const doctypes = (config && config.doctypes) || {};
+        types.forEach((type) => {
+          const info = doctypes[type];
+          if (info && Array.isArray(info.schemas)) {
+            info.schemas.forEach((schema) => schemas.add(schema));
+          }
+        });
+      } catch (e) {
+        // keep the provider's display schemas when the types configuration cannot be fetched
+      }
+    }
+    // ignore stale resolutions if the provider changed while awaiting the types configuration
+    if (this.provider === provider) {
+      this._resolvedSchemas = schemas.size > 0 ? [...schemas].join(',') : undefined;
+    }
+  },
+
+  _fetchTypes() {
+    return _fetchTypes(this.$.types);
+  },
+
+  _toList(value) {
+    return value
+      ? value
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
+  },
+
   _params() {
     const actionParams = {};
-    const schemas = this.schemas != null ? this.schemas : this.provider && this.provider.schemas;
+    const schemas =
+      this.schemas != null ? this.schemas : this._resolvedSchemas || (this.provider && this.provider.schemas);
     if (schemas) {
-      actionParams.schemas = schemas.split(',').map((s) => s.trim());
+      actionParams.schemas = this._toList(schemas);
     }
     if (this.fields) {
-      actionParams.xpaths = this.fields.split(',').map((s) => s.trim());
+      actionParams.xpaths = this._toList(this.fields);
     }
     return {
       action: 'csvExport',

--- a/elements/nuxeo-csv-export/nuxeo-csv-export-button.js
+++ b/elements/nuxeo-csv-export/nuxeo-csv-export-button.js
@@ -114,6 +114,13 @@ Polymer({
     this._resolveSchemas();
   },
 
+  detached() {
+    // avoid leaking the current-page-changed listener when the element is removed (e.g. page/dom-if switch)
+    if (this._onProviderPageChanged && this.provider?.removeEventListener) {
+      this.provider.removeEventListener('current-page-changed', this._onProviderPageChanged);
+    }
+  },
+
   _providerChanged(provider, oldProvider) {
     if (!this._onProviderPageChanged) {
       this._onProviderPageChanged = () => this._resolveSchemas();

--- a/elements/nuxeo-csv-export/nuxeo-csv-export-button.js
+++ b/elements/nuxeo-csv-export/nuxeo-csv-export-button.js
@@ -116,24 +116,37 @@ Polymer({
     this._resolveSchemas();
   },
 
+  attached() {
+    // Re-wire the page-changed listener when the element is re-inserted with the SAME provider
+    // instance — `_providerChanged` won't fire in that case — and re-resolve to catch any page
+    // changes that happened while detached (otherwise `_resolvedSchemas` can be left stale).
+    this._bindProviderPageChanged(this.provider);
+    this._resolveSchemas();
+  },
+
   detached() {
     // avoid leaking the current-page-changed listener when the element is removed (e.g. page/dom-if switch)
-    if (this._onProviderPageChanged && this.provider?.removeEventListener) {
-      this.provider.removeEventListener('current-page-changed', this._onProviderPageChanged);
-    }
+    this._unbindProviderPageChanged(this.provider);
   },
 
   _providerChanged(provider, oldProvider) {
+    this._unbindProviderPageChanged(oldProvider);
+    this._bindProviderPageChanged(provider);
+    this._resolveSchemas();
+  },
+
+  _bindProviderPageChanged(provider) {
     if (!this._onProviderPageChanged) {
       this._onProviderPageChanged = () => this._resolveSchemas();
     }
-    if (oldProvider?.removeEventListener) {
-      oldProvider.removeEventListener('current-page-changed', this._onProviderPageChanged);
+    // addEventListener with the same listener reference is idempotent, so re-binding is safe.
+    provider?.addEventListener?.('current-page-changed', this._onProviderPageChanged);
+  },
+
+  _unbindProviderPageChanged(provider) {
+    if (this._onProviderPageChanged) {
+      provider?.removeEventListener?.('current-page-changed', this._onProviderPageChanged);
     }
-    if (provider?.addEventListener) {
-      provider.addEventListener('current-page-changed', this._onProviderPageChanged);
-    }
-    this._resolveSchemas();
   },
 
   /**

--- a/elements/nuxeo-csv-export/nuxeo-csv-export-button.js
+++ b/elements/nuxeo-csv-export/nuxeo-csv-export-button.js
@@ -70,7 +70,9 @@ Polymer({
     },
     /**
      * A comma separated list of schemas to be used to get the results.
-     * If `null` or `undefined`, the `provider`'s schemas will be used.
+     * If `null` or `undefined`, the schemas resolved from the `provider`'s result document types
+     * (`_resolvedSchemas`) are used, falling back to the `provider`'s own schemas when the resolved
+     * set is unavailable.
      */
     schemas: {
       type: String,

--- a/elements/nuxeo-csv-export/nuxeo-csv-export-button.js
+++ b/elements/nuxeo-csv-export/nuxeo-csv-export-button.js
@@ -118,10 +118,10 @@ Polymer({
     if (!this._onProviderPageChanged) {
       this._onProviderPageChanged = () => this._resolveSchemas();
     }
-    if (oldProvider && oldProvider.removeEventListener) {
+    if (oldProvider?.removeEventListener) {
       oldProvider.removeEventListener('current-page-changed', this._onProviderPageChanged);
     }
-    if (provider && provider.addEventListener) {
+    if (provider?.addEventListener) {
       provider.addEventListener('current-page-changed', this._onProviderPageChanged);
     }
     this._resolveSchemas();
@@ -143,11 +143,11 @@ Polymer({
       return;
     }
     const schemas = new Set(this._toList(provider.schemas));
-    const types = [...new Set((provider.currentPage || []).map((doc) => doc && doc.type).filter(Boolean))];
-    if (types.length > 0 && this.$ && this.$.types) {
+    const types = [...new Set((provider.currentPage || []).map((doc) => doc?.type).filter(Boolean))];
+    if (types.length > 0 && this.$?.types) {
       try {
         const config = await this._fetchTypes();
-        const doctypes = (config && config.doctypes) || {};
+        const doctypes = config?.doctypes || {};
         types.forEach((type) => {
           const info = doctypes[type];
           if (info && Array.isArray(info.schemas)) {
@@ -156,6 +156,7 @@ Polymer({
         });
       } catch (e) {
         // keep the provider's display schemas when the types configuration cannot be fetched
+        console.warn(`nuxeo-csv-export-button: could not resolve schemas from config/types: ${e}`);
       }
     }
     // ignore stale resolutions superseded by a newer call (provider change or a rapid page change)
@@ -179,8 +180,7 @@ Polymer({
 
   _params() {
     const actionParams = {};
-    const schemas =
-      this.schemas != null ? this.schemas : this._resolvedSchemas || (this.provider && this.provider.schemas);
+    const schemas = this.schemas != null ? this.schemas : this._resolvedSchemas || this.provider?.schemas;
     if (schemas) {
       actionParams.schemas = this._toList(schemas);
     }

--- a/test/fetch-types.test.js
+++ b/test/fetch-types.test.js
@@ -1,0 +1,46 @@
+/**
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+suite('fetch-types', () => {
+  /** Fresh module instance so module-level cache does not leak across tests or the rest of Karma. */
+  const load = async () => {
+    const { _fetchTypes } = await import(`../elements/fetch-types.js?test=${Date.now()}`);
+    return _fetchTypes;
+  };
+
+  test('sets path to config/types and populates cache on first call', async () => {
+    const _fetchTypes = await load();
+    const payload = { doctypes: {} };
+    const resource = { path: 'ignored', get: sinon.stub().resolves(payload) };
+    const result = await _fetchTypes(resource);
+    expect(resource.path).to.equal('config/types');
+    expect(resource.get).to.have.been.calledOnce;
+    expect(result).to.equal(payload);
+  });
+
+  test('returns cached types without calling get on subsequent calls', async () => {
+    const _fetchTypes = await load();
+    const payload = { doctypes: {} };
+    const first = { path: 'a', get: sinon.stub().resolves(payload) };
+    await _fetchTypes(first);
+    const second = { path: 'should-not-change', get: sinon.stub().resolves({ other: true }) };
+    const cached = await _fetchTypes(second);
+    expect(second.get).to.not.have.been.called;
+    expect(second.path).to.equal('should-not-change');
+    expect(cached).to.deep.equal(payload);
+  });
+});

--- a/test/fetch-types.test.js
+++ b/test/fetch-types.test.js
@@ -45,4 +45,40 @@ suite('fetch-types', () => {
     expect(second.path).to.equal('should-not-change');
     expect(cached).to.deep.equal(payload);
   });
+
+  test('shares a single config/types request across concurrent callers', async () => {
+    const _fetchTypes = await load();
+    const payload = { doctypes: {} };
+    let resolveGet;
+    const get = sinon.stub().returns(
+      new Promise((resolve) => {
+        resolveGet = resolve;
+      }),
+    );
+    const resource = { path: 'x', get };
+    const p1 = _fetchTypes(resource);
+    const p2 = _fetchTypes(resource);
+    resolveGet(payload);
+    const [a, b] = await Promise.all([p1, p2]);
+    expect(get).to.have.been.calledOnce;
+    expect(a).to.equal(payload);
+    expect(b).to.equal(payload);
+  });
+
+  test('clears the cache on failure so a later call can retry', async () => {
+    const _fetchTypes = await load();
+    const failing = { path: 'x', get: sinon.stub().rejects(new Error('boom')) };
+    let rejected = false;
+    try {
+      await _fetchTypes(failing);
+    } catch (e) {
+      rejected = true;
+    }
+    expect(rejected).to.be.true;
+    const payload = { doctypes: {} };
+    const ok = { path: 'y', get: sinon.stub().resolves(payload) };
+    const result = await _fetchTypes(ok);
+    expect(ok.get).to.have.been.calledOnce;
+    expect(result).to.equal(payload);
+  });
 });

--- a/test/fetch-types.test.js
+++ b/test/fetch-types.test.js
@@ -17,8 +17,10 @@ limitations under the License.
 */
 suite('fetch-types', () => {
   /** Fresh module instance so module-level cache does not leak across tests or the rest of Karma. */
+  let nonce = 0;
   const load = async () => {
-    const { _fetchTypes } = await import(`../elements/fetch-types.js?test=${Date.now()}`);
+    nonce += 1;
+    const { _fetchTypes } = await import(`../elements/fetch-types.js?test=${nonce}`);
     return _fetchTypes;
   };
 

--- a/test/fetch-types.test.js
+++ b/test/fetch-types.test.js
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 suite('fetch-types', () => {
-  /** Fresh module instance so module-level cache does not leak across tests or the rest of Karma. */
+  /** Fresh module instance so the module-level cache does not leak across tests or the rest of the suite. */
   let nonce = 0;
   const load = async () => {
     nonce += 1;

--- a/test/nuxeo-csv-export-button.test.js
+++ b/test/nuxeo-csv-export-button.test.js
@@ -200,6 +200,22 @@ suite('nuxeo-csv-export-button', () => {
       element.provider = { schemas: 'dublincore' };
       expect(() => element.detached()).to.not.throw();
     });
+
+    test('re-attaches the current-page-changed listener on re-insert with the same provider', () => {
+      const provider = makeProvider();
+      element.provider = provider;
+      // simulate a detach/reattach cycle without changing the provider instance
+      element.detached();
+      provider.addEventListener.resetHistory();
+      element.attached();
+      expect(provider.addEventListener).to.have.been.calledWith('current-page-changed');
+    });
+
+    test('re-resolves the schemas on attach', () => {
+      const resolveSpy = sinon.spy(element, '_resolveSchemas');
+      element.attached();
+      expect(resolveSpy).to.have.been.called;
+    });
   });
 
   suite('_fetchTypes', () => {

--- a/test/nuxeo-csv-export-button.test.js
+++ b/test/nuxeo-csv-export-button.test.js
@@ -99,7 +99,7 @@ suite('nuxeo-csv-export-button', () => {
       sinon.stub(element, '_fetchTypes').resolves(typesConfig);
       element.provider = {
         schemas: 'dublincore,common',
-        currentPage: [{ type: 'Note' }, { type: 'File' }, { type: 'Note' }],
+        currentPage: [{ type: 'Note' }, null, { type: 'File' }, { type: 'Note' }],
       };
       await element._resolveSchemas();
       const parsed = JSON.parse(element._params().parameters);

--- a/test/nuxeo-csv-export-button.test.js
+++ b/test/nuxeo-csv-export-button.test.js
@@ -69,5 +69,56 @@ suite('nuxeo-csv-export-button', () => {
       const parsed = JSON.parse(params.parameters);
       expect(parsed.schemas).to.deep.equal(['common', 'uid']);
     });
+
+    test('should use the resolved schemas when schemas is not explicitly set', () => {
+      element.provider = { schemas: 'dublincore' };
+      element.schemas = null;
+      element._resolvedSchemas = 'dublincore,note';
+      const parsed = JSON.parse(element._params().parameters);
+      expect(parsed.schemas).to.deep.equal(['dublincore', 'note']);
+    });
+
+    test('explicit schemas takes precedence over the resolved schemas', () => {
+      element.provider = { schemas: 'dublincore' };
+      element._resolvedSchemas = 'dublincore,note';
+      element.schemas = 'dublincore, file';
+      const parsed = JSON.parse(element._params().parameters);
+      expect(parsed.schemas).to.deep.equal(['dublincore', 'file']);
+    });
+  });
+
+  suite('_resolveSchemas', () => {
+    const typesConfig = {
+      doctypes: {
+        Note: { schemas: ['dublincore', 'common', 'uid', 'note'] },
+        File: { schemas: ['dublincore', 'common', 'uid', 'file'] },
+      },
+    };
+
+    test('unions the provider display schemas with the schemas of the result document types', async () => {
+      sinon.stub(element, '_fetchTypes').resolves(typesConfig);
+      element.provider = {
+        schemas: 'dublincore,common',
+        currentPage: [{ type: 'Note' }, { type: 'File' }, { type: 'Note' }],
+      };
+      await element._resolveSchemas();
+      const parsed = JSON.parse(element._params().parameters);
+      expect(parsed.schemas.slice().sort()).to.deep.equal(['common', 'dublincore', 'file', 'note', 'uid']);
+    });
+
+    test('keeps the provider display schemas when there are no results', async () => {
+      const fetchTypes = sinon.stub(element, '_fetchTypes').resolves(typesConfig);
+      element.provider = { schemas: 'dublincore,common', currentPage: [] };
+      await element._resolveSchemas();
+      expect(fetchTypes).to.not.have.been.called;
+      expect(element._resolvedSchemas.split(',').sort()).to.deep.equal(['common', 'dublincore']);
+    });
+
+    test('falls back to the provider display schemas when the types config cannot be fetched', async () => {
+      sinon.stub(element, '_fetchTypes').rejects(new Error('boom'));
+      element.provider = { schemas: 'dublincore,common', currentPage: [{ type: 'Note' }] };
+      await element._resolveSchemas();
+      expect(element._resolvedSchemas.split(',').sort()).to.deep.equal(['common', 'dublincore']);
+    });
   });
 });

--- a/test/nuxeo-csv-export-button.test.js
+++ b/test/nuxeo-csv-export-button.test.js
@@ -174,6 +174,32 @@ suite('nuxeo-csv-export-button', () => {
       element.provider = undefined;
       expect(element._resolvedSchemas).to.be.undefined;
     });
+
+    test('removes the current-page-changed listener on detach', () => {
+      const provider = makeProvider();
+      element.provider = provider;
+      provider.removeEventListener.resetHistory();
+      element.detached();
+      expect(provider.removeEventListener).to.have.been.calledWith('current-page-changed');
+    });
+
+    test('detach is a no-op when no provider listener was wired', () => {
+      expect(() => element.detached()).to.not.throw();
+    });
+
+    test('detach is a no-op after the provider has been cleared', () => {
+      const provider = makeProvider();
+      element.provider = provider;
+      element.provider = undefined;
+      provider.removeEventListener.resetHistory();
+      element.detached();
+      expect(provider.removeEventListener).to.not.have.been.called;
+    });
+
+    test('detach tolerates a provider without removeEventListener', () => {
+      element.provider = { schemas: 'dublincore' };
+      expect(() => element.detached()).to.not.throw();
+    });
   });
 
   suite('_fetchTypes', () => {

--- a/test/nuxeo-csv-export-button.test.js
+++ b/test/nuxeo-csv-export-button.test.js
@@ -120,5 +120,67 @@ suite('nuxeo-csv-export-button', () => {
       await element._resolveSchemas();
       expect(element._resolvedSchemas.split(',').sort()).to.deep.equal(['common', 'dublincore']);
     });
+
+    test('keeps only the provider schemas when the result type is unknown to the types config', async () => {
+      sinon.stub(element, '_fetchTypes').resolves({});
+      element.provider = { schemas: 'dublincore', currentPage: [{ type: 'Unknown' }] };
+      await element._resolveSchemas();
+      expect(element._resolvedSchemas).to.equal('dublincore');
+    });
+
+    test('resolves to undefined when the provider has neither schemas nor results', async () => {
+      element.provider = { currentPage: [] };
+      await element._resolveSchemas();
+      expect(element._resolvedSchemas).to.be.undefined;
+    });
+
+    test('resolves to undefined when there is no provider', async () => {
+      element.provider = undefined;
+      await element._resolveSchemas();
+      expect(element._resolvedSchemas).to.be.undefined;
+    });
+  });
+
+  suite('_providerChanged', () => {
+    const makeProvider = () => {
+      return {
+        schemas: 'dublincore',
+        addEventListener: sinon.spy(),
+        removeEventListener: sinon.spy(),
+      };
+    };
+
+    test('wires and rewires the current-page-changed listener when the provider changes', () => {
+      const first = makeProvider();
+      const second = makeProvider();
+      element.provider = first;
+      expect(first.addEventListener).to.have.been.calledWith('current-page-changed');
+      element.provider = second;
+      expect(first.removeEventListener).to.have.been.calledWith('current-page-changed');
+      expect(second.addEventListener).to.have.been.calledWith('current-page-changed');
+    });
+
+    test('re-resolves the schemas when the provider fires current-page-changed', () => {
+      const provider = makeProvider();
+      element.provider = provider;
+      const [, handler] = provider.addEventListener.firstCall.args;
+      const resolveSpy = sinon.spy(element, '_resolveSchemas');
+      handler();
+      expect(resolveSpy).to.have.been.calledOnce;
+    });
+
+    test('tolerates a provider without event listener support and a later cleared provider', () => {
+      element.provider = { schemas: 'dublincore' };
+      element.provider = undefined;
+      expect(element._resolvedSchemas).to.be.undefined;
+    });
+  });
+
+  suite('_fetchTypes', () => {
+    test('delegates to the shared config/types helper via the local resource', async () => {
+      element.$.types.get = sinon.stub().resolves({ doctypes: {} });
+      const config = await element._fetchTypes();
+      expect(config).to.be.an('object');
+    });
   });
 });


### PR DESCRIPTION
### Problem
CSV exports generated from Web UI results (search and folder content) omit properties that belong to custom document schemas. Only fields from `dublincore`, `common`, `file` and `uid` are exported. The same metadata is available on the documents and is included when exporting through JSF UI, or through the backend CSV bulk action when the custom schema is provided explicitly.

Ticket: https://hyland.atlassian.net/browse/WEBUI-2138

### Root cause
`nuxeo-csv-export-button` builds the `csvExport` bulk-action `schemas` parameter from the page provider's display schemas. For the default search that value is the contribution's hardcoded `schemas="dublincore,common,file,uid"` (kept narrow for display performance). Server-side, `DocumentModelCSVWriter` emits columns only for the exact schema names supplied — it silently skips unknown names, has no "all"/wildcard fallback, and rejects `*` with HTTP 400. So every custom-schema property is dropped from the export.

### Changes
- `elements/nuxeo-csv-export/nuxeo-csv-export-button.js`: resolve the export schemas from the document **types actually present in the provider results** (via `config/types`), unioned with the provider's display schemas, and use that when no explicit `schemas` is set. Each exported document's own schemas — including custom ones — are now included, without hardcoding schema names. Explicit `schemas` still takes precedence; falls back to the provider's display schemas when result types or their config are unavailable.
- `elements/fetch-types.js`: small cached `config/types` fetch helper (mirrors `fetch-schemas.js`).
- Unit tests for the resolution logic and the new helper.

### Test plan
- `npm run lint` — passes.
- `npm test` — passes (2255 tests), including new `nuxeo-csv-export-button` and `fetch-types` cases.
- Manual A/B against a 2025 server, inspecting the `Bulk.RunAction` request (the ticket's repro step):
  - Before: `{"schemas":["dublincore","common","uid","file"]}` — custom/extra schema columns missing.
  - After: `{"schemas":["dublincore","common","uid","file","note","files","facetedTag","relatedtext"]}` — the document type's own schemas (a stand-in for the reported custom schema) are now exported, with no unrelated schema noise.

### Notes
- Export runs over the whole provider result set; the schema list is derived from the currently loaded result page's types. For heterogeneous, multi-page results, types that appear only on not-yet-loaded pages are not added. This is strictly better than the previous hardcoded behavior and covers the reported cases.
- Backported to both `lts-2025` and `maintenance-3.1.x`.
