### PR TITLE
WEBUI-2039: Upgrade CI to Node 24 and minimum supported to Node 22 [LTS-2025]

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@
 Nuxeo Web UI is the standard web application for the Nuxeo content services platform, built with **Polymer 3** (mostly legacy `Polymer({…})` factory pattern) and backed by the **@nuxeo/nuxeo-elements** library of web components. Licensed Apache 2.0, owned by Hyland Software.
 
 - **Runtime**: Browser (no server-side JS in production)
-- **Node**: ≥ 18
+- **Node**: ≥ 22
 - **Build**: Webpack 5
 - **Package manager**: npm (no yarn/pnpm)
 - **Java**: 21 (Maven wraps the frontend build for marketplace packaging)

--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           registry-url: ${{ env.NPM_REPOSITORY }}
-          node-version: 22
+          node-version: 24
           scope: '@nuxeo'
 
       - name: Setup Maven build

--- a/.github/workflows/catalog.yaml
+++ b/.github/workflows/catalog.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Setup Maven build
         uses: nuxeo/gh-build-tools/.github/actions/setup-maven-build@v0.10.4

--- a/.github/workflows/cross-repo.yaml
+++ b/.github/workflows/cross-repo.yaml
@@ -81,7 +81,7 @@ jobs:
           registry-url: ${{ env.NPM_REPOSITORY }}
           always-auth: true
           scope: '@nuxeo'
-          node-version: 22
+          node-version: 24
 
       - name: Determine nuxeo-web-ui branch to use
         uses: nuxeo/ui-team-gh-actions/get-branch@ca09d5c52a62e297502d3572c36d813be927982a

--- a/.github/workflows/ftest.yaml
+++ b/.github/workflows/ftest.yaml
@@ -53,7 +53,7 @@ jobs:
           registry-url: ${{ env.NPM_REPOSITORY }}
           always-auth: true
           scope: '@nuxeo'
-          node-version: 22
+          node-version: 24
 
       - name: Setup Maven build
         uses: nuxeo/gh-build-tools/.github/actions/setup-maven-build@v0.10.4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
-          node-version: 22
+          node-version: 24
           scope: '@nuxeo'
 
       - name: Cache npm dependencies

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -76,6 +76,7 @@ jobs:
         with:
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
           scope: '@nuxeo'
+          node-version: 24
 
       - name: Cache npm dependencies
         uses: actions/cache@v5

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
           scope: '@nuxeo'
 

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
           scope: '@nuxeo'
 

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
-          node-version: 22
+          node-version: 24
           scope: '@nuxeo'
 
       - name: Cache npm packages

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
           scope: '@nuxeo'
-          node-version: 22
+          node-version: 24
 
       - name: Cache npm dependencies
         uses: actions/cache@v5

--- a/.github/workflows/veracode-3.1.x.yaml
+++ b/.github/workflows/veracode-3.1.x.yaml
@@ -47,7 +47,7 @@ jobs:
       with:
           registry-url: ${{ env.NPM_REPOSITORY }}
           always-auth: true
-          node-version: 22
+          node-version: 24
           scope: '@nuxeo'
 
     - name: Determine nuxeo-elements branch to link

--- a/.github/workflows/veracode-lts-2025.yaml
+++ b/.github/workflows/veracode-lts-2025.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           registry-url: ${{ env.NPM_REPOSITORY }}
           always-auth: true
-          node-version: 18
+          node-version: 24
           scope: '@nuxeo'
 
       - name: Determine nuxeo-elements branch to link

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This is a Polymer 3 web application (SPA) for the Nuxeo content services platfor
 Always follow this sequence when making changes:
 
 ```bash
-npm install                  # Install dependencies (Node ≥ 18)
+npm install                  # Install dependencies (Node ≥ 22)
 npm run format               # Auto-fix formatting (Prettier → ESLint)
 npm run lint                 # ESLint + Prettier check — must pass
 npm test                     # Web Test Runner unit tests — must pass

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,7 +39,7 @@ Nuxeo Web UI is a single-page application (SPA) that serves as the standard user
 | Web Components Polyfills | @webcomponents/webcomponentsjs | ^2.0 |
 | Bundler | Webpack 5 | ^5.3 |
 | Package Manager | npm | ≥ 8 |
-| Node.js | Node.js | ≥ 18 |
+| Node.js | Node.js | ≥ 22 |
 | Unit Testing | @web/test-runner + Mocha + Chai + Sinon | Various |
 | Functional Testing | WebdriverIO 9 + Cucumber | ^9.12 |
 | Linting | ESLint 9 (flat config) + Prettier | ^9.0 / ^3.8 |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- **Node.js** ≥ 18
+- **Node.js** ≥ 22
 - **npm** (bundled with Node — no yarn or pnpm)
 - **Maven** and **Java 21** for marketplace builds
 - A running **Nuxeo Server** at `localhost:8080` for development and functional testing

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Nuxeo Web UI is the standard web application for the [Nuxeo Platform](https://ww
 
 ### Prerequisites
 
-- **Node.js** ≥ 18 (see `engines` in `package.json`)
+- **Node.js** ≥ 22 (see `engines` in `package.json`)
 - **npm** (bundled with Node)
 
 ### Quick Start

--- a/docs/KARMA-TO-WTR-MIGRATION.md
+++ b/docs/KARMA-TO-WTR-MIGRATION.md
@@ -41,7 +41,7 @@
 | **Puppeteer integration** | Uses a bundled Chromium via `puppeteer`; no system Chrome version mismatches in CI. |
 | **Simpler configuration** | Single `web-test-runner.config.mjs` replaces Karma config + Karma plugins + ESM config. |
 | **Better error reporting** | Stack traces are source-mapped; browser logs are filterable; uncaught errors are attributed to tests. |
-| **Node ≥ 18 native** | No hacks or legacy providers needed. |
+| **Node ≥ 22 native** | No hacks or legacy providers needed. |
 
 ---
 
@@ -424,7 +424,7 @@ If overall coverage drops significantly, it likely means new untested modules we
 | Coverage engine | Istanbul (source transform) | Istanbul (rollup-plugin-istanbul, no Babel) |
 | Coverage % (lcov) | reported by Karma at the end of the run | reported by `inject-zero-coverage.js` at the end of `npm test`; current baseline tracked in SonarCloud |
 | Browser | System ChromeHeadless | Puppeteer bundled Chromium |
-| Node requirement | ≥18 (with --openssl-legacy-provider) | ≥18 (no hacks) |
+| Node requirement | ≥18 (with --openssl-legacy-provider) | ≥22 (no hacks) |
 | Karma plugins | 8 packages | 0 |
 | WTR plugins | 0 | 1 custom (fallback) |
 | CI stability | Intermittent race conditions | Deterministic (single-entry barrel) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,7 +151,7 @@
         "workbox-cli": "7.4.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "vendor": "Nuxeo",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "config": {
     "workboxCli": "7.4.1"

--- a/packages/nuxeo-designer-catalog/README.md
+++ b/packages/nuxeo-designer-catalog/README.md
@@ -14,7 +14,7 @@ The catalog contains data about elements properties, methods and behaviors:
 npm install
 ```
 
-Note: This version of the catalog generator requires node version >=14.0.0.
+Note: This version of the catalog generator requires node version >=22.0.0.
 
 #### Catalog generation
 

--- a/packages/nuxeo-designer-catalog/package-lock.json
+++ b/packages/nuxeo-designer-catalog/package-lock.json
@@ -42,7 +42,7 @@
         "writestreamp": "^0.1.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/packages/nuxeo-designer-catalog/package.json
+++ b/packages/nuxeo-designer-catalog/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "vendor": "Nuxeo",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=22.0.0"
   },
   "private": true,
   "main": "index.js",

--- a/packages/nuxeo-web-ui-ftest/package-lock.json
+++ b/packages/nuxeo-web-ui-ftest/package-lock.json
@@ -36,7 +36,7 @@
         "nuxeo-web-ui-ftest": "bin/nuxeo-web-ui-ftest.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/packages/nuxeo-web-ui-ftest/package.json
+++ b/packages/nuxeo-web-ui-ftest/package.json
@@ -10,7 +10,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "overrides": {
     "ws": "8.20.1",

--- a/plugin/a11y/package-lock.json
+++ b/plugin/a11y/package-lock.json
@@ -20,7 +20,7 @@
         "axe-core": "^4.1.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "../../packages/nuxeo-web-ui-ftest": {
@@ -56,7 +56,7 @@
         "nuxeo-web-ui-ftest": "bin/nuxeo-web-ui-ftest.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3024,7 +3024,7 @@
       "engines": {
         "bun": ">=0.7.0",
         "deno": ">=1.0.0",
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -6217,7 +6217,7 @@
       "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/ms": {
@@ -7200,7 +7200,7 @@
       "integrity": "sha512-jkg4434cYgtrIF2AeY/X0Wmd2W73cK5qIEFE3hDrrQenJH/2SDJIXGvPAigfvQTcE9+H31zkiNHbUqcihEiMRA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -7744,7 +7744,7 @@
         "tsx": "dist/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"

--- a/plugin/a11y/package-lock.json
+++ b/plugin/a11y/package-lock.json
@@ -3024,7 +3024,7 @@
       "engines": {
         "bun": ">=0.7.0",
         "deno": ">=1.0.0",
-        "node": ">=22.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -6217,7 +6217,7 @@
       "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/ms": {
@@ -7200,7 +7200,7 @@
       "integrity": "sha512-jkg4434cYgtrIF2AeY/X0Wmd2W73cK5qIEFE3hDrrQenJH/2SDJIXGvPAigfvQTcE9+H31zkiNHbUqcihEiMRA==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -7744,7 +7744,7 @@
         "tsx": "dist/cli.mjs"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=18.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"

--- a/plugin/a11y/package.json
+++ b/plugin/a11y/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type":"module",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "start": "npm run test",


### PR DESCRIPTION
## Summary
- Raise `engines.node` to `>=22.0.0` across root and sub-packages
- Set GitHub Actions CI runtime to Node 24 in all workflows (including `veracode-lts-2025.yaml`)
- Update developer documentation to reflect Node >= 22 minimum

## Related
- Paired with nuxeo/nuxeo-elements PR (same branch name)
- Backport of LTS-2023 node upgrade
- Jira: https://hyland.atlassian.net/browse/WEBUI-2039

## Test plan
- [ ] ftest, a11y CI green on PR
- [ ] cross-repo check green (via elements PR)
- [ ] main pipeline green after merge

Made with [Cursor](https://cursor.com)