### PR TITLE
WEBUI-2126: Pin exact alpha elements version (alpha build was pulling rc elements)

### DIFF
--- a/.github/workflows/alpha.yaml
+++ b/.github/workflows/alpha.yaml
@@ -103,7 +103,12 @@ jobs:
           echo "Latest nuxeo-elements version: $ELEMENTS_VERSION"
 
           # Update package.json dependencies and devDependencies
-          jq --arg ver "~$ELEMENTS_VERSION" '
+          # Pin the EXACT elements version (no "~"). main.yaml uses "~$ELEMENTS_VERSION" for
+          # rc, which is safe there because rc is already the highest prerelease. For alpha it is
+          # NOT: an alpha sorts below the rc's of the same base (X.Y.Z-alpha.N < X.Y.Z-rc.M), so a
+          # "~" range lets npm resolve UP to the latest rc and install rc elements instead of the
+          # alpha we built (dropping the alpha/rebranding changes). Exact pin prevents that.
+          jq --arg ver "$ELEMENTS_VERSION" '
             .dependencies."@nuxeo/nuxeo-dataviz-elements" = $ver |
             .dependencies."@nuxeo/nuxeo-elements" = $ver |
             .dependencies."@nuxeo/nuxeo-ui-elements" = $ver |


### PR DESCRIPTION
https://hyland.atlassian.net/browse/WEBUI-2126


## Summary
Fixes the web-ui **alpha build** installing **rc** elements instead of the **alpha** it just built — which dropped the alpha/rebranding element changes (icons, checkbox, etc.) from the generated build.

## Root cause
The build linked elements with a **tilde range**: `~$ELEMENTS_VERSION`. An alpha version sorts *below* the rc's of the same base (`2025.18.0-alpha.0 < 2025.18.0-rc.6`), so npm's `maxSatisfying("~2025.18.0-alpha.0")` resolves **up** to the latest rc. The build pinned the string `alpha.0`, but `npm ci` actually installed `2025.18.0-rc.6`.

`main.yaml` uses `~` safely only because it links the latest *rc* (already the highest prerelease); the alpha workflow inherited that pattern where it's wrong.

## Fix
Pin the **exact** elements version (drop the `~`), matching what `promote.yaml` does with `--save-exact`. npm then installs precisely the alpha built for the dispatched branch.

Verified with semver:
- `~2025.18.0-alpha.0` → resolves `2025.18.0-rc.6` (bug)
- `2025.18.0-alpha.0` (exact) → resolves `2025.18.0-alpha.0` (fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
