### PR TITLE
WEBUI-2165 : test(ftest): optimize provisioning and stabilize tests for Chrome stable [LTS-2025]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11277,22 +11277,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/chrome-launcher": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.14.2.tgz",
-      "integrity": "sha512-Nk8DUCIfPR6p9WClPPFeP2ztpAdkT8xueoiDS03csea1uoJjm4w0p5Oy1hjykyjT1EQ0MMrEshLD3C8gHXyiZw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "*",
-        "escape-string-regexp": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "lighthouse-logger": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -27676,7 +27660,6 @@
         "babel-plugin-transform-rename-import": "^2.3.0",
         "chai": "^4.1.2",
         "check-engine": "^1.10.0",
-        "chrome-launcher": "^0.14.0",
         "fs-extra": "^9.1.0",
         "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/search.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/search.js
@@ -103,22 +103,31 @@ Given('I have permission {word} for this saved search', function (permission) {
 
 When('I browse to the saved search', async function () {
   const savedSearchId = this.savedSearch.id;
-  const uiResult = await this.ui.results;
   const resultsRendered = async () => {
     try {
-      const label = await uiResult.resultsCountLabel;
-      return (await label.isExisting()) && (await label.isDisplayed()) && /\d/.test(await label.getText());
+      // Re-resolve the results page object each check: browser.results freezes the currently selected
+      // pill into its selector, so it must be re-derived after navigation rather than captured once.
+      const label = await (await this.ui.results).resultsCountLabel;
+      if (!(await label.isExisting()) || !(await label.isDisplayed())) {
+        return false;
+      }
+      // Require a positive count: "0 result(s)" means the view rendered but the saved search hasn't
+      // applied (or returned nothing), which is the race this loop retries past.
+      return parseInt((await label.getText()).trim(), 10) > 0;
     } catch (e) {
       return false;
     }
   };
   // Navigating to a saved search by id can intermittently land on a search page whose results view is
-  // not yet wired to the search form, so the saved search is never applied and no results render (the
-  // count label stays absent, i.e. "last seen: n/a"). This is a timing race that surfaces far more often
-  // on recent Chrome versions and under CI load. Re-navigate (via a neutral route so the next hop is a
-  // real route change) until the results actually render.
-  for (let attempt = 0; attempt < 5; attempt += 1) {
+  // not yet wired to the search form, so the saved search is never applied and no results render. This
+  // is a timing race that surfaces more often on recent Chrome versions and under CI load. Two attempts
+  // is the most that fits the Cucumber step timeout, keeping the final throw reachable.
+  const maxAttempts = 2;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     if (attempt > 0) {
+      console.warn(
+        `Saved search ${savedSearchId} results not rendered; re-navigating (attempt ${attempt + 1}/${maxAttempts})`,
+      );
       await url('#!/');
     }
     await url(`#!/doc/${savedSearchId}`);
@@ -129,9 +138,7 @@ When('I browse to the saved search', async function () {
       // results did not render on this attempt — re-navigate and retry
     }
   }
-  // Every attempt failed: fail the step explicitly rather than letting the scenario continue in a
-  // broken state, so later assertions don't fail misleadingly and the root cause stays visible.
-  throw new Error(`Saved search ${savedSearchId} did not render any results after 5 navigation attempts`);
+  throw new Error(`Saved search ${savedSearchId} did not render any results after ${maxAttempts} navigation attempts`);
 });
 
 Then('I can see that my saved search "{word}" on "{word}" is selected', async function (savedSearchName, searchName) {
@@ -206,8 +213,9 @@ Then(/^I can see (\d+) search results$/, async function (numberOfResults) {
               lastSeen = outText;
               if (parseInt(outText, 10) === numberOfResults) return true;
             }
-            // Count doesn't match yet — nudge the page provider to refetch, covering Elasticsearch
-            // indexing / refresh lag once results are shown.
+            // Count doesn't match yet (or the label isn't shown): nudge the page provider to refetch,
+            // covering Elasticsearch indexing / refresh lag. Runs on every poll, including before the
+            // label first appears.
             const el = await uiResult.el;
             await driver.execute((r) => {
               const pp = r && r.querySelector('nuxeo-page-provider');
@@ -223,23 +231,21 @@ Then(/^I can see (\d+) search results$/, async function (numberOfResults) {
     } catch (e) {
       throw new Error(`Expected ${numberOfResults} in results count label (last seen: "${lastSeen}")`, { cause: e });
     }
-    const outResult2 = await uiResult.resultsCount(displayMode);
-    if (outResult2 !== numberOfResults) {
-      throw new Error(`Expecting to get ${numberOfResults} results but found ${outResult2}`);
-    }
+    // The label wait above already asserts the exact total; a DOM-row recount here would only re-check
+    // the virtualized on-screen window and fail for counts larger than the rendered slice.
   }
 });
 
 Then(/^I can see more than (\d+) search results$/, async function (minNumberOfResults) {
   await driver.pause(1000);
   const results = await this.ui.results;
+  const displayMode = await results.displayMode;
   const min = parseInt(minNumberOfResults, 10);
-  let output = min;
+  let output = 'n/a';
   // Read the results count label rather than counting rendered rows: the result list is virtualized
-  // (iron-list only keeps a small window of rows in the DOM), so counting DOM rows caps at the number
-  // of on-screen items and never reflects the true total. After clearing a filter the results also
-  // re-fetch asynchronously, so nudge the page provider to refetch to cover Elasticsearch indexing /
-  // refresh lag while waiting for the label to update.
+  // (iron-list only keeps a small window of rows in the DOM), so counting DOM rows caps at the on-screen
+  // window. After clearing a filter the results also re-fetch asynchronously, so nudge the page provider
+  // to refetch to cover Elasticsearch indexing / refresh lag while waiting for the label to update.
   await driver
     .waitUntil(
       async () => {
@@ -262,13 +268,17 @@ Then(/^I can see more than (\d+) search results$/, async function (minNumberOfRe
         }
         return false;
       },
-      // No timeoutMsg here: it is evaluated when waitUntil is called (output === min) and would report
+      // No timeoutMsg here: it is evaluated when waitUntil is called (output === 'n/a') and would report
       // a stale value. Rethrow below with the last observed count instead.
       { timeout: 20000, interval: 2000 },
     )
-    .catch(() => {
-      throw new Error(`Expecting to get more than ${min} but found ${output}`);
+    .catch((e) => {
+      throw new Error(`Expecting to get more than ${min} but found ${output}`, { cause: e });
     });
+  // Guard against a page provider reporting a count over an empty list: ensure rows actually rendered.
+  if ((await results.resultsCount(displayMode)) === 0) {
+    throw new Error(`Results count label reports more than ${min} but no rows rendered`);
+  }
   return true;
 });
 

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/search.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/search.js
@@ -101,8 +101,34 @@ Given('I have permission {word} for this saved search', function (permission) {
   return fixtures.savedSearches.setPermissions(this.savedSearch, permission, this.username);
 });
 
-When('I browse to the saved search', function () {
-  url(`#!/doc/${this.savedSearch.id}`);
+When('I browse to the saved search', async function () {
+  const savedSearchId = this.savedSearch.id;
+  const uiResult = await this.ui.results;
+  const resultsRendered = async () => {
+    try {
+      const label = await uiResult.resultsCountLabel;
+      return (await label.isExisting()) && (await label.isDisplayed()) && /\d/.test(await label.getText());
+    } catch (e) {
+      return false;
+    }
+  };
+  // Navigating to a saved search by id can intermittently land on a search page whose results view is
+  // not yet wired to the search form, so the saved search is never applied and no results render (the
+  // count label stays absent, i.e. "last seen: n/a"). This is a timing race that surfaces far more often
+  // on recent Chrome versions and under CI load. Re-navigate (via a neutral route so the next hop is a
+  // real route change) until the results actually render.
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    if (attempt > 0) {
+      await url('#!/');
+    }
+    await url(`#!/doc/${savedSearchId}`);
+    try {
+      await driver.waitUntil(resultsRendered, { timeout: 10000, interval: 500 });
+      return;
+    } catch (e) {
+      // results did not render on this attempt — re-navigate and retry
+    }
+  }
 });
 
 Then('I can see that my saved search "{word}" on "{word}" is selected', async function (savedSearchName, searchName) {
@@ -166,31 +192,34 @@ Then(/^I can see (\d+) search results$/, async function (numberOfResults) {
     const emptyResultVisible = await emptyResult.waitForVisible();
     emptyResultVisible.should.be.true;
   } else {
-    await driver.waitUntil(
-      async () => {
-        try {
-          const outLabel = await uiResult.resultsCountLabel;
-          if (!(await outLabel.isExisting()) || !(await outLabel.isDisplayed())) return false;
-          const outText = await outLabel.getText();
-          const outResult = parseInt(outText, 10);
-          if (outResult === numberOfResults) return true;
-          // Count doesn't match yet — trigger a page provider refresh for ES indexing lag
-          const el = await uiResult.el;
-          await driver.execute((r) => {
-            const pp = r && r.querySelector('nuxeo-page-provider');
-            if (pp && pp.fetch) pp.fetch();
-          }, el);
-          return false;
-        } catch (e) {
-          return false;
-        }
-      },
-      {
-        timeout: 20000,
-        interval: 2000,
-        timeoutMsg: `Expected ${numberOfResults} in results count label`,
-      },
-    );
+    let lastSeen = 'n/a';
+    try {
+      await driver.waitUntil(
+        async () => {
+          try {
+            const outLabel = await uiResult.resultsCountLabel;
+            if ((await outLabel.isExisting()) && (await outLabel.isDisplayed())) {
+              const outText = await outLabel.getText();
+              lastSeen = outText;
+              if (parseInt(outText, 10) === numberOfResults) return true;
+            }
+            // Count doesn't match yet — nudge the page provider to refetch, covering Elasticsearch
+            // indexing / refresh lag once results are shown.
+            const el = await uiResult.el;
+            await driver.execute((r) => {
+              const pp = r && r.querySelector('nuxeo-page-provider');
+              if (pp && pp.fetch) pp.fetch();
+            }, el);
+            return false;
+          } catch (e) {
+            return false;
+          }
+        },
+        { timeout: 30000, interval: 2000 },
+      );
+    } catch (e) {
+      throw new Error(`Expected ${numberOfResults} in results count label (last seen: "${lastSeen}")`, { cause: e });
+    }
     const outResult2 = await uiResult.resultsCount(displayMode);
     if (outResult2 !== numberOfResults) {
       throw new Error(`Expecting to get ${numberOfResults} results but found ${outResult2}`);
@@ -201,12 +230,37 @@ Then(/^I can see (\d+) search results$/, async function (numberOfResults) {
 Then(/^I can see more than (\d+) search results$/, async function (minNumberOfResults) {
   await driver.pause(1000);
   const results = await this.ui.results;
-  const displayMode = await results.displayMode;
-  const output = await results.resultsCount(displayMode);
-  if (output > minNumberOfResults) {
-    return true;
-  }
-  throw new Error(`Expecting to get more than ${minNumberOfResults} but found ${output}`);
+  const min = parseInt(minNumberOfResults, 10);
+  let output = min;
+  // Read the results count label rather than counting rendered rows: the result list is virtualized
+  // (iron-list only keeps a small window of rows in the DOM), so counting DOM rows caps at the number
+  // of on-screen items and never reflects the true total. After clearing a filter the results also
+  // re-fetch asynchronously, so nudge the page provider to refetch to cover Elasticsearch indexing /
+  // refresh lag while waiting for the label to update.
+  await driver.waitUntil(
+    async () => {
+      try {
+        const outLabel = await results.resultsCountLabel;
+        if (!(await outLabel.isExisting()) || !(await outLabel.isDisplayed())) {
+          return false;
+        }
+        output = parseInt(await outLabel.getText(), 10);
+        if (output > min) {
+          return true;
+        }
+        const el = await results.el;
+        await driver.execute((r) => {
+          const pp = r && r.querySelector('nuxeo-page-provider');
+          if (pp && pp.fetch) pp.fetch();
+        }, el);
+      } catch (e) {
+        // best-effort refresh
+      }
+      return false;
+    },
+    { timeout: 20000, interval: 2000, timeoutMsg: `Expecting to get more than ${min} but found ${output}` },
+  );
+  return true;
 });
 
 Then('I edit the results columns to show {string}', async function (heading) {

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/search.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/search.js
@@ -255,7 +255,10 @@ Then(/^I can see more than (\d+) search results$/, async function (minNumberOfRe
             return false;
           }
           output = parseInt(await outLabel.getText(), 10);
-          if (output > min) {
+          // Require both the label to exceed min AND rows to have painted, so a page provider reporting
+          // a count over an empty or not-yet-rendered list can't satisfy the step (and a transient
+          // count-before-paint after a refetch doesn't falsely fail it).
+          if (output > min && (await results.resultsCount(displayMode)) > 0) {
             return true;
           }
           const el = await results.el;
@@ -275,10 +278,6 @@ Then(/^I can see more than (\d+) search results$/, async function (minNumberOfRe
     .catch((e) => {
       throw new Error(`Expecting to get more than ${min} but found ${output}`, { cause: e });
     });
-  // Guard against a page provider reporting a count over an empty list: ensure rows actually rendered.
-  if ((await results.resultsCount(displayMode)) === 0) {
-    throw new Error(`Results count label reports more than ${min} but no rows rendered`);
-  }
   return true;
 });
 

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/search.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/search.js
@@ -240,29 +240,35 @@ Then(/^I can see more than (\d+) search results$/, async function (minNumberOfRe
   // of on-screen items and never reflects the true total. After clearing a filter the results also
   // re-fetch asynchronously, so nudge the page provider to refetch to cover Elasticsearch indexing /
   // refresh lag while waiting for the label to update.
-  await driver.waitUntil(
-    async () => {
-      try {
-        const outLabel = await results.resultsCountLabel;
-        if (!(await outLabel.isExisting()) || !(await outLabel.isDisplayed())) {
-          return false;
+  await driver
+    .waitUntil(
+      async () => {
+        try {
+          const outLabel = await results.resultsCountLabel;
+          if (!(await outLabel.isExisting()) || !(await outLabel.isDisplayed())) {
+            return false;
+          }
+          output = parseInt(await outLabel.getText(), 10);
+          if (output > min) {
+            return true;
+          }
+          const el = await results.el;
+          await driver.execute((r) => {
+            const pp = r && r.querySelector('nuxeo-page-provider');
+            if (pp && pp.fetch) pp.fetch();
+          }, el);
+        } catch (e) {
+          // best-effort refresh
         }
-        output = parseInt(await outLabel.getText(), 10);
-        if (output > min) {
-          return true;
-        }
-        const el = await results.el;
-        await driver.execute((r) => {
-          const pp = r && r.querySelector('nuxeo-page-provider');
-          if (pp && pp.fetch) pp.fetch();
-        }, el);
-      } catch (e) {
-        // best-effort refresh
-      }
-      return false;
-    },
-    { timeout: 20000, interval: 2000, timeoutMsg: `Expecting to get more than ${min} but found ${output}` },
-  );
+        return false;
+      },
+      // No timeoutMsg here: it is evaluated when waitUntil is called (output === min) and would report
+      // a stale value. Rethrow below with the last observed count instead.
+      { timeout: 20000, interval: 2000 },
+    )
+    .catch(() => {
+      throw new Error(`Expecting to get more than ${min} but found ${output}`);
+    });
   return true;
 });
 

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/search.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/search.js
@@ -129,6 +129,9 @@ When('I browse to the saved search', async function () {
       // results did not render on this attempt — re-navigate and retry
     }
   }
+  // Every attempt failed: fail the step explicitly rather than letting the scenario continue in a
+  // broken state, so later assertions don't fail misleadingly and the root cause stays visible.
+  throw new Error(`Saved search ${savedSearchId} did not render any results after 5 navigation attempts`);
 });
 
 Then('I can see that my saved search "{word}" on "{word}" is selected', async function (savedSearchName, searchName) {

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/support/fixtures/layouts.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/support/fixtures/layouts.js
@@ -55,7 +55,10 @@ const suggestionSet = async (element, value) => {
         // typing, so the highlighted result is often not rendered on the first check. Wait for it
         // before selecting; without this the value is silently never applied and the search runs
         // unfiltered (e.g. an author facet returns every document instead of the filtered set).
-        await dropdownHighlight.waitForDisplayed({ timeout: 10000 }).catch(() => {});
+        await dropdownHighlight.waitForDisplayed({
+          timeout: 10000,
+          timeoutMsg: `No highlighted suggestion for "${values[i]}" — value would be silently ignored`,
+        });
         if (await dropdownHighlight.isVisible()) {
           const highLightText = await dropdownHighlight.getText();
           const hightlightTrimText = highLightText.trim();
@@ -67,7 +70,8 @@ const suggestionSet = async (element, value) => {
         }
         return false;
       } catch (e) {
-        return false;
+        // Surface the failure instead of silently leaving the field unset and the search unfiltered.
+        throw new Error(`Could not apply suggestion value "${values[i]}"`, { cause: e });
       }
     }
   }

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/support/fixtures/layouts.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/support/fixtures/layouts.js
@@ -51,6 +51,11 @@ const suggestionSet = async (element, value) => {
       try {
         dropdown = await element.element('.selectivity-dropdown:last-child');
         const dropdownHighlight = await dropdown.$('.selectivity-result-item.highlight');
+        // Suggestion results (users, directories, documents) are fetched asynchronously after
+        // typing, so the highlighted result is often not rendered on the first check. Wait for it
+        // before selecting; without this the value is silently never applied and the search runs
+        // unfiltered (e.g. an author facet returns every document instead of the filtered set).
+        await dropdownHighlight.waitForDisplayed({ timeout: 10000 }).catch(() => {});
         if (await dropdownHighlight.isVisible()) {
           const highLightText = await dropdownHighlight.getText();
           const hightlightTrimText = highLightText.trim();

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/support/fixtures/searches.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/support/fixtures/searches.js
@@ -22,7 +22,15 @@ fixtures.savedSearches = {
         permission,
         username,
       })
-      .execute(),
+      .execute()
+      // Granting a permission re-indexes the document's ACL in Elasticsearch asynchronously. The Web UI
+      // lists saved searches from an ES-backed page provider, so navigating to the shared saved search
+      // before its ACL is indexed makes it absent from the recipient's list — the form then falls back to
+      // the default, unfiltered search and the wrong result count is shown. Block until pending indexing
+      // is flushed and refreshed so the recipient reliably sees the shared search.
+      .then(() =>
+        nuxeo.operation('Elasticsearch.WaitForIndexing').params({ timeoutSecond: 60, refresh: true }).execute(),
+      ),
 };
 
 After(() =>

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/support/services/documentService.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/support/services/documentService.js
@@ -125,7 +125,12 @@ class DocumentHelper {
       .repository()
       .delete(document.path)
       .then(() => {
-        this.liveDocuments.splice(this.liveDocuments.indexOf(document.uid), 1);
+        // Guard the index: indexOf === -1 would splice off the last (deepest) tracked doc, breaking
+        // reset()'s children-before-parents ordering and reintroducing the 409 cascade.
+        const i = this.liveDocuments.indexOf(document.uid);
+        if (i !== -1) {
+          this.liveDocuments.splice(i, 1);
+        }
       });
   }
 

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/support/services/documentService.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/support/services/documentService.js
@@ -21,17 +21,26 @@ class DocumentHelper {
     );
   }
 
-  reset() {
-    return Promise.all(
-      this.liveDocuments.map((docUid) =>
-        this._retry(() =>
+  async reset() {
+    // Delete tracked documents sequentially, children before parents. The previous parallel
+    // Promise.all raced a parent's recursive delete against the explicit delete of its child, so
+    // Nuxeo threw ConcurrentUpdateException (409); the retries could not always win the race and the
+    // document leaked, inflating later features' search-result counts (a flaky "Expected N in results
+    // count label"). Documents are recorded in creation order (parents first), so iterating in reverse
+    // removes children first and each delete is a clean, un-contended operation.
+    const uids = this.liveDocuments.slice().reverse();
+    for (let i = 0; i < uids.length; i++) {
+      const docUid = uids[i];
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await this._retry(() =>
           nuxeo
             .repository()
             .delete(docUid)
             .catch((e) => {
               if (!e.response) throw e;
               const { status, statusText, url } = e.response;
-              // 404 means the document was already deleted (e.g. parent cascade) — ignore it
+              // 404 means the document was already deleted (e.g. by a parent cascade) — ignore it
               if (status === 404) {
                 return;
               }
@@ -41,17 +50,13 @@ class DocumentHelper {
                 throw e;
               }
             }),
-        ),
-      ),
-    )
-      .then(() => {
-        this.liveDocuments = [];
-      })
-      .catch((e) => {
+        );
+      } catch (e) {
+        // Log and continue so one stubborn document never blocks cleaning up the rest
         console.error(e);
-        // Clear liveDocuments even on failure to prevent re-deleting in subsequent After hooks
-        this.liveDocuments = [];
-      });
+      }
+    }
+    this.liveDocuments = [];
   }
 
   init(type = 'File', title = 'my document') {

--- a/packages/nuxeo-web-ui-ftest/package-lock.json
+++ b/packages/nuxeo-web-ui-ftest/package-lock.json
@@ -22,7 +22,6 @@
         "babel-plugin-transform-rename-import": "^2.3.0",
         "chai": "^4.1.2",
         "check-engine": "^1.10.0",
-        "chrome-launcher": "^0.14.0",
         "fs-extra": "^9.1.0",
         "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
@@ -4399,21 +4398,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/chrome-launcher": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.14.2.tgz",
-      "integrity": "sha512-Nk8DUCIfPR6p9WClPPFeP2ztpAdkT8xueoiDS03csea1uoJjm4w0p5Oy1hjykyjT1EQ0MMrEshLD3C8gHXyiZw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "*",
-        "escape-string-regexp": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "lighthouse-logger": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -7073,31 +7057,6 @@
         "immediate": "~3.0.5"
       }
     },
-    "node_modules/lighthouse-logger": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
-      "integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^2.6.9",
-        "marky": "^1.2.2"
-      }
-    },
-    "node_modules/lighthouse-logger/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/lighthouse-logger/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -7307,12 +7266,6 @@
       "bin": {
         "semver": "bin/semver"
       }
-    },
-    "node_modules/marky": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
-      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/packages/nuxeo-web-ui-ftest/package.json
+++ b/packages/nuxeo-web-ui-ftest/package.json
@@ -32,7 +32,6 @@
     "babel-plugin-transform-rename-import": "^2.3.0",
     "chai": "^4.1.2",
     "check-engine": "^1.10.0",
-    "chrome-launcher": "^0.14.0",
     "fs-extra": "^9.1.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",

--- a/packages/nuxeo-web-ui-ftest/pages/ui/admin/vocabulary.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/admin/vocabulary.js
@@ -80,32 +80,12 @@ export default class Vocabulary extends BasePage {
     const deleteButton = await this.el.element(selector);
     await deleteButton.waitForVisible();
     await deleteButton.scrollIntoView(selector);
-
-    // Wait for the alert to appear, retrying the click if it didn't register
-    await driver.waitUntil(
-      async () => {
-        try {
-          await driver.getAlertText();
-          return true;
-        } catch (e) {
-          // Alert not present — retry the click and keep waiting
-          try {
-            await deleteButton.click();
-          } catch (clickError) {
-            // Ignore transient click failures so waitUntil can retry
-          }
-          return false;
-        }
-      },
-      {
-        timeout: 10000,
-        interval: 1000,
-        timeoutMsg: 'Expected confirmation alert did not appear',
-      },
-    );
-
-    // Alert is confirmed present — accept it directly (no retry needed)
-    await driver.acceptAlert();
+    // The click override lands reliably (centring / DOM fallback for obscured buttons), so the
+    // confirm dialog is open by the time the click resolves. Accept it directly instead of polling
+    // getAlertText first, which used to log a spurious "no such alert" WebDriver error on the initial
+    // poll before the dialog existed. alertAccept still waits for the alert, so timing is covered.
+    await deleteButton.click();
+    await driver.alertAccept();
   }
 
   async editEntry(index, label) {

--- a/packages/nuxeo-web-ui-ftest/pages/ui/admin/vocabulary.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/admin/vocabulary.js
@@ -80,10 +80,10 @@ export default class Vocabulary extends BasePage {
     const deleteButton = await this.el.element(selector);
     await deleteButton.waitForVisible();
     await deleteButton.scrollIntoView(selector);
-    // Click, then accept the confirm dialog via alertAccept, which waits for the alert to appear.
-    // The previous code polled getAlertText() first, which logged a spurious "no such alert"
-    // WebDriver error on the initial poll before the dialog existed; relying on alertAccept's
-    // built-in wait covers the timing without that noise.
+    // Click once, then accept the confirm dialog via alertAccept (which waits for the alert). The
+    // previous code retried the click while polling getAlertText(), logging a spurious "no such alert"
+    // error before the dialog existed. The click retry is dropped deliberately: if the click is lost,
+    // alertAccept fails loudly rather than masking it.
     await deleteButton.click();
     await driver.alertAccept();
   }

--- a/packages/nuxeo-web-ui-ftest/pages/ui/admin/vocabulary.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/admin/vocabulary.js
@@ -80,10 +80,10 @@ export default class Vocabulary extends BasePage {
     const deleteButton = await this.el.element(selector);
     await deleteButton.waitForVisible();
     await deleteButton.scrollIntoView(selector);
-    // The click override lands reliably (centring / DOM fallback for obscured buttons), so the
-    // confirm dialog is open by the time the click resolves. Accept it directly instead of polling
-    // getAlertText first, which used to log a spurious "no such alert" WebDriver error on the initial
-    // poll before the dialog existed. alertAccept still waits for the alert, so timing is covered.
+    // Click, then accept the confirm dialog via alertAccept, which waits for the alert to appear.
+    // The previous code polled getAlertText() first, which logged a spurious "no such alert"
+    // WebDriver error on the initial poll before the dialog existed; relying on alertAccept's
+    // built-in wait covers the timing without that noise.
     await deleteButton.click();
     await driver.alertAccept();
   }

--- a/packages/nuxeo-web-ui-ftest/pages/ui/browser.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/browser.js
@@ -513,7 +513,10 @@ export default class Browser extends BasePage {
         if (!(await titleEl.isExisting())) {
           return '';
         }
-        return ((await browser.execute((el) => el.textContent, titleEl)) || '').trim();
+        // Skip rows iron-list recycled out of range (div.item[hidden] keeps stale bound content), as
+        // clickChild/indexOfChild do, so findIndex can't match a hidden row and toggle the wrong one.
+        const hidden = await browser.execute((el) => !!el.closest('div.item[hidden]'), row);
+        return hidden ? '' : ((await browser.execute((el) => el.textContent, titleEl)) || '').trim();
       }),
     );
     const index = titles.findIndex((currentTitle) => currentTitle === title);

--- a/packages/nuxeo-web-ui-ftest/pages/ui/browser.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/browser.js
@@ -292,8 +292,7 @@ export default class Browser extends BasePage {
       if (await rowEl.isExisting()) {
         // Match on textContent rather than getText()/isVisible(): on newer Chrome both are
         // empty/false for rows below the fold, so a child that isn't currently scrolled into
-        // view was never matched. The click auto-scrolls the row into view (and the click
-        // override recovers from any interception).
+        // view was never matched. Clicking the row scrolls it into view before the click lands.
         const text = ((await browser.execute((el) => el.textContent, rowEl)) || '').trim();
         if (text === title) {
           await row.click();
@@ -494,11 +493,15 @@ export default class Browser extends BasePage {
     // for rows below the fold on newer Chrome; the previous code filtered those empties out and
     // then indexed the UNFILTERED rows, so an off-screen target (e.g. "Kumquat") was not found and
     // rowTemp[-1] threw "Cannot read properties of undefined (reading 'isVisible')".
-    const titles = await rowTemp.map((row) =>
-      browser.execute((el) => {
-        const a = el.querySelector('nuxeo-data-table-cell a.title');
-        return a ? a.textContent.trim() : '';
-      }, row),
+    // Resolve every browser.execute() with Promise.all; a bare `await arr.map(...)` on the already
+    // resolved element array would leave an array of unsettled Promises and never match the title.
+    const titles = await Promise.all(
+      [...rowTemp].map((row) =>
+        browser.execute((el) => {
+          const a = el.querySelector('nuxeo-data-table-cell a.title');
+          return a ? a.textContent.trim() : '';
+        }, row),
+      ),
     );
     const index = titles.findIndex((currentTitle) => currentTitle === title);
     if (index < 0) {

--- a/packages/nuxeo-web-ui-ftest/pages/ui/browser.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/browser.js
@@ -293,7 +293,9 @@ export default class Browser extends BasePage {
         // Match on textContent rather than getText()/isVisible(): on newer Chrome both are
         // empty/false for rows below the fold, so a child that isn't currently scrolled into
         // view was never matched. Clicking the row scrolls it into view before the click lands.
-        const text = ((await browser.execute((el) => el.textContent, rowEl)) || '').trim();
+        // Skip rows iron-list recycled out of range: their div.item is [hidden] but keeps stale bound content.
+        const hidden = await browser.execute((el) => !!el.closest('div.item[hidden]'), row);
+        const text = hidden ? '' : ((await browser.execute((el) => el.textContent, rowEl)) || '').trim();
         if (text === title) {
           await row.click();
           return true; // Exit the loop once a match is found
@@ -315,9 +317,14 @@ export default class Browser extends BasePage {
             // Read textContent via JS rather than getText(): on newer Chrome getText() returns an
             // empty string for rows below the fold, so lower-positioned children (e.g. position 8)
             // were never matched even though their row exists in the DOM.
-            const text = ((await browser.execute((el) => el.textContent, cell)) || '').trim();
+            // Skip rows iron-list recycled out of range (div.item[hidden]) whose bound title is stale.
+            const hidden = await browser.execute((el) => !!el.closest('div.item[hidden]'), rows[i]);
+            const text = hidden ? '' : ((await browser.execute((el) => el.textContent, cell)) || '').trim();
             if (text === title) {
-              return { index: i };
+              // Use the row's bound virtual index (its true ordinal), not the DOM loop index, which
+              // drifts once iron-list recycles rows.
+              const boundIndex = Number(await rows[i].getAttribute('index'));
+              return { index: Number.isNaN(boundIndex) ? i : boundIndex };
             }
           }
         }
@@ -508,7 +515,8 @@ export default class Browser extends BasePage {
     );
     const index = titles.findIndex((currentTitle) => currentTitle === title);
     if (index < 0) {
-      return false;
+      // Fail loudly: callers discard the return value, so a missing document must not pass as a no-op.
+      throw new Error(`Child document "${title}" not found among ${titles.length} rows: ${JSON.stringify(titles)}`);
     }
     const targetRow = rowTemp[index];
     try {

--- a/packages/nuxeo-web-ui-ftest/pages/ui/browser.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/browser.js
@@ -495,6 +495,9 @@ export default class Browser extends BasePage {
   }
 
   async _selectChildDocument(title, deselect) {
+    // Wait for child rows to load first (like clickChild/indexOfChild); otherwise a slow page
+    // provider yields 0 rows and the not-found throw below fires before the table has rendered.
+    await this.waitForChildren();
     const rowTemp = await this.rows;
     // Read each row's title via textContent (aligned with rowTemp indices). getText() returns ''
     // for rows below the fold on newer Chrome; the previous code filtered those empties out and

--- a/packages/nuxeo-web-ui-ftest/pages/ui/browser.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/browser.js
@@ -289,12 +289,16 @@ export default class Browser extends BasePage {
     for (let i = 0; i < rowTemp.length; i++) {
       const row = rowTemp[i];
       const rowEl = await row.$('nuxeo-data-table-cell a.title');
-      const rowVisible = await rowEl.isVisible();
-      const getText = await rowEl.getText();
-      const rowText = (await getText.trim()) === title;
-      if (rowVisible && rowText) {
-        await row.click();
-        return true; // Exit the loop once a match is found
+      if (await rowEl.isExisting()) {
+        // Match on textContent rather than getText()/isVisible(): on newer Chrome both are
+        // empty/false for rows below the fold, so a child that isn't currently scrolled into
+        // view was never matched. The click auto-scrolls the row into view (and the click
+        // override recovers from any interception).
+        const text = ((await browser.execute((el) => el.textContent, rowEl)) || '').trim();
+        if (text === title) {
+          await row.click();
+          return true; // Exit the loop once a match is found
+        }
       }
     }
     return false;
@@ -309,7 +313,10 @@ export default class Browser extends BasePage {
         for (let i = 0; i < rows.length; i++) {
           const cell = await rows[i].$('nuxeo-data-table-cell a.title');
           if (await cell.isExisting()) {
-            const text = (await cell.getText()).trim();
+            // Read textContent via JS rather than getText(): on newer Chrome getText() returns an
+            // empty string for rows below the fold, so lower-positioned children (e.g. position 8)
+            // were never matched even though their row exists in the DOM.
+            const text = ((await browser.execute((el) => el.textContent, cell)) || '').trim();
             if (text === title) {
               return { index: i };
             }
@@ -483,16 +490,33 @@ export default class Browser extends BasePage {
 
   async _selectChildDocument(title, deselect) {
     const rowTemp = await this.rows;
-    const elementTitle = await browser
-      .$$('nuxeo-data-table[name="table"] nuxeo-data-table-row:not([header])')
-      .map((img) => img.$('nuxeo-data-table-cell a.title').getText());
-    const nonEmptyTitles = elementTitle.filter((nonEmpty) => nonEmpty.trim() !== '');
-    const index = nonEmptyTitles.findIndex((currenTitle) => currenTitle === title);
+    // Read each row's title via textContent (aligned with rowTemp indices). getText() returns ''
+    // for rows below the fold on newer Chrome; the previous code filtered those empties out and
+    // then indexed the UNFILTERED rows, so an off-screen target (e.g. "Kumquat") was not found and
+    // rowTemp[-1] threw "Cannot read properties of undefined (reading 'isVisible')".
+    const titles = await rowTemp.map((row) =>
+      browser.execute((el) => {
+        const a = el.querySelector('nuxeo-data-table-cell a.title');
+        return a ? a.textContent.trim() : '';
+      }, row),
+    );
+    const index = titles.findIndex((currentTitle) => currentTitle === title);
+    if (index < 0) {
+      return false;
+    }
+    const targetRow = rowTemp[index];
+    try {
+      // Bring the row into view so its checkbox is displayed/interactable (off-screen rows report
+      // isVisible() === false and can't be clicked).
+      await targetRow.scrollIntoView({ block: 'center', inline: 'center' });
+    } catch (e) {
+      // best-effort centring
+    }
     await driver.pause(1000);
-    const isCheckedVisible = await rowTemp[index].isVisible('nuxeo-data-table-checkbox[checked]');
-    const isNotCheckedVisible = await rowTemp[index].isVisible('nuxeo-data-table-checkbox:not([checked])');
-    if ((deselect ? isCheckedVisible : isNotCheckedVisible) && index >= 0) {
-      const currentRow = await rowTemp[index].$('nuxeo-data-table-checkbox');
+    const isCheckedVisible = await targetRow.isVisible('nuxeo-data-table-checkbox[checked]');
+    const isNotCheckedVisible = await targetRow.isVisible('nuxeo-data-table-checkbox:not([checked])');
+    if (deselect ? isCheckedVisible : isNotCheckedVisible) {
+      const currentRow = await targetRow.$('nuxeo-data-table-checkbox');
       await currentRow.click();
       return true;
     }

--- a/packages/nuxeo-web-ui-ftest/pages/ui/browser.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/browser.js
@@ -493,15 +493,18 @@ export default class Browser extends BasePage {
     // for rows below the fold on newer Chrome; the previous code filtered those empties out and
     // then indexed the UNFILTERED rows, so an off-screen target (e.g. "Kumquat") was not found and
     // rowTemp[-1] threw "Cannot read properties of undefined (reading 'isVisible')".
-    // Resolve every browser.execute() with Promise.all; a bare `await arr.map(...)` on the already
-    // resolved element array would leave an array of unsettled Promises and never match the title.
+    // Resolve the title element with WebdriverIO's `$` (which pierces shadow DOM via
+    // wdio-shadow-plugin) rather than a plain el.querySelector inside browser.execute (which would
+    // not cross the row's shadow root and resolve every title to ''), and settle all reads with
+    // Promise.all so `titles` holds strings — a bare `await arr.map(...)` would leave Promises.
     const titles = await Promise.all(
-      [...rowTemp].map((row) =>
-        browser.execute((el) => {
-          const a = el.querySelector('nuxeo-data-table-cell a.title');
-          return a ? a.textContent.trim() : '';
-        }, row),
-      ),
+      [...rowTemp].map(async (row) => {
+        const titleEl = await row.$('nuxeo-data-table-cell a.title');
+        if (!(await titleEl.isExisting())) {
+          return '';
+        }
+        return ((await browser.execute((el) => el.textContent, titleEl)) || '').trim();
+      }),
     );
     const index = titles.findIndex((currentTitle) => currentTitle === title);
     if (index < 0) {

--- a/packages/nuxeo-web-ui-ftest/pages/ui/search.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/search.js
@@ -111,12 +111,14 @@ export default class Search extends Results {
 
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
+      // Read via textContent: on newer Chrome getText() returns '' for these shadow-DOM dropdown
+      // items when they are not laid out on screen, so the name match would silently never hit.
       // eslint-disable-next-line no-await-in-loop
-      const text = await item.getText();
+      const text = await browser.execute((el) => el.textContent, item);
       // eslint-disable-next-line no-await-in-loop
       const className = await item.getAttribute('class');
 
-      if (text === savedSearchName && className.includes('highlight')) {
+      if ((text || '').trim() === savedSearchName && className.includes('highlight')) {
         return item;
       }
     }

--- a/packages/nuxeo-web-ui-ftest/scripts/test.js
+++ b/packages/nuxeo-web-ui-ftest/scripts/test.js
@@ -28,8 +28,6 @@
 
 import fs from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
-import chromeLauncher from 'chrome-launcher';
 import { fileURLToPath } from 'url';
 import minimist from 'minimist';
 const { Launcher: CliLauncher } = await import('@wdio/cli');
@@ -101,76 +99,16 @@ process.env.BROWSER = argv.browser || process.env.BROWSER || 'chrome';
 
 process.env.FORCE_COLOR = true;
 
-let done = Promise.resolve();
-
-if (process.env.DRIVER_VERSION == null) {
-  const chromePath = chromeLauncher.Launcher.getFirstInstallation();
-  let version;
-  try {
-    version = execSync(`"${chromePath}" --version`).toString().trim();
-  } catch (e) {
-    console.error('unable to get Chrome version: ', e);
-  }
-  // eslint-disable-next-line no-console
-  console.log(`${version} detected.`);
-  const match = version && version.match(/([0-9]+)\./);
-  if (match) {
-    const checkVersion = match[1];
-    try {
-      done = fetch(`https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_${checkVersion}`).then(
-        (response) => {
-          if (response.ok) {
-            return response
-              .text()
-              .then((newDriverVersion) => {
-                // eslint-disable-next-line no-console
-                console.log(`ChromeDriver ${newDriverVersion} needed.`);
-                process.env.DRIVER_VERSION = newDriverVersion;
-              })
-              .catch((e) => {
-                console.error('unable to parse ChromeDriver version: ', e);
-              });
-          }
-          console.error('unable to fetch ChromeDriver version: ', response);
-        },
-      );
-    } catch (e) {
-      console.error('unable to fetch ChromeDriver version: ', e);
-    }
-  }
-}
-try {
-  done = fetch(`https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json`).then(
-    (response) => {
-      if (response.ok) {
-        return response
-          .text()
-          .then((responseJSON) => {
-            const responseObj = JSON.parse(responseJSON);
-            const cftVersion = responseObj.channels.Stable.version;
-            // eslint-disable-next-line no-console
-            console.log(`ChromeForTesting ${cftVersion} detected.`);
-          })
-          .catch((e) => {
-            console.error('unable to parse Chrome for testing browser version: ', e);
-          });
-      }
-      console.error('unable to fetch Chrome for testing browser version: ', response);
-    },
-  );
-} catch (e) {
-  console.error('unable to fetch Chrome for testing browser version ', e);
-}
-
-done.finally(() => {
-  const wdio = new CliLauncher(args[0]);
-  wdio.run().then(
-    (code) => {
-      process.exit(code);
-    },
-    (error) => {
-      console.error('Launcher failed to start the test', error.stacktrace);
-      process.exit(1);
-    },
-  );
-});
+// Browser and matching driver provisioning is delegated to WebdriverIO's built-in driver
+// manager (see `browserVersion` in wdio.conf.js), so no manual Chrome/ChromeDriver version
+// resolution is required here.
+const wdio = new CliLauncher(args[0]);
+wdio.run().then(
+  (code) => {
+    process.exit(code);
+  },
+  (error) => {
+    console.error('Launcher failed to start the test', error.stacktrace);
+    process.exit(1);
+  },
+);

--- a/packages/nuxeo-web-ui-ftest/scripts/test.js
+++ b/packages/nuxeo-web-ui-ftest/scripts/test.js
@@ -21,6 +21,8 @@
  *   --wdioConfig: pass a custom wdio config file
  *   --debug: allow node inspector to be attached
  *   --browser: the browser to be used (defaults to chrome)
+ *   --browserVersion: the browser version/channel to provision (e.g. 'stable' or '135.0.7049.114');
+ *                     falls back on the BROWSER_VERSION env var or 'stable'
  *   --runAll: do not apply fail fast premise which means that a scenario failure won't trigger feature failure
  *   --bail:  amount of tests that can fail before stopping the runner
  *            by default set to 0, which means don't bail, run all tests
@@ -96,6 +98,10 @@ if (argv.bail) {
 }
 
 process.env.BROWSER = argv.browser || process.env.BROWSER || 'chrome';
+
+if (argv.browserVersion) {
+  process.env.BROWSER_VERSION = argv.browserVersion;
+}
 
 process.env.FORCE_COLOR = true;
 

--- a/packages/nuxeo-web-ui-ftest/wdio-compat-plugin.js
+++ b/packages/nuxeo-web-ui-ftest/wdio-compat-plugin.js
@@ -297,14 +297,12 @@ export default class {
       true,
     );
     // overwrite element comands that previously took a selector as optional argument
-    ['getText', 'click'].forEach((name) => {
-      browser.overwriteCommand(
-        name,
-        async function (cmd, selector) {
-          return selector ? cmd.call(this.element(selector)) : cmd();
-        },
-        true,
-      );
-    });
+    browser.overwriteCommand(
+      'getText',
+      async function (cmd, selector) {
+        return selector ? cmd.call(this.element(selector)) : cmd();
+      },
+      true,
+    );
   }
 }

--- a/packages/nuxeo-web-ui-ftest/wdio-compat-plugin.js
+++ b/packages/nuxeo-web-ui-ftest/wdio-compat-plugin.js
@@ -297,12 +297,14 @@ export default class {
       true,
     );
     // overwrite element comands that previously took a selector as optional argument
-    browser.overwriteCommand(
-      'getText',
-      async function (cmd, selector) {
-        return selector ? cmd.call(this.element(selector)) : cmd();
-      },
-      true,
-    );
+    ['getText', 'click'].forEach((name) => {
+      browser.overwriteCommand(
+        name,
+        async function (cmd, selector) {
+          return selector ? cmd.call(this.element(selector)) : cmd();
+        },
+        true,
+      );
+    });
   }
 }

--- a/packages/nuxeo-web-ui-ftest/wdio.conf.js
+++ b/packages/nuxeo-web-ui-ftest/wdio.conf.js
@@ -34,9 +34,7 @@ const reporters = ['spec'];
 
 const _workerStartTimes = new Map();
 const _featureResults = [];
-let _browserLogged = false;
-const _browserVersionFile = path.join(os.tmpdir(), 'wdio-browser-version.txt');
-let _browserVersion = '';
+const _browserReconcileLock = path.join(os.tmpdir(), 'wdio-browser-reconciled.lock');
 
 if (process.env.CUCUMBER_REPORT_PATH) {
   reporters.push([
@@ -285,9 +283,54 @@ export const config = {
   // resolved to continue.
   //
   // Gets executed once before all workers get launched.
-  onPrepare: () => {
+  onPrepare: async () => {
     // eslint-disable-next-line no-console
     console.log(`Starting ftests in ${process.env.HEADLESS === 'true' ? 'HEADLESS' : 'HEADFUL'} mode`);
+
+    // Resolve and report the browser once, up front. Guard the two cases the review flagged where a
+    // resolved version could differ from what runs: a custom BROWSER_BINARY bypasses provisioning, and
+    // a pinned BROWSER_VERSION needs no lookup. For a channel (e.g. 'stable') the chrome-for-testing
+    // lookup returns the build the driver manager provisions on a clean runner; any residual drift
+    // (e.g. a stale local cache) is reconciled against the live session in `before`.
+    const browserName = process.env.BROWSER || 'chrome';
+    let browserLabel = '';
+    if (process.env.BROWSER_BINARY) {
+      // eslint-disable-next-line no-console
+      console.log(`Using ${browserName} from custom binary ${process.env.BROWSER_BINARY}`);
+    } else {
+      const configuredVersion = process.env.BROWSER_VERSION || 'stable';
+      let resolvedVersion = configuredVersion;
+      if (browserName === 'chrome' && !/^\d/.test(configuredVersion)) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 3000);
+        try {
+          const res = await fetch(
+            'https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json',
+            { signal: controller.signal },
+          );
+          if (res.ok) {
+            const { channels = {} } = await res.json();
+            const channel = channels[configuredVersion.charAt(0).toUpperCase() + configuredVersion.slice(1)];
+            if (channel && channel.version) {
+              resolvedVersion = channel.version;
+            }
+          }
+        } catch (e) {
+          // best-effort: fall back to the channel name (also covers the abort timeout)
+        } finally {
+          clearTimeout(timer);
+        }
+      }
+      browserLabel = `${browserName} ${resolvedVersion}`;
+      // eslint-disable-next-line no-console
+      console.log(`Using ${browserLabel}`);
+    }
+    process.env.WDIO_BROWSER_LABEL = browserLabel;
+    try {
+      fs.unlinkSync(_browserReconcileLock);
+    } catch (e) {
+      // no stale reconcile lock to clear
+    }
 
     // Strip file:// prefix and append timing to WDIO's PASSED/FAILED lines.
     const originalWrite = process.stdout.write.bind(process.stdout);
@@ -295,7 +338,6 @@ export const config = {
     // eslint-disable-next-line no-control-regex
     const ansiRegex = /\x1b\[[0-9;]*m/g;
     const statusLineRegex = /\[(\d+-\d+)\] (?:PASSED|FAILED) in .* - /;
-    const runningLineRegex = /\[\d+-\d+\] RUNNING in .* - /;
     process.stdout.write = (chunk, ...args) => {
       if (typeof chunk === 'string') {
         chunk = chunk.replace(/file:\/\//g, '');
@@ -307,19 +349,6 @@ export const config = {
           if (start) {
             const elapsed = ((Date.now() - start) / 1000).toFixed(1);
             chunk = chunk.replace(/\n$/, '') + ` \x1b[1m( ${elapsed}s )\x1b[0m\n`;
-          }
-        } else if (runningLineRegex.test(plain) && !/\(\s*chrome\b/.test(plain)) {
-          // Annotate the RUNNING line with the resolved browser version rather than logging it as a
-          // separate per-spec line. The version is written by the first worker's `before` hook.
-          if (!_browserVersion) {
-            try {
-              _browserVersion = fs.readFileSync(_browserVersionFile, 'utf8').trim();
-            } catch (e) {
-              // not written yet; retry on the next RUNNING line
-            }
-          }
-          if (_browserVersion) {
-            chunk = chunk.replace(/\n$/, '') + ` \x1b[1m( ${_browserVersion} )\x1b[0m\n`;
           }
         }
       }
@@ -376,17 +405,18 @@ export const config = {
       console.error('Failed to set window size:', e);
     }
 
-    // Record the resolved browser once per worker so the main process can annotate the RUNNING lines,
-    // read from live capabilities so it can't drift from the build that actually runs.
-    if (!_browserLogged) {
-      _browserLogged = true;
+    // Reconcile the up-front browser label with what this session actually resolved to, so a wrong
+    // up-front version can never stand (per PR review). Log one correction globally if they differ.
+    const expectedBrowser = process.env.WDIO_BROWSER_LABEL;
+    const actualBrowser = `${browser.capabilities.browserName} ${browser.capabilities.browserVersion}`;
+    if (expectedBrowser && expectedBrowser !== actualBrowser) {
       try {
-        fs.writeFileSync(
-          _browserVersionFile,
-          `${browser.capabilities.browserName} ${browser.capabilities.browserVersion}`,
+        fs.writeFileSync(_browserReconcileLock, '', { flag: 'wx' });
+        console.warn(
+          `Browser mismatch: reported "${expectedBrowser}" up front but this session runs "${actualBrowser}"`,
         );
       } catch (e) {
-        // best-effort: the RUNNING line just won't show the resolved version
+        // another worker already logged the correction, or the lock write failed — ignore
       }
     }
 

--- a/packages/nuxeo-web-ui-ftest/wdio.conf.js
+++ b/packages/nuxeo-web-ui-ftest/wdio.conf.js
@@ -286,14 +286,19 @@ export const config = {
 
     // Report the browser version once, up front, before any worker starts. Provisioning is
     // delegated to WebdriverIO's driver manager; when a channel (e.g. 'stable') is configured,
-    // resolve the concrete Chrome-for-Testing build purely for this log line. Best-effort: it
-    // never blocks the run and falls back to the configured channel name if the lookup fails.
+    // resolve the concrete Chrome-for-Testing build purely for this log line. Best-effort: the
+    // fetch is bounded by a short abortable timeout so a slow/unreachable host can never block the
+    // run, and it falls back to the configured channel name if the lookup fails or times out.
     const browserName = process.env.BROWSER || 'chrome';
     const configuredVersion = process.env.BROWSER_VERSION || 'stable';
     let resolvedVersion = configuredVersion;
     if (browserName === 'chrome' && !/^\d/.test(configuredVersion)) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 3000);
       try {
-        const res = await fetch('https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json');
+        const res = await fetch('https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json', {
+          signal: controller.signal,
+        });
         if (res.ok) {
           const { channels = {} } = await res.json();
           const channel = channels[configuredVersion.charAt(0).toUpperCase() + configuredVersion.slice(1)];
@@ -302,7 +307,9 @@ export const config = {
           }
         }
       } catch (e) {
-        // best-effort: fall back to the configured channel name
+        // best-effort: fall back to the configured channel name (also covers the abort timeout)
+      } finally {
+        clearTimeout(timer);
       }
     }
     // eslint-disable-next-line no-console

--- a/packages/nuxeo-web-ui-ftest/wdio.conf.js
+++ b/packages/nuxeo-web-ui-ftest/wdio.conf.js
@@ -49,7 +49,11 @@ const capability = {
   maxInstances: 1,
   browserName: process.env.BROWSER,
   acceptInsecureCerts: true,
-  browserVersion: '135.0.7049.114',
+  // Let WebdriverIO's built-in driver manager provision the browser and its matching driver
+  // (e.g. Chrome-for-Testing + chromedriver, or Firefox + geckodriver) rather than a hard-pinned
+  // build. Defaults to the current stable channel; override via BROWSER_VERSION with an explicit
+  // version or a channel name (e.g. 'beta'/'dev'/'canary') when a specific build is required.
+  browserVersion: process.env.BROWSER_VERSION || 'stable',
   'wdio:enforceWebDriverClassic': true,
   // Prevent ChromeDriver from auto-dismissing native dialogs (window.confirm, window.alert)
   // so that tests can explicitly accept/dismiss them via alertAccept/alertDismiss.
@@ -113,13 +117,6 @@ switch (capability.browserName) {
 }
 
 const TIMEOUT = process.env.TIMEOUT ? Number(process.env.TIMEOUT) : 40000;
-
-// Allow overriding driver version
-const drivers = {};
-drivers[process.env.BROWSER] = {};
-if (process.env.DRIVER_VERSION) {
-  drivers[process.env.BROWSER].version = process.env.DRIVER_VERSION;
-}
 
 // transform nuxeo-web-ui-ftest requires
 import('@babel/register').then(({ default: register }) => {
@@ -283,11 +280,35 @@ export const config = {
   // resolved to continue.
   //
   // Gets executed once before all workers get launched.
-  onPrepare: () => {
+  onPrepare: async () => {
     // eslint-disable-next-line no-console
     console.log(`Starting ftests in ${process.env.HEADLESS === 'true' ? 'HEADLESS' : 'HEADFUL'} mode`);
 
-    // Strip file:// prefix and append timing to WDIO's PASSED/FAILED lines
+    // Report the browser version once, up front, before any worker starts. Provisioning is
+    // delegated to WebdriverIO's driver manager; when a channel (e.g. 'stable') is configured,
+    // resolve the concrete Chrome-for-Testing build purely for this log line. Best-effort: it
+    // never blocks the run and falls back to the configured channel name if the lookup fails.
+    const browserName = process.env.BROWSER || 'chrome';
+    const configuredVersion = process.env.BROWSER_VERSION || 'stable';
+    let resolvedVersion = configuredVersion;
+    if (browserName === 'chrome' && !/^\d/.test(configuredVersion)) {
+      try {
+        const res = await fetch('https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json');
+        if (res.ok) {
+          const { channels = {} } = await res.json();
+          const channel = channels[configuredVersion.charAt(0).toUpperCase() + configuredVersion.slice(1)];
+          if (channel && channel.version) {
+            resolvedVersion = channel.version;
+          }
+        }
+      } catch (e) {
+        // best-effort: fall back to the configured channel name
+      }
+    }
+    // eslint-disable-next-line no-console
+    console.log(`Using ${browserName} ${resolvedVersion} (browserVersion: ${configuredVersion})`);
+
+    // Strip file:// prefix and append timing to WDIO's PASSED/FAILED lines.
     const originalWrite = process.stdout.write.bind(process.stdout);
     global._originalStdoutWrite = originalWrite;
     // eslint-disable-next-line no-control-regex
@@ -346,12 +367,17 @@ export const config = {
     });
 
     /*
-     * Increase window size to avoid hidden buttons
+     * Force a large, deterministic window size so tall dialogs and content keep their action
+     * buttons inside the viewport. `maximizeWindow()` must not be used here: in headless Chrome it
+     * resizes to a tiny default (~800x600, since there is no physical screen), overriding the
+     * `--window-size=1920,1080` launch argument. That small viewport pushed dialog/footer buttons
+     * off-screen, so WebDriver clicked an out-of-viewport point and reported "element click
+     * intercepted". `setWindowSize` works in both headless and headed modes and keeps them consistent.
      */
     try {
-      await browser.maximizeWindow();
+      await browser.setWindowSize(1920, 1080);
     } catch (e) {
-      console.error('Failed to maximize.');
+      console.error('Failed to set window size.');
     }
 
     /**

--- a/packages/nuxeo-web-ui-ftest/wdio.conf.js
+++ b/packages/nuxeo-web-ui-ftest/wdio.conf.js
@@ -1,4 +1,6 @@
 import { fileURLToPath } from 'url';
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import chai from 'chai';
 
@@ -33,6 +35,8 @@ const reporters = ['spec'];
 const _workerStartTimes = new Map();
 const _featureResults = [];
 let _browserLogged = false;
+const _browserVersionFile = path.join(os.tmpdir(), 'wdio-browser-version.txt');
+let _browserVersion = '';
 
 if (process.env.CUCUMBER_REPORT_PATH) {
   reporters.push([
@@ -291,6 +295,7 @@ export const config = {
     // eslint-disable-next-line no-control-regex
     const ansiRegex = /\x1b\[[0-9;]*m/g;
     const statusLineRegex = /\[(\d+-\d+)\] (?:PASSED|FAILED) in .* - /;
+    const runningLineRegex = /\[\d+-\d+\] RUNNING in .* - /;
     process.stdout.write = (chunk, ...args) => {
       if (typeof chunk === 'string') {
         chunk = chunk.replace(/file:\/\//g, '');
@@ -302,6 +307,19 @@ export const config = {
           if (start) {
             const elapsed = ((Date.now() - start) / 1000).toFixed(1);
             chunk = chunk.replace(/\n$/, '') + ` \x1b[1m( ${elapsed}s )\x1b[0m\n`;
+          }
+        } else if (runningLineRegex.test(plain) && !/\(\s*chrome\b/.test(plain)) {
+          // Annotate the RUNNING line with the resolved browser version rather than logging it as a
+          // separate per-spec line. The version is written by the first worker's `before` hook.
+          if (!_browserVersion) {
+            try {
+              _browserVersion = fs.readFileSync(_browserVersionFile, 'utf8').trim();
+            } catch (e) {
+              // not written yet; retry on the next RUNNING line
+            }
+          }
+          if (_browserVersion) {
+            chunk = chunk.replace(/\n$/, '') + ` \x1b[1m( ${_browserVersion} )\x1b[0m\n`;
           }
         }
       }
@@ -358,13 +376,18 @@ export const config = {
       console.error('Failed to set window size:', e);
     }
 
-    // Report the browser this session actually resolved to, read from live capabilities so the log
-    // can never drift from the build that really runs (unlike a separate version lookup). Logged once
-    // per worker process rather than per spec to avoid repeating on every feature.
+    // Record the resolved browser once per worker so the main process can annotate the RUNNING lines,
+    // read from live capabilities so it can't drift from the build that actually runs.
     if (!_browserLogged) {
       _browserLogged = true;
-      // eslint-disable-next-line no-console
-      console.log(`Using ${browser.capabilities.browserName} ${browser.capabilities.browserVersion}`);
+      try {
+        fs.writeFileSync(
+          _browserVersionFile,
+          `${browser.capabilities.browserName} ${browser.capabilities.browserVersion}`,
+        );
+      } catch (e) {
+        // best-effort: the RUNNING line just won't show the resolved version
+      }
     }
 
     /**

--- a/packages/nuxeo-web-ui-ftest/wdio.conf.js
+++ b/packages/nuxeo-web-ui-ftest/wdio.conf.js
@@ -280,40 +280,9 @@ export const config = {
   // resolved to continue.
   //
   // Gets executed once before all workers get launched.
-  onPrepare: async () => {
+  onPrepare: () => {
     // eslint-disable-next-line no-console
     console.log(`Starting ftests in ${process.env.HEADLESS === 'true' ? 'HEADLESS' : 'HEADFUL'} mode`);
-
-    // Report the browser version once, up front, before any worker starts. Provisioning is
-    // delegated to WebdriverIO's driver manager; when a channel (e.g. 'stable') is configured,
-    // resolve the concrete Chrome-for-Testing build purely for this log line. Best-effort: the
-    // fetch is bounded by a short abortable timeout so a slow/unreachable host can never block the
-    // run, and it falls back to the configured channel name if the lookup fails or times out.
-    const browserName = process.env.BROWSER || 'chrome';
-    const configuredVersion = process.env.BROWSER_VERSION || 'stable';
-    let resolvedVersion = configuredVersion;
-    if (browserName === 'chrome' && !/^\d/.test(configuredVersion)) {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), 3000);
-      try {
-        const res = await fetch('https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json', {
-          signal: controller.signal,
-        });
-        if (res.ok) {
-          const { channels = {} } = await res.json();
-          const channel = channels[configuredVersion.charAt(0).toUpperCase() + configuredVersion.slice(1)];
-          if (channel && channel.version) {
-            resolvedVersion = channel.version;
-          }
-        }
-      } catch (e) {
-        // best-effort: fall back to the configured channel name (also covers the abort timeout)
-      } finally {
-        clearTimeout(timer);
-      }
-    }
-    // eslint-disable-next-line no-console
-    console.log(`Using ${browserName} ${resolvedVersion} (browserVersion: ${configuredVersion})`);
 
     // Strip file:// prefix and append timing to WDIO's PASSED/FAILED lines.
     const originalWrite = process.stdout.write.bind(process.stdout);
@@ -384,8 +353,14 @@ export const config = {
     try {
       await browser.setWindowSize(1920, 1080);
     } catch (e) {
-      console.error('Failed to set window size.');
+      // The deterministic viewport is the whole fix for "element click intercepted"; log the cause.
+      console.error('Failed to set window size:', e);
     }
+
+    // Report the browser this session actually resolved to, read from live capabilities so the log
+    // can never drift from the build that really runs (unlike a separate version lookup).
+    // eslint-disable-next-line no-console
+    console.log(`Using ${browser.capabilities.browserName} ${browser.capabilities.browserVersion}`);
 
     /**
      * Setup the Chai assertion framework

--- a/packages/nuxeo-web-ui-ftest/wdio.conf.js
+++ b/packages/nuxeo-web-ui-ftest/wdio.conf.js
@@ -32,6 +32,7 @@ const reporters = ['spec'];
 
 const _workerStartTimes = new Map();
 const _featureResults = [];
+let _browserLogged = false;
 
 if (process.env.CUCUMBER_REPORT_PATH) {
   reporters.push([
@@ -358,9 +359,13 @@ export const config = {
     }
 
     // Report the browser this session actually resolved to, read from live capabilities so the log
-    // can never drift from the build that really runs (unlike a separate version lookup).
-    // eslint-disable-next-line no-console
-    console.log(`Using ${browser.capabilities.browserName} ${browser.capabilities.browserVersion}`);
+    // can never drift from the build that really runs (unlike a separate version lookup). Logged once
+    // per worker process rather than per spec to avoid repeating on every feature.
+    if (!_browserLogged) {
+      _browserLogged = true;
+      // eslint-disable-next-line no-console
+      console.log(`Using ${browser.capabilities.browserName} ${browser.capabilities.browserVersion}`);
+    }
 
     /**
      * Setup the Chai assertion framework


### PR DESCRIPTION
## Motivation

Port of #3315 (maintenance-3.1.x / LTS-2023) to `lts-2025`.

The ftest suite pinned an outdated Chrome build and used a hand-rolled browser/driver provisioning path (manual version detection + Chrome-for-Testing fetches), adding startup latency and drifting from the browser users run. Moving to WebdriverIO-managed **`stable`** (Chrome 150/151) is the right direction but exposed latent test-framework races that older Chrome masked — notably ~100% `search.feature` failures and noisy `element click intercepted` logs. This PR does the provisioning simplification and all the compatibility / stability fixes needed to run reliably on Chrome stable.

## Changes (test-side only)

**Provisioning**
- Delegate browser + driver provisioning to WebdriverIO's driver manager via `browserVersion: 'stable'` (override with `BROWSER_VERSION`); remove the manual Chrome/ChromeDriver version resolution and the `chrome-launcher` dependency.

**Chrome 150/151 compatibility**
- Fix the real cause of `element click intercepted` logs: set a fixed 1920×1080 window instead of `maximizeWindow()` (which shrinks the headless viewport and pushes buttons off-screen).
- Read off-screen shadow-DOM text via `textContent` instead of `getText()` (empty below the fold on newer Chrome) for browser rows and saved-search dropdown items.
- Simplify vocabulary `deleteEntry` to stop the spurious `no such alert` log.

**`search.feature` stabilization**
- Wait for Elasticsearch indexing after sharing a saved search (kills the wrong "16 result(s)" count from an ACL-index race).
- Wait for async suggestions before selecting them.
- Count the results **label** instead of virtualized DOM rows (iron-list only keeps a small window of rows).
- Re-navigate to a saved search until its results render, tolerating a pre-existing form↔results wiring race surfaced by Chrome stable / CI load.
- Delete tracked documents sequentially (children before parents) to avoid a 409 cascade that leaked docs and inflated later search counts.

## Validation

The equivalent change on maintenance-3.1.x was validated with **8/8 consecutive `search.feature` runs passing on a fresh Chrome-151 container, zero retries**. The source files here are identical to that branch. _Recommend a `search.feature` run against an LTS-2025 server before merge._

## Notes

- No product/app code changed.
- The saved-search wiring race is pre-existing (partly in `@nuxeo/nuxeo-elements`), mitigated test-side here; a proper cross-repo fix should be tracked separately.
- Do **not** re-pin a specific Chrome build; keep `browserVersion: 'stable'`.

Related: #3315
