### PR TITLE
chore: share team Cursor agent skills + onboarding guide

### DIFF
--- a/.cursor/skills/README.md
+++ b/.cursor/skills/README.md
@@ -1,0 +1,139 @@
+# Nuxeo Web UI — Cursor Agent Skills
+
+Shared [Cursor Agent Skills](https://docs.cursor.com) for the Web UI team. They are **project
+skills**: because they live in `.cursor/skills/`, anyone who clones this repo and opens it in Cursor
+gets them automatically — no install step. Just describe your task in chat and the matching skill
+activates.
+
+> **First time using these?** Do the one-time [Setup](#one-time-setup) below (Atlassian MCP,
+> Jira token, GitHub CLI, signed commits). If you skip it, the Jira/PR steps will fail with auth
+> errors. When you start a bug-fix, the agent will also check these prerequisites and walk you
+> through anything missing.
+
+## Skills catalog
+
+| Skill | Use it when you… | Notes |
+|---|---|---|
+| [`fix-nuxeo-web-ui-bug`](fix-nuxeo-web-ui-bug/SKILL.md) | say "fix WEBUI-\<id>", paste a Jira URL, "commit and raise PR", "take this to Ready for QA" | **Orchestrator** — runs the full flow end-to-end. Delegates to the two PR skills below. |
+| [`nuxeo-web-ui-pr`](nuxeo-web-ui-pr/SKILL.md) | open a PR, push a branch, backport to both bases | Branch naming, commit format, PR body, `lts-2025` + `maintenance-3.1.x` backport. |
+| [`nuxeo-web-ui-pr-checks`](nuxeo-web-ui-pr-checks/SKILL.md) | run the gating checks before pushing | Mirrors CI lint + unit tests. Script: `nuxeo-web-ui-pr-checks/scripts/pr-checks.sh`. |
+| [`jira/create-qa-subtask`](jira/create-qa-subtask/SKILL.md) | "create a QA task", "plan QA for this ticket" | Files a `QA task` sub-task with what/how to verify. |
+| [`jira/raise-backend-jira-ticket`](jira/raise-backend-jira-ticket/SKILL.md) | a fix needs a server-side change; "raise a backend/NXP ticket" | Files an NXP (`nxplatform`) ticket and links it as a blocker. |
+
+**Dependencies:** `fix-nuxeo-web-ui-bug` → `nuxeo-web-ui-pr` + `nuxeo-web-ui-pr-checks`. The Jira
+skills are independent and can be used on their own.
+
+## One-time setup
+
+Prerequisites: [Cursor](https://cursor.com), Node ≥ 18 (repo uses `nvm`), the
+[GitHub CLI](https://cli.github.com) (`gh`), and `git`. Do the following once per machine.
+
+### 1. Atlassian (Jira/Confluence) MCP server — needed for every Jira-touching skill
+
+The skills read/write Jira and Confluence through the **Atlassian MCP server**. Add and authenticate
+it in Cursor:
+
+1. Open **Cursor → Settings → Tools & MCP → Add** and add the Atlassian server (from Cursor's MCP
+   directory), or add it manually to `~/.cursor/mcp.json`:
+   ```json
+   {
+     "mcpServers": {
+       "atlassian": { "url": "https://mcp.atlassian.com/v1/sse" }
+     }
+   }
+   ```
+2. Reload Cursor. The first call opens a browser **OAuth** flow — sign in with your **Hyland
+   Atlassian** account and grant access. (Inside the agent this is the `mcp_auth` step; if a call
+   ever returns `needsAuth` / 403, re-run it.)
+3. Verify: the agent can call `atlassianUserInfo` and `getAccessibleAtlassianResources`. Our site is
+   `hyland.atlassian.net`, cloudId `252cce86-035e-4b0e-abd2-3c002935632f`.
+
+> You need Jira access to the **WEBUI** and **NXP** projects (via org SSO). Ask your lead if a call
+> returns "no accessible resources".
+
+### 2. Jira API token — needed to upload evidence (screenshots/videos) & some comment ops
+
+The Atlassian MCP has **no attachment-upload tool**, so binary uploads go through the Jira REST API,
+which needs an API token. Store your credentials in two local files (kept out of git, **never
+commit**):
+
+```bash
+printf '%s' 'you@hyland.com' > ~/.jira_email
+printf '%s' '<api-token>'    > ~/.jira_token && chmod 600 ~/.jira_token
+```
+
+Create the token at <https://id.atlassian.com/manage-profile/security/api-tokens>. Rotate it there if
+it ever leaks. The skills auto-detect these files; if they're absent, the agent will ask you to
+create them rather than have you paste a token into chat.
+
+### 3. GitHub CLI — needed to open PRs and watch CI
+
+```bash
+gh auth login     # GitHub.com; pick HTTPS or SSH; authenticate in the browser
+gh auth status    # verify you're logged in
+```
+
+You need push access to `nuxeo/nuxeo-web-ui` (branches are pushed to **origin**, never a fork — CI
+checks out by branch name from the upstream repo).
+
+### 4. Signed commits (SSH) — the repo requires signed commits
+
+```bash
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub   # your SSH public key
+git config --global commit.gpgsign true
+```
+
+Then add that **same** SSH key to GitHub as a **Signing key** (GitHub → Settings → SSH and GPG keys →
+New SSH key → Key type: *Signing Key*). Verify a commit shows `signed:G` via
+`git log --format='%G? %s' -1`. (Internal signed-commits guide: Confluence page `4125330218`.)
+
+### 5. Local dev/test prerequisites (for the bug-fix gating checks)
+
+```bash
+nvm use 22        # or any Node ≥ 18
+npm ci
+```
+
+If unit tests fail to import `@nuxeo/...` after an install, the `nuxeo-elements` symlinks were
+replaced — re-link them (see the [`nuxeo-web-ui-pr`](nuxeo-web-ui-pr/SKILL.md) skill, "Before opening
+a PR").
+
+## How to use (examples)
+
+Type these in Cursor chat — the right skill activates automatically:
+
+- **Fix a bug end-to-end:** "Fix WEBUI-2138" or paste `https://hyland.atlassian.net/browse/WEBUI-2138`
+  → reproduce (with before/after evidence) → fix → gating checks → signed-commit PRs on both bases →
+  watch CI → Ready-for-QA check.
+- **Just the PR:** "Open a PR for these changes and backport to both bases."
+- **Just local checks:** "Run the PR gating checks" — or directly:
+  ```bash
+  bash .cursor/skills/nuxeo-web-ui-pr-checks/scripts/pr-checks.sh --fix
+  ```
+- **QA task:** "Create a QA task for WEBUI-1234."
+- **Backend ticket:** "This needs a server change — raise a backend NXP ticket and link it."
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| MCP call returns `needsAuth` / 403 | Re-run the Atlassian OAuth (agent: `mcp_auth`); confirm SSO access to the WEBUI/NXP projects. |
+| Attachment upload 401/403 | Check `~/.jira_email` / `~/.jira_token`; regenerate the token if expired. |
+| `gh` command fails | `gh auth status`; re-run `gh auth login`. |
+| Commit shows unsigned (`N`/`E`) | Re-check §4; the SSH key must be added to GitHub as a **Signing** key. |
+| Tests can't import `@nuxeo/*` | Re-link `nuxeo-elements` symlinks (see the PR skill). |
+
+## Using these skills in other repos (optional)
+
+Project skills only load for *this* repo. To use them everywhere on your machine, symlink them into
+your personal skills folder:
+
+```bash
+mkdir -p ~/.cursor/skills
+ln -s "$PWD/.cursor/skills/fix-nuxeo-web-ui-bug"   ~/.cursor/skills/fix-nuxeo-web-ui-bug
+ln -s "$PWD/.cursor/skills/nuxeo-web-ui-pr"        ~/.cursor/skills/nuxeo-web-ui-pr
+ln -s "$PWD/.cursor/skills/nuxeo-web-ui-pr-checks" ~/.cursor/skills/nuxeo-web-ui-pr-checks
+```
+
+`git pull` on this repo then updates them everywhere (symlinks, so no re-copy needed).

--- a/.cursor/skills/fix-nuxeo-web-ui-bug/SKILL.md
+++ b/.cursor/skills/fix-nuxeo-web-ui-bug/SKILL.md
@@ -1,0 +1,410 @@
+---
+name: fix-nuxeo-web-ui-bug
+description: >-
+  End-to-end agentic playbook for fixing a Jira bug (WEBUI-<id>, or an
+  ELEMENTS-<id>/other ticket whose fix lands in nuxeo-web-ui) in the
+  nuxeo-web-ui repo: runs fully autonomously end-to-end (YOLO mode, no
+  confirmation gates), analyse the ticket + all comments, reproduce
+  and capture evidence (images AND videos) to ~/Desktop/<TICKET-ID>/ first, then branch from both
+  lts-2025 and maintenance-3.1.x, fix without inducing regressions, run the PR gating
+  checks, create signed-commit PRs on both bases, watch CI and fix/rerun
+  failures, then evaluate the Ready-for-QA checklist. Use when asked to fix a
+  WEBUI-/Jira bug, "commit and raise PR", or take a nuxeo-web-ui ticket to
+  Ready for QA.
+---
+
+# Fix a Nuxeo Web UI bug — agentic, end-to-end
+
+Drive the whole fix in **YOLO mode: run the entire workflow end-to-end without pausing for
+confirmation between phases** — reproduce → fix → validate → commit → push → open PRs → update the
+ticket → summarize. State the plan up front for the record, then keep going. The only hard stops are
+the safety **Guardrails** at the bottom (never force-push protected branches, never silently change
+global git config); YOLO relaxes the *confirmation* gates, not those. Use a TODO list to track
+phases. Delegate PR mechanics to the [`nuxeo-web-ui-pr`](../nuxeo-web-ui-pr/SKILL.md) skill and local
+gating to the [`nuxeo-web-ui-pr-checks`](../nuxeo-web-ui-pr-checks/SKILL.md) skill.
+
+> **Evidence is always captured in BOTH forms — screenshots (images) AND screen recordings (videos),
+> before and after.** Never ask which format; always produce both.
+
+> **Core rule — every fix ships on BOTH bases.** For *every* fix, always create a new branch
+> from **`lts-2025`** *and* a new branch from **`maintenance-3.1.x`** (the maintenance base),
+> each named with the ticket id (`<type>-WEBUI-<id>-<kebab-summary>-<base>`), and **raise a PR
+> for each**. Two branches, two PRs — never fix on only one base. (If the ticket's `fixVersions`
+> genuinely exclude a base, state that explicitly in your summary and skip it — no need to ask.)
+
+Useful constants:
+- Atlassian cloudId: `252cce86-035e-4b0e-abd2-3c002935632f` (site `hyland.atlassian.net`)
+- Ready-for-QA checklist page: `4169400498` · Signed-commits guide: `4125330218`
+- Upstream repo: `nuxeo/nuxeo-web-ui` · bases: `lts-2025` and `maintenance-3.1.x`
+
+## Setup check — first-time users
+Before the first run on a new machine, verify the environment is set up. If anything is missing,
+**pause and walk the user through it** (point them at [`.cursor/skills/README.md`](../README.md),
+"One-time setup") — do not silently continue past a missing prerequisite:
+- **Atlassian MCP** authenticated (a quick `atlassianUserInfo` call succeeds). If it returns
+  `needsAuth`/403, run `mcp_auth` for the Atlassian namespace and have the user complete the OAuth
+  login; confirm they have access to the **WEBUI** and **NXP** projects.
+- **Jira token** for attachments: `~/.jira_email` and `~/.jira_token` exist (see README §2). If
+  absent, have the user create them — never accept a token pasted into chat.
+- **GitHub CLI**: `gh auth status` is logged in with push access to `nuxeo/nuxeo-web-ui`.
+- **Signed commits**: `git config commit.gpgsign` is `true` with an SSH signing key registered on
+  GitHub (README §4). The repo requires signed commits.
+- **Local build**: Node ≥ 18 (`nvm use 22`) and `npm ci` done.
+
+Once verified (or on subsequent runs), proceed.
+
+## Phase 0 — Plan (non-blocking)
+Restate the goal and list the phases below as concrete steps (a TODO list). **Show the plan, then
+immediately proceed — do not wait for approval.** Re-plan on the fly if scope changes.
+
+## Phase 1 — Understand the ticket
+- `getJiraIssue` (cloudId above, `issueIdOrKey=WEBUI-<id>`, `fields:["*all"]` incl. `comment`).
+  If Atlassian tools aren't listed, call `mcp_auth` for the Atlassian server first.
+- Read the description **and every comment** (repro steps, expected vs actual, affected
+  versions). Note `fixVersions` — they map to the base branches you must target.
+
+## Phase 2 — Reproduce + capture evidence (first hands-on step)
+**Reproduce the bug on the `lts-2025` branch before creating any feature branch or touching code.**
+Confirming the bug exists — and capturing the "before" evidence — is the first thing you do after
+understanding the ticket. Check out the base first so the repro reflects released code:
+```bash
+git fetch origin lts-2025
+git switch -c lts-2025 origin/lts-2025 2>/dev/null || git switch lts-2025 && git pull --ff-only
+```
+> **Reproduce autonomously (no confirmation).** Default to a **throwaway Docker container** (recipe
+> below) — never touch a live/running container. Only fall back to another approach if Docker is
+> unavailable.
+>
+> **Always capture BOTH images and videos** — before *and* after. Screenshots for the ticket/summary,
+> screen recordings for QA. Capture both every time; never ask which format.
+
+Create the evidence folder up front and put **before/after** screenshots, **videos**, and logs there:
+```bash
+mkdir -p ~/Desktop/<TICKET-ID>   # e.g. WEBUI-1234 or ELEMENTS-1856
+```
+- Reproduce against a real instance. If the bug needs a special setup (e.g. multi-repository),
+  stand up a throwaway Docker instance rather than touching any live container; remove it with
+  `docker rm -f <name>` (or `docker compose down -v`) when done.
+- To A/B the fix on the real `/nuxeo/ui` URL, build the branch (`npm run build`) and hot-swap
+  `main.bundle.js` into the running instance's `nxserver/nuxeo.war/ui`, keeping `.unpatched` /
+  `.patched` copies to toggle. Note any build/version-skew artifacts (e.g. `ts/ui` layout 404s)
+  as environment-only, not regressions.
+- Capture the **before** evidence (bug visible) before fixing.
+
+### Standing up a throwaway instance (single-container recipe — preferred)
+The repo `docker-compose.yml` is stale (proxy upstreams `nuxeo_1`/`webui` don't match modern
+compose service DNS), so prefer a single container that serves Web UI directly at `/nuxeo/ui/`:
+```bash
+# If Docker Desktop is off: `open -a Docker` and wait until `docker info` succeeds.
+# Reuse a CLID + image from an existing Nuxeo container if you have one (package download needs
+# Nuxeo Connect registration — without a CLID it fails with "Registration required"):
+CLID=$(docker inspect <existing-nuxeo> --format '{{range .Config.Env}}{{println .}}{{end}}' \
+       | sed -n 's/^NUXEO_CLID=//p')
+# Pick a FREE host port (8080 is often taken by a live container — never disturb it):
+docker run -d --name nx-<ticket> -p 8090:8080 \
+  -e NUXEO_DEV_MODE=true -e NUXEO_PACKAGES="nuxeo-web-ui nuxeo-drive" -e NUXEO_CLID="$CLID" \
+  docker-private.packages.nuxeo.com/nuxeo/nuxeo:2025
+# Wait for readiness, then verify:
+docker logs -f nx-<ticket>                 # until "Nuxeo Platform Started"
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8090/nuxeo/runningstatus   # 200
+```
+Seed test data over REST + Automation (admin is `Administrator:Administrator`; **use explicit
+`curl` flags, not shell vars — quoting `-u`/`-H` into a var breaks auth and yields 401**):
+```bash
+# create a folder/workspace
+curl -s -u Administrator:Administrator -H "Content-Type: application/json" -X POST \
+  http://localhost:8090/nuxeo/api/v1/path/default-domain/workspaces \
+  -d '{"entity-type":"document","name":"sync-root-a","type":"Workspace","properties":{"dc:title":"Marketing Assets"}}'
+# register it as a Drive sync root
+curl -s -u Administrator:Administrator -H "Content-Type: application/json" -X POST \
+  http://localhost:8090/nuxeo/site/automation/NuxeoDrive.SetSynchronization \
+  -d '{"params":{"enable":true},"input":"doc:/default-domain/workspaces/sync-root-a"}'
+```
+
+### Skew-free A/B by deploying your own build for BOTH states
+`npm run build` is fast (~15s), so build twice and deploy each into the container's UI dir. Both
+captures then use the *same* dev build, differing only by your fix (eliminates marketplace skew):
+```bash
+UI=$(docker exec nx-<ticket> sh -lc 'find /opt/nuxeo/server -type d -name ui -path "*nuxeo.war*"' | head -1)
+npm run build && cp -R dist /tmp/dist-patched                 # current tree (with fix)
+git stash && npm run build && cp -R dist /tmp/dist-unpatched && git stash pop   # baseline
+docker cp /tmp/dist-unpatched/. nx-<ticket>:"$UI/"            # deploy BEFORE, capture
+docker cp /tmp/dist-patched/.   nx-<ticket>:"$UI/"            # deploy AFTER,  capture
+```
+Confirm the deployed bundle actually changed (addon elements land in a hashed
+`dist/<addon>.<hash>.bundle.js`): `rg -c "<the-markup-you-added>" /tmp/dist-*/…bundle.js`.
+
+**Two deploy gotchas that silently break the deployed app (both cost real time):**
+- **`base-url` / broken links.** The dev build's `dist/index.html` hardcodes `<nuxeo-app base-url="/">`
+  and `docker cp` drops it next to the server's `index.jsp` (which computes `base-url="<context>/ui/"`).
+  Tomcat then serves *your* `index.html`, so `Nuxeo.UI.app.baseUrl` becomes `/` and `urlFor` yields
+  root-relative `/#!/browse/...` for **every** link — clicking navigates outside `/nuxeo/ui/` and 404s
+  (page.js runs `click:false`, so a wrong href is just a broken full navigation). Fix before capturing:
+  edit the deployed `index.html` to `base-url="/nuxeo/ui/"` (or delete it so `index.jsp` is served —
+  but then you lose your patched bundles). Verify: `Nuxeo.UI.app.baseUrl` and a sample
+  `document.querySelector('nuxeo-app').urlFor({...,path,uid})` should both include `/nuxeo/ui/`.
+- **Addon provider errors (e.g. `Invalid provider: box`).** Building with the default
+  `NUXEO_PACKAGES` (…`nuxeo-liveconnect`…) loads cloud providers (`box`, `googledrive`) the target
+  server may not have configured, and the page 404s with `Invalid provider: …`. Build scoped to just
+  the addon under test — `NUXEO_PACKAGES="nuxeo-drive" npm run build` — so `index.html`'s
+  `Nuxeo.UI.bundles` list drops the unrelated addons.
+- After any redeploy, the browser caches `index.html`/bundles — **hard-refresh (Cmd+Shift+R)** or the
+  Puppeteer runs (which set `setCacheEnabled(false)`) to see changes.
+
+### Video capture (required — before AND after)
+QA and the Ready-for-QA checklist expect a short screen recording of the bug and the fix, not just
+stills. Record both `~/Desktop/WEBUI-<id>/WEBUI-<id>-before.mp4` and `-after.mp4`.
+
+Drive a headless Chrome with Puppeteer and record with `puppeteer-screen-recorder` (it bundles its
+own ffmpeg, so no system ffmpeg is needed). Do it in a throwaway repro dir, not the repo:
+```bash
+mkdir -p ~/Desktop/WEBUI-<id>/repro && cd ~/Desktop/WEBUI-<id>/repro
+[ -f package.json ] || echo '{"name":"repro","private":true}' > package.json
+npm install puppeteer puppeteer-screen-recorder
+```
+Recorder skeleton (reuse for before/after; the only difference is which bundle is deployed and the
+user actions performed):
+```js
+const puppeteer = require('puppeteer');
+const { PuppeteerScreenRecorder } = require('puppeteer-screen-recorder');
+const browser = await puppeteer.launch({ headless: 'new',
+  executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  args: ['--no-sandbox', '--window-size=1280,800'] });
+const page = await browser.newPage();
+// Web UI gates bootstrap on `automation-ready` when navigator.webdriver is true (headless):
+await page.evaluateOnNewDocument(() => { window.automationReady = true; });
+await page.setViewport({ width: 1280, height: 800 });
+await page.setCacheEnabled(false);
+const rec = new PuppeteerScreenRecorder(page, { fps: 25, videoFrame: { width: 1280, height: 800 } });
+await rec.start('/Users/<you>/Desktop/WEBUI-<id>/WEBUI-<id>-after.mp4');
+/* ...navigate + interact (type creds with { delay: 90 }, add short sleeps so the flow is followable)... */
+await rec.stop(); await browser.close();
+```
+Tips: bootstrap the app once (`/nuxeo/ui/`, ~4s) before driving the scenario; add ~2.5s pauses on the
+key states (error page, login page, final document) so the video is readable; keep clips ~10–20s.
+
+Concrete gotchas that cost time (learned the hard way):
+- **Login form:** Nuxeo `login.jsp` fields are `#username` / `#password` (names `user_name` /
+  `user_password`), submit is `.login_button` / `input[type=submit]` — not `input[name=username]`.
+- **Deep shadow DOM:** Web UI content is nested in many shadow roots. Walk them recursively to find
+  an element (e.g. `nuxeo-drive-sync-roots-management`) and to probe its rendered state
+  (`isLink`/`href`) — a flat `document.querySelector` won't find it.
+- **Verify with a DOM probe, not just pixels.** A new link that inherits the theme link colour looks
+  almost identical to plain text in a static shot (before/after PNGs can be byte-identical). Prove the
+  change by (a) logging the probe (`isLink:true`, `href=…`) and (b) `page.mouse.move` to **hover** the
+  link so the underline shows in a screenshot.
+- **In-app navigation from a dev build:** `urlFor` yields a root-relative `/#!/browse/...`; a raw
+  `a.click()` resolves that against the origin (→ wrong page). To show the target opens, `page.goto`
+  the correct base: `${BASE}/ui/#!${href.replace(/^\/#!/, '')}`. The base difference is a
+  dev-build/marketplace artifact, not a regression.
+
+If the repro instance's web-ui version differs from your source branch (marketplace `main.bundle.js`
+is built and lazy-loads assets differently than `npm run build`), the safest way to get a faithful
+**after** video is: deploy your dev `dist/` and, if lazy `elements/*.html` requests 404, mirror the
+instance's root html tree into `ui/elements/` so they resolve. Patching the marketplace bundle's
+minified code is unreliable (the error-handling code path and property names drift between versions).
+
+## Phase 3 — Branches (both bases)
+**Only after the bug is reproduced on `lts-2025`**, create one feature branch per base — cut from the
+bases, not from your local repro state — named per the `nuxeo-web-ui-pr` skill
+(`<type>-WEBUI-<id>-<kebab-summary>-<base>`):
+```bash
+git fetch origin lts-2025 maintenance-3.1.x
+git switch -c <type>-WEBUI-<id>-<summary>-lts-2025 origin/lts-2025
+git switch -c <type>-WEBUI-<id>-<summary>-maintenance-3.1.x origin/maintenance-3.1.x
+```
+Implement on `lts-2025` first, then cherry-pick to `maintenance-3.1.x` (see the PR skill's backport section).
+
+## Phase 4 — Fix (no new induced issues)
+> **Fix autonomously (no confirmation).** Once the issue is reproduced and the "before" evidence is
+> captured, proceed straight to the fix. Still **print the identified root cause first** (see below)
+> so it lands in the record before any change.
+
+- Identify the real root cause (often in `node_modules/@nuxeo/...` i.e. the sibling
+  `nuxeo-elements` repo) before editing. **Print the root cause to the user** — a clear,
+  explicit statement of what is actually causing the bug (file/function/line and why) — before
+  making any change. Then make the **minimal** change in `nuxeo-web-ui`.
+- Keep the diff focused — do not bundle unrelated files. Capture the **after** evidence, including
+  the **after video** (Phase 2 recipe) showing the fixed behavior end-to-end.
+- **Extract self-contained/cross-cutting client logic into a Polymer behavior**, don't inline it
+  into already-large elements (`nuxeo-app.js` is 900+ lines). If a feature has its own state,
+  constants, lifecycle wiring (arm on `ready`/`attached`, tear down on `detached`) and listeners
+  with no coupling to the host's core responsibilities, put it in `elements/behaviors/nuxeo-<name>-behavior.js`
+  exporting `Nuxeo<Name>Behavior` (`@polymerBehavior Nuxeo.<Name>Behavior`) and compose it via the
+  `behaviors` array — mirroring `NuxeoAppDrawerResizeBehavior` and the `AGENTS.md` convention. This is
+  a common reviewer ask; doing it up front avoids a review round-trip. Keep on the host only what the
+  template/host truly needs (e.g. a method bound in the template, or a `<nuxeo-resource>` the behavior
+  references via `this.$`); behavior methods are mixed into the host, so template bindings and host
+  lifecycle calls to them still resolve. Verify the composition with the full unit-test suite.
+
+## Phase 5 — Validate locally (gate before any push)
+Run the same checks the PR CI gates on:
+```bash
+bash .cursor/skills/nuxeo-web-ui-pr-checks/scripts/pr-checks.sh --fix
+```
+Only proceed when it exits `0`. Revert incidental `package-lock.json` churn.
+
+> **No manual-verification pause.** In YOLO mode do not stop to ask for manual verification — the
+> automated before/after capture (Phase 2) already proves the fix. Instead, write the exact numbered
+> **"Steps to verify the fix"** and fold them into the final summary (Phase 9) and the Jira comment,
+> so a human can re-verify later.
+
+## Phase 6 — Commit (signed) + raise PRs
+This is the "commit and raise PR" trigger.
+> **Commit + push + open PRs autonomously (no confirmation).** Proceed without asking. (The safety
+> Guardrails still apply: only feature branches; never force-push protected branches.)
+- **Signed commits are required.** Verify signing is configured; if not, set up SSH signing
+  per page `4125330218` (`gpg.format=ssh`, `user.signingkey=<key>.pub`, `commit.gpgsign=true`).
+  Confirm a commit is signed: `git log -1 --format='%G?'` → `G`.
+- Commit `WEBUI-<id>: <summary>` with a why-focused body (heredoc).
+- Open one PR per base via the `nuxeo-web-ui-pr` skill. **Always push the branch to `origin`
+  (`nuxeo/nuxeo-web-ui`) and open a same-repo PR — never a fork.** CI checks out the branch by name
+  from the upstream repo, so fork branches aren't found and fork PRs fail at checkout (red
+  lint/unit-test/a11y). Use the Problem/Root cause/Changes/Test plan/Notes body template.
+- After pushing, confirm GitHub shows commits as **Verified**:
+  `gh api repos/nuxeo/nuxeo-web-ui/commits/<sha> --jq '.commit.verification'` → `verified:true`.
+  `unknown_key` means the signing key isn't added on GitHub as a **Signing Key** (separate
+  from an Authentication key) — fix that, no re-push needed.
+
+## Phase 7 — Watch checks; fix or rerun
+```bash
+gh pr view <pr> --repo nuxeo/nuxeo-web-ui --json statusCheckRollup \
+  --jq '[.statusCheckRollup[]|{name:(.name//.context),conclusion:(.conclusion//.state)}]'
+```
+- Real failure → read the failing job log (`gh api repos/nuxeo/nuxeo-web-ui/actions/jobs/<jobId>/logs`),
+  fix on the branch, re-run the gate, push.
+- Known flake (e.g. `nuxeo-document-tree` "Tree should collapse…") that passes locally →
+  re-run, don't "fix": `gh run rerun <run-id> --failed`.
+- Telemetry noise (`catchpoint/workflow-telemetry-action` 403s, Node-20 deprecation) is not a failure.
+- **Apply every post-PR change to both PRs.** Any fix after the PRs exist — review feedback
+  (Copilot/Sonar/reviewers), CI fixes, follow-ups — must land on **every** base branch, not just one.
+  Commit once (signed), cherry-pick the same commit onto each other base, re-run the gate, push, and
+  confirm CI reruns on both PRs. See the `nuxeo-web-ui-pr` skill ("Keep both PRs in sync").
+- Sonar surfaces new issues even when the Quality Gate passes — fetch them per PR from SonarCloud
+  (`GET https://sonarcloud.io/api/issues/search?componentKeys=nuxeo_nuxeo-web-ui&pullRequest=<pr>&resolved=false`)
+  and Copilot inline comments via `gh api repos/nuxeo/nuxeo-web-ui/pulls/<pr>/comments`; fix both.
+- **Close the loop on every review thread — reply *and* resolve.** After the fix for a comment is
+  pushed to **all** bases, on **each** PR: (1) reply to the thread citing the commit
+  (`gh api repos/<owner>/<repo>/pulls/<pr>/comments -f body='…' -F in_reply_to=<commentId>`), then
+  (2) mark it resolved. A reply alone does **not** resolve the thread — resolving needs the GraphQL
+  `resolveReviewThread` mutation. Do this autonomously (no confirmation); only leave a thread open if
+  you disagree with the comment, in which case reply explaining why instead of resolving.
+  ```bash
+  # list unresolved threads (thread id + first comment) for a PR
+  gh api graphql -f query='{repository(owner:"<owner>",name:"<repo>"){pullRequest(number:<pr>){
+    reviewThreads(first:50){nodes{id isResolved comments(first:1){nodes{author{login} body}}}}}}}' \
+    --jq '.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)
+      |{id,first:.comments.nodes[0].author.login,snippet:(.comments.nodes[0].body[0:80])}'
+  # resolve one thread
+  gh api graphql -f query='mutation{resolveReviewThread(input:{threadId:"<threadId>"}){thread{isResolved}}}'
+  ```
+  Note: `<owner>/<repo>` is `nuxeo/nuxeo-elements` when the fix lands there (e.g. `WEBUI`/`ELEMENTS`
+  fixes in shared UI components), otherwise `nuxeo/nuxeo-web-ui`.
+
+## Phase 7.5 — Update the ticket with the fix
+> **Update the ticket autonomously (no confirmation).** Post the fix-summary comment as soon as the
+> PRs are open and CI status is known. No need to ask first.
+
+Post the **structured fix-summary comment** (the Phase 9 sections) on the Jira issue via
+`addCommentToJiraIssue` (cloudId above, `contentFormat:"markdown"`). Include: issue, root cause, the
+files changed, **both PR links** (one per base), verification (lint/test counts), reproduce +
+verify steps, and the names of the before/after recordings. Keep the wording honest — only say a
+file is "attached" once it actually is.
+
+> **Write real Markdown, not Jira wiki markup.** With `contentFormat:"markdown"` the body must be
+> GitHub-flavoured Markdown — `###` headings, `**bold**`, `-`/`1.` lists, and triple-backtick fenced
+> code blocks. Do **NOT** use Jira wiki syntax (`h3.`, `{code}…{code}`, `*bold*`, `# ordered`): it
+> renders **literally** as text (you'll see a stray `h3.` in the comment). If you need to fix a
+> comment you already posted, re-send `addCommentToJiraIssue` with the same `commentId` to update it
+> in place rather than adding a duplicate.
+
+**Attaching evidence (images/videos/CSVs) — MCP can't do it.** The Atlassian MCP has *no* attachment
+tool (only comment/edit/search), so binary uploads must go through the Jira REST attachments endpoint.
+Do **not** claim a file is attached when it isn't.
+
+Stored credentials (created for this account, outside the repo — never commit these):
+- `~/.jira_email` — Atlassian account email
+- `~/.jira_token` — Jira API token (`chmod 600`; rotate at
+  https://id.atlassian.com/manage-profile/security/api-tokens if leaked)
+
+If `~/.jira_token` exists, upload attachments directly — no need to ask the user for a token. First
+verify auth (`GET /rest/api/3/myself`), then upload:
+```bash
+cd ~/Desktop/<TICKET-ID>
+U="$(cat ~/.jira_email):$(cat ~/.jira_token)"
+for f in <TICKET-ID>-before.png <TICKET-ID>-before.mp4 <TICKET-ID>-after.png <TICKET-ID>-after.mp4; do
+  curl -s -u "$U" -H "X-Atlassian-Token: no-check" -F "file=@$f" \
+    https://hyland.atlassian.net/rest/api/3/issue/<TICKET-ID>/attachments \
+    | python3 -c "import sys,json;d=json.load(sys.stdin);print('OK', d[0]['filename']) if isinstance(d,list) and d else print('FAIL', d)"
+done
+```
+If `~/.jira_token` is absent, have the user create it (`printf '%s' '<token>' > ~/.jira_token &&
+chmod 600 ~/.jira_token`) rather than pasting the token into chat. Drag-and-drop in the browser is the
+manual fallback.
+
+## Phase 8 — Ready for QA checklist
+Evaluate page `4169400498` against both PRs and produce a Markdown table (Question | Link |
+Y/N/NA | Comments). Check, per PR: review comments resolved; before/after evidence attached (screenshots **and the
+before/after videos** from Phase 2); both PRs linked on the ticket; no open Copilot threads (GraphQL
+`reviewThreads.isResolved`); all checks green; ≥2 approvals incl. lead; all commits Verified. Post
+the table as a JIRA comment (`addCommentToJiraIssue`) — no need to ask. Flag what stays manual:
+uploading the before/after videos to the ticket (MCP can't attach — see Phase 7.5), dev-panel PR
+links, and approvals.
+
+## Phase 9 — Final fix summary (always output)
+End every run with a single, structured summary — print it in chat **and** post it as the Jira
+fix-summary comment (Phase 7.5). Use exactly these sections, in this order:
+
+1. **Issue** — the user-visible symptom and impact (1–2 sentences), with the ticket link.
+2. **Root cause** — what actually causes it (file / function / code path and why).
+3. **Fix provided** — what changed and why it's safe; list the files touched and **both PR links**.
+4. **Steps to reproduce the issue** — numbered and copy-pasteable. **Explicitly call out any local
+   environment changes required** — e.g. "inject a phantom row into the `user2group` table", a
+   specific `NUXEO_PACKAGES` value, an LDAP / multi-repository setup, or seed data created via
+   REST/Automation. If none are needed, say "no environment changes required".
+5. **Steps to verify the fix** — numbered: how to build/deploy the patched branch, the exact
+   URL/screen to open, the actions to perform, and the expected (fixed) result vs. the old behavior.
+6. **Areas that may be affected (impact / regression surface)** — call out everything the change
+   could ripple into, so QA knows where to focus and reviewers understand the blast radius. Cover:
+   - **Other consumers of the touched code** — every element/screen that imports or shares the
+     changed file, method, behavior, or i18n key (e.g. a shared element used by multiple layouts, a
+     `nuxeo-elements` change consumed by all of `nuxeo-web-ui`). Search for usages before claiming
+     "isolated".
+   - **Adjacent behaviors in the same component** — pagination, sorting, filtering, add/remove,
+     counts, empty states, permissions/read-only — anything that shares state with what you changed.
+     Note which you exercised.
+   - **Edge cases & scale** — empty/1-item/large lists, multiple pages, special characters,
+     permissions variants, and any case intentionally left out of scope (state it explicitly).
+   - **Cross-cutting concerns** — i18n (new keys need translations across all locales),
+     accessibility, theming/styles, and the two base branches (`lts-2025` vs `maintenance-3.1.x`).
+   - **Explicitly list what was NOT affected** when you verified it (e.g. "nested-groups table and
+     permissions table untouched; unit suite still green"). Keep it honest — only list something as
+     unaffected once you've actually checked.
+
+Reference the evidence in both formats: `~/Desktop/<TICKET-ID>/<TICKET-ID>-before.{png,mp4}` and
+`-after.{png,mp4}`.
+
+## Phase 10 — Clean up & report
+- Tear down the throwaway repro container(s): `docker rm -f nx-<ticket>`. Never remove or disturb
+  pre-existing/live containers.
+- Leave the evidence files in `~/Desktop/<TICKET-ID>/` so they can be attached to the ticket.
+- Report the final CI state of both PRs. If a long cross-repo check (e.g. `web-ui`) is still
+  running, say so explicitly — do **not** claim green until it is.
+
+## Recommended extras (do these when applicable, still autonomously)
+- **Add/adjust a functional test.** For user-facing behavior, add a Gherkin scenario
+  (`ftest/features/*.feature`) plus page object / step definition so the fix is covered end-to-end —
+  the DoD expects "functional tests updated/added".
+- **Regression sanity.** The local gate already runs the full unit suite; report the pass count.
+- **Keep both PRs identical.** Any later change (review feedback / CI fix) is committed once and
+  cherry-picked onto the other base so the two PRs never diverge.
+- **Evaluate the Ready-for-QA checklist** (Phase 8) and post it as a table.
+- **Attach the videos.** MCP can't attach — provide the ready-to-run `curl` (Phase 7.5) or note the
+  drag-and-drop fallback so QA gets the recordings.
+
+## Guardrails (these still hold in YOLO mode)
+- Never force-push to `lts-2025` / `maintenance-3.1.x`; only to feature branches (`--force-with-lease`).
+- Never edit git config silently beyond the one-time signing setup; confirm global config changes.
+- Keep the PR scoped to the fix — never bundle unrelated files.
+- YOLO relaxes *confirmation gates only*. It does **not** authorize destructive/irreversible git
+  operations, force-pushes to protected branches, or committing secrets.

--- a/.cursor/skills/jira/create-qa-subtask/SKILL.md
+++ b/.cursor/skills/jira/create-qa-subtask/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: create-qa-subtask
+description: >-
+  Create a QA sub-task ("QA task") under a main Nuxeo Web UI Jira so the QA team
+  can plan verification of that ticket in a sprint. Reads the parent issue's
+  description, comments, fix-summary and PR links, then files a Sub-task titled
+  "QA task" whose description captures the full issue, the fix that was made,
+  what to verify (acceptance criteria) and how to verify (step-by-step). Use when
+  the user gives a WEBUI-<id> (or Jira key/URL) with an intent like "create QA
+  jira", "create QA task", "raise QA sub-task", "plan QA for this ticket", or
+  "QA sub-task for the sprint".
+---
+
+# Create a QA sub-task for the QA team
+
+Given a main Jira (a `WEBUI-<id>`, other Jira key, or Jira URL) plus an intent like
+"create QA jira/task", file a **Sub-task** under it named **`QA task`** that tells the QA
+team what was fixed and exactly how to verify it in the sprint.
+
+Constants:
+- Atlassian cloudId: `252cce86-035e-4b0e-abd2-3c002935632f` (site `hyland.atlassian.net`)
+- QA sub-task convention (from existing tasks): `issuetype = Sub-task`, `summary = "QA task"`,
+  `parent = <main issue>`, `component` inherited from the parent (usually `UI`), and the
+  **Tags** field `customfield_13956 = ["nxqa", "nxui", "nxui-triaged"]` (always set these
+  three; this is the "Tags" custom field, NOT the built-in `labels` field).
+
+## Workflow
+
+Track these steps with a TODO list.
+
+### 1. Resolve the parent key
+Extract the `WEBUI-<id>` (or other key) from the user's text/URL. If Atlassian tools aren't
+listed, call `mcp_auth` for the Atlassian server first.
+
+### 2. Read the parent issue fully
+`getJiraIssue` with `issueIdOrKey=<key>`, `fields:["*all"]` (includes `comment`),
+`contentFormat:"markdown"`. From it gather:
+- **Issue** — summary, description, user-visible symptom, repro steps, expected vs actual.
+- **Fix made** — look in the comments for the structured **fix-summary** comment (sections
+  *Issue / Root cause / Fix provided / Steps to reproduce / Steps to verify / Areas affected*
+  produced by the `fix-nuxeo-web-ui-bug` skill) and for **PR links**. Also check
+  `getJiraIssueRemoteIssueLinks` for linked PRs if the comments don't have them.
+- **Metadata to inherit** — `components` (copy to the sub-task), `fixVersions`, `priority`.
+
+If the fix details are missing (no fix-summary comment, no PRs, ticket not yet resolved), do NOT
+invent them. Fill the "Fix delivered" section with what's known and say the fix is pending /
+ask the user for the PR(s).
+
+### 3. Draft the QA task description
+Use this Markdown template (mirrors the existing "QA task" tickets — a verify statement, context,
+then acceptance criteria — extended with explicit how-to-verify steps the QA team asked for):
+
+```markdown
+### Summary
+Verify that <the fixed behaviour, one sentence>.
+
+### Issue
+<Original problem: user-visible symptom + impact, from the parent. Keep it self-contained so QA
+need not open the parent to understand it.>
+
+### Fix delivered
+<Root cause in one line + what changed and why it is safe.>
+PR(s): <links, one per base — lts-2025 / maintenance-3.1.x>
+
+### How to verify
+1. <Environment / setup — e.g. NUXEO_PACKAGES value, seed data, LDAP/multi-repo; or "no
+   environment changes required".>
+2. <Exact URL / screen to open.>
+3. <Actions to perform.>
+4. <Expected (fixed) result vs. the old behaviour.>
+
+### What to verify (Acceptance criteria)
+* <Observable pass condition 1>
+* <Observable pass condition 2>
+* No new console/JS errors; UI layout and performance uncompromised.
+
+### Areas to check for regressions
+* <Other screens/elements that share the changed code, adjacent behaviours, edge cases/scale.>
+
+### References
+* Parent: <WEBUI-id>
+* Before/after evidence: <attachment names if any>
+```
+
+Prefer reusing the parent's *Steps to verify* and *Areas affected* from the fix-summary comment
+verbatim where they exist, rather than rewriting them.
+
+### 4. Create the sub-task
+`createJiraIssue` with:
+- `cloudId` = constant above
+- `projectKey` = parent's project (e.g. `WEBUI`)
+- `issueTypeName` = `Sub-task`
+- `parent` = the main issue key
+- `summary` = `QA task`
+- `description` = the drafted Markdown, `contentFormat:"markdown"`
+- `additional_fields` = `{"components": [{"name":"<parent component, e.g. UI>"}], "customfield_13956": ["nxqa", "nxui", "nxui-triaged"]}`
+  (copy the parent's components and always set the three **Tags** via `customfield_13956`, not
+  `labels`; add `fixVersions`/`priority` only if the user asks).
+
+Do **not** set an assignee unless the user names the QA engineer (then resolve with
+`lookupJiraAccountId` and pass `assignee_account_id`). Sub-tasks follow the parent's sprint —
+no sprint field to set.
+
+### 5. Confirm
+Report the new sub-task key + URL (`https://hyland.atlassian.net/browse/<new-key>`) and a one-line
+recap of what QA is asked to verify.
+
+## Notes
+- Keep the summary exactly `QA task` — that is the team convention across the project.
+- One QA sub-task per main Jira unless the user asks to split verification.
+- Never fabricate fix/PR/verification details; when unknown, state so and ask.

--- a/.cursor/skills/jira/raise-backend-jira-ticket/SKILL.md
+++ b/.cursor/skills/jira/raise-backend-jira-ticket/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: raise-backend-jira-ticket
+description: >-
+  Create a backend Jira ticket in the NXP ("Nuxeo Platform") project — the
+  "NPX board" — tagged `nxplatform`, for work that a nuxeo-web-ui ticket
+  cannot fix on the client alone (a missing/changed REST endpoint, Automation
+  operation, adapter, or other server-side capability). Fills in proper issue
+  details, recommends the concrete backend solution that works for the Web UI,
+  and links the source (given input) ticket so it is "blocked by" the new NXP
+  ticket. Use when a WEBUI-/ELEMENTS- ticket needs a backend change, when asked
+  to "raise/create a backend ticket", "file an NXP/nxplatform ticket", or
+  "recommend the backend team" for a server-side gap.
+---
+
+# Raise a backend (NXP / nxplatform) Jira ticket
+
+Use this when analysing a Web UI ticket reveals the real fix (or part of it) must happen on the
+**server** — a REST endpoint that doesn't return the needed data, a missing Automation operation, a
+document adapter/enricher gap, a permissions/security check, etc. This skill files that backend work
+on the platform board, recommends the solution the Web UI needs, and wires up the dependency so the
+UI ticket is visibly blocked by it.
+
+Run it autonomously end-to-end (draft → create → link → cross-reference → report). The only thing
+that isn't fully automatable is the issue **link** and (optionally) the cross-reference comment when
+no API token is available — see Phase 4.
+
+## Constants
+- Atlassian cloudId: `252cce86-035e-4b0e-abd2-3c002935632f` (site `hyland.atlassian.net`)
+- Target project: **`NXP`** — *Nuxeo Platform* (this is the "NPX board")
+- Required **Tags**: **`nxplatform`** (always add it; add `web-ui` too so the origin is searchable).
+  On this site "Tags" is a **custom labels-type field `customfield_13956`** — NOT the built-in
+  `labels` field. Set `customfield_13956` or the tag won't show up on the board.
+- Required **Component**: NXP rejects creation without one (`"Components is required"`). Pick the
+  closest match to the affected server module — e.g. `User Profile / User Manager` (id `18042`) for
+  `nuxeo-platform-usermanager`, `Directory`, `Security / Rights`, `Authentication`, etc. If unsure,
+  list options with `getJiraIssueTypeMetaWithFields` (project `NXP`, Bug issueTypeId `10004`,
+  `requiredFieldsOnly:false`) and read the `components` field's `allowedValues`.
+- Default issue type: **`Bug`** for a defect that needs a server fix; **`Improvement`** or
+  **`New Feature`** when the UI needs a *new* server capability (new field/endpoint/operation).
+  Valid NXP types: Epic, Story, Task, Sub-task, Bug, Improvement, New Feature, Clean up, Question, Discovery.
+- Link type: **`Blocks`** (outward `blocks` / inward `is blocked by`).
+- If Atlassian tools aren't listed, call `mcp_auth` for the `plugin-atlassian-atlassian` server first.
+
+## Input
+The "given input" is the source ticket (e.g. `WEBUI-411`) — pass its key. If only a free-text
+description of the backend gap is given, still capture which UI ticket it came from so the block link
+can be created; if there is genuinely no source ticket, skip the link (Phase 4) and say so.
+
+## Phase 1 — Understand the gap
+- `getJiraIssue` (cloudId above, `issueIdOrKey=<input>`, `fields:["*all"]` incl. `comment`). Read the
+  description **and every comment** to pin down exactly what the client can't do and why.
+- Identify the **specific** server-side gap: which REST endpoint / Automation operation / adapter /
+  page-provider / property is missing or wrong, and what the UI needs it to return or accept.
+- Confirm it truly can't be solved client-side (no existing endpoint/operation, enricher, or header
+  already provides it). Only file backend work when the client genuinely can't.
+
+## Phase 2 — Draft the ticket
+Write a self-contained ticket a platform engineer can action without the UI context. Use the
+**title** and **description** templates below. The **Recommended solution** section is required —
+propose the concrete change that works for the Web UI (endpoint shape, new operation + params,
+adapter field, response payload), not just "please fix". Offer a primary recommendation and, if
+relevant, one acceptable alternative.
+
+## Phase 3 — Create the issue (MCP)
+`createJiraIssue`:
+- `cloudId` = constant, `projectKey` = `NXP`, `issueTypeName` = default `Bug` (see Constants),
+  `summary` = the drafted title, `description` = the drafted body, `contentFormat` = `markdown`.
+- Tags **and** the required component go through `additional_fields` (the only way to set custom
+  fields / components / priority). The **Tags** field is `customfield_13956` (a labels-type custom
+  field) — setting the built-in `labels` alone leaves the board's Tags empty:
+```json
+{ "customfield_13956": ["nxplatform", "web-ui"], "components": [{ "id": "18042" }] }
+```
+  (`18042` = `User Profile / User Manager`; swap for the component that fits the module — see
+  Constants. Optionally also set `"labels": ["nxplatform", "web-ui"]` for extra searchability.)
+- Capture the returned key (e.g. `NXP-1234`) and browse URL: `https://hyland.atlassian.net/browse/NXP-1234`.
+  If creation fails with `"Components is required"`, you omitted the component — add it and retry.
+
+## Phase 4 — Link the input as "blocked by" the new ticket
+The source (given input) ticket must end up showing **"is blocked by → NXP-new"** (equivalently, the
+new NXP ticket **blocks** the input).
+
+The Atlassian MCP now exposes **`createIssueLink`** — use it (no REST/curl or token needed).
+⚠️ Its inward/outward semantics are **inverted vs raw REST**: per the tool's own description,
+`inwardIssue` = the **blocker**, `outwardIssue` = the **blocked** issue. So:
+- `type` = `Blocks`
+- `inwardIssue` = the **new NXP** ticket (the blocker)
+- `outwardIssue` = the **given input** ticket (the blocked one)
+
+```json
+{ "cloudId": "…", "type": "Blocks", "inwardIssue": "NXP-1234", "outwardIssue": "WEBUI-411" }
+```
+Then **verify** with `getJiraIssue` on the input (`fields:["issuelinks"]`): the link should read
+`type: Blocks` with the NXP ticket as `inwardIssue` and `inward: "is blocked by"` — i.e. the input
+*is blocked by* NXP. Use `getIssueLinkTypes` first if the `Blocks` name is uncertain.
+
+Fallback (only if `createIssueLink` is unavailable): create the link via the Jira REST `issueLink`
+endpoint (note REST uses the opposite convention — `outwardIssue` *blocks* `inwardIssue`), or link
+manually in the browser: **Link → is blocked by → NXP-1234** on the input ticket.
+
+## Phase 5 — Cross-reference (recommended)
+Comment on the **input** ticket via `addCommentToJiraIssue` (cloudId, `contentFormat:"markdown"`)
+noting the backend dependency was filed and linked — e.g. *"A backend change is required; raised
+`NXP-1234` (nxplatform) and linked it as **is blocked by**. This UI ticket is blocked until that
+lands."* Keep it honest: only say "linked" once Phase 4 actually succeeded.
+
+## Phase 6 — Report
+Output: the new `NXP-<id>` key + browse URL, the issue type, component, and tags set
+(`customfield_13956`), and the link status (created via `createIssueLink` and verified / manual
+fallback). If the link couldn't be created automatically, say so explicitly.
+
+---
+
+## Title template
+```
+[Web UI] <concise capability the UI needs> (blocks <INPUT>)
+```
+Examples:
+- `[Web UI] Expose "canEdit" flag on document REST enrichers (blocks WEBUI-411)`
+- `[Web UI] Add Automation op to bulk-update retention (blocks WEBUI-1987)`
+
+## Description template (markdown)
+```markdown
+## Context
+Raised from **<INPUT>** (<input link>). The Web UI cannot resolve this on the client alone; a
+server-side change is required.
+
+## Problem
+<What the client is trying to do and the exact server-side limitation blocking it — the endpoint /
+operation / adapter / property involved and what it currently returns or lacks.>
+
+## Why a backend change is needed
+<Why this can't be done in nuxeo-web-ui / nuxeo-elements: no existing endpoint or operation provides
+the data/behaviour; the missing piece is server-side.>
+
+## Recommended solution (what works for the Web UI)
+<Concrete, actionable proposal:
+- REST: endpoint + method + request/response shape the UI needs, or the field/enricher to add.
+- Automation: new operation id + params + return, or the change to an existing one.
+- Adapter/enricher/property: what to expose and where.
+Give a primary recommendation; add one acceptable alternative if relevant.>
+
+## Acceptance criteria
+- [ ] <observable server behaviour 1 the UI can consume>
+- [ ] <backward compatibility / permissions / error handling as needed>
+
+## Affected UI work
+Blocks **<INPUT>**. Web UI change is ready to consume this once available.
+```
+
+## Guardrails
+- Always target project **`NXP`**, set a **component** (required), and add the **`nxplatform`** tag to
+  the **Tags** custom field `customfield_13956` (not just the built-in `labels`).
+- Link direction matters: the **input** must end up *blocked by* the **new NXP** ticket. With the
+  `createIssueLink` MCP tool that means `inwardIssue` = new NXP (blocker), `outwardIssue` = input
+  (blocked), type `Blocks`. (Raw REST is the opposite convention.) Verify after creating; don't invert it.
+  
+- Don't fabricate a link/comment as done — issue links need REST (no MCP tool); state the real status.
+- File backend work only when the client genuinely can't do it; confirm no existing endpoint/operation
+  already covers the need before creating the ticket.

--- a/.cursor/skills/nuxeo-web-ui-pr-checks/SKILL.md
+++ b/.cursor/skills/nuxeo-web-ui-pr-checks/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: nuxeo-web-ui-pr-checks
+description: >-
+  Run the gating checks that nuxeo-web-ui PR CI runs (Lint + Unit tests),
+  locally, before pushing. Use before every `git push` to a PR branch, when
+  updating an open PR, or before opening one — so the push doesn't turn the PR
+  red. Mirrors .github/workflows/lint.yaml and test.yaml. Also documents the
+  heavier CI-only checks (a11y, Maven build, sonar) and the common local
+  gotchas (broken @nuxeo symlinks, package-lock churn, flaky document-tree test).
+---
+
+# Nuxeo Web UI — pre-push PR checks
+
+Before pushing commits to a PR branch (new PR or updating an existing one),
+run the same checks that gate the PR, and **only push if they pass**.
+
+## What the PR actually gates on
+
+| CI workflow | Command | Run locally? |
+|---|---|---|
+| **Lint** (`lint.yaml`) | `npm run lint` (eslint + `prettier --list-different`) | Yes — fast |
+| **Test** (`test.yaml`) | `npm run test` (web-test-runner `--coverage`) | Yes — ~2 min |
+| A11y (`a11y.yaml`) | `mvn -B -ntp install` + `mvn -B -ntp -f plugin/a11y install` | Optional — needs Java + npm token + repo creds |
+| Sonar / full build | push-only (`main.yaml`) | No — not a PR gate |
+
+`npm run lint` and `npm run test` are the gate developers must reproduce locally.
+A11y/build/sonar need Maven and secrets, so they're not part of the fast pre-push loop.
+
+## Run the gate
+
+From the repo root:
+
+```bash
+bash .cursor/skills/nuxeo-web-ui-pr-checks/scripts/pr-checks.sh         # lint + test (matches CI)
+bash .cursor/skills/nuxeo-web-ui-pr-checks/scripts/pr-checks.sh --fix   # npm run format first, then lint + test
+```
+
+- Exit code `0` → safe to push.
+- Non-zero → **do not push**; fix and re-run.
+
+CI runs `npm run lint` in **check** mode (it does not auto-fix). Use `--fix`
+locally to apply `npm run format` (prettier `--write` then eslint `--fix`) before
+the lint gate, then commit the formatting changes.
+
+## Push only on green
+
+```bash
+bash .cursor/skills/nuxeo-web-ui-pr-checks/scripts/pr-checks.sh && git push --force-with-lease origin HEAD
+```
+
+Never force-push to `lts-2025` / `maintenance-3.1.x` themselves — only to the PR's feature branch.
+
+## Common local gotchas
+
+- **`@nuxeo/...` import errors in `npm test`**: a prior `npm install` replaced the
+  `nuxeo-elements` symlinks. Re-link (see `AGENTS.md`) and re-run:
+
+```bash
+rm -rf node_modules/@nuxeo/nuxeo-ui-elements && ln -s ../../../nuxeo-elements/ui node_modules/@nuxeo/nuxeo-ui-elements
+rm -rf node_modules/@nuxeo/nuxeo-elements && ln -s ../../../nuxeo-elements/core node_modules/@nuxeo/nuxeo-elements
+rm -rf node_modules/@nuxeo/nuxeo-dataviz-elements && ln -s ../../../nuxeo-elements/dataviz node_modules/@nuxeo/nuxeo-dataviz-elements
+```
+
+- **`package-lock.json` churn**: npm version differences add/remove `"peer": true`
+  lines. Don't commit it: `git checkout -- package-lock.json`.
+
+- **Flaky `nuxeo-document-tree` test** (`test/nuxeo-document-tree.test.js` "Tree should
+  collapse when clicking on a document"): timing flake unrelated to most changes. If it
+  fails *only* in CI but passes locally, re-run the job instead of "fixing" it:
+  `gh run rerun <run-id> --failed`.
+
+## Optional: reproduce the A11y check locally
+
+Only when a change might affect accessibility/build. Requires Java (21 for `lts-2025`,
+17 for `maintenance-3.1.x`) and `@nuxeo` npm/Maven auth configured:
+
+```bash
+mvn -B -ntp install
+mvn -B -ntp -f plugin/a11y install
+```

--- a/.cursor/skills/nuxeo-web-ui-pr-checks/scripts/pr-checks.sh
+++ b/.cursor/skills/nuxeo-web-ui-pr-checks/scripts/pr-checks.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Run the same gating checks the nuxeo-web-ui PR CI runs (Lint + Unit tests),
+# locally, before pushing to a PR branch.
+# Mirrors .github/workflows/lint.yaml (npm run lint) and test.yaml (npm run test).
+#
+# Usage:
+#   pr-checks.sh          # lint + test (exactly what CI gates on)
+#   pr-checks.sh --fix    # npm run format first (prettier --write + eslint --fix), then lint + test
+#
+# Exit codes: 0 = all green (safe to push); 1 = a check failed; 2 = usage/setup error.
+
+set -uo pipefail
+
+FIX=0
+for arg in "$@"; do
+  case "$arg" in
+    --fix) FIX=1 ;;
+    -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+    *) echo "Unknown argument: $arg (use --fix or --help)" >&2; exit 2 ;;
+  esac
+done
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "Not inside a git repository." >&2; exit 2; }
+cd "$ROOT" || exit 2
+
+fail() { printf '\n\xe2\x9d\x8c %s\n' "$1"; exit 1; }
+step() { printf '\n\xe2\x96\xb6 %s\n' "$1"; }
+
+# 0. Optional auto-format. CI does NOT format; it only verifies (prettier --list-different).
+if [ "$FIX" -eq 1 ]; then
+  step "npm run format (prettier --write -> eslint --fix)"
+  npm run format || fail "format failed"
+fi
+
+# 1. Lint gate (lint.yaml): eslint + prettier --list-different.
+step "npm run lint"
+npm run lint || fail "lint failed - run with --fix (or 'npm run format'), commit, then re-run"
+
+# 2. Unit tests (test.yaml): web-test-runner --coverage.
+step "npm test"
+if ! npm test; then
+  # Most common local-only cause: npm install replaced the nuxeo-elements symlinks.
+  if [ -e node_modules/@nuxeo/nuxeo-ui-elements ] && [ ! -L node_modules/@nuxeo/nuxeo-ui-elements ] && [ -d ../nuxeo-elements ]; then
+    cat >&2 <<'HINT'
+
+Hint: @nuxeo packages are not symlinked to ../nuxeo-elements (a prior `npm install`
+likely replaced them). Re-link and retry:
+  rm -rf node_modules/@nuxeo/nuxeo-ui-elements && ln -s ../../../nuxeo-elements/ui node_modules/@nuxeo/nuxeo-ui-elements
+  rm -rf node_modules/@nuxeo/nuxeo-elements && ln -s ../../../nuxeo-elements/core node_modules/@nuxeo/nuxeo-elements
+  rm -rf node_modules/@nuxeo/nuxeo-dataviz-elements && ln -s ../../../nuxeo-elements/dataviz node_modules/@nuxeo/nuxeo-dataviz-elements
+HINT
+  fi
+  fail "unit tests failed"
+fi
+
+printf '\n\xe2\x9c\x85 Lint + unit tests passed (matches the PR gating checks). Safe to push.\n'
+printf '   Note: CI also runs a11y/build/sonar (Maven + secrets); see SKILL.md if relevant.\n'
+exit 0

--- a/.cursor/skills/nuxeo-web-ui-pr/SKILL.md
+++ b/.cursor/skills/nuxeo-web-ui-pr/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: nuxeo-web-ui-pr
+description: >-
+  Create and push a pull request for the Nuxeo Web UI repository following team
+  conventions: branch naming, WEBUI-<id> commit messages, the origin (same-repo)
+  flow — always push branches to origin (nuxeo/nuxeo-web-ui), never a fork,
+  because CI checks out the branch by name from the upstream repo — the Problem /
+  Root cause / Changes / Test plan / Notes PR body format, and backporting to both
+  lts-2025 and maintenance-3.1.x. Use when opening a PR, pushing a branch, or
+  backporting a fix in nuxeo-web-ui.
+---
+
+# Nuxeo Web UI — Pull Request workflow
+
+Reference PR this format mirrors: https://github.com/nuxeo/nuxeo-web-ui/pull/3259
+
+## Before opening a PR
+
+Always validate locally first (see `AGENTS.md`):
+
+```bash
+npm run format   # prettier --write then eslint --fix
+npm run lint     # eslint + prettier --list-different — must pass
+npm test         # Web Test Runner unit tests — must pass
+```
+
+If `npm test` fails to import `@nuxeo/nuxeo-ui-elements/...`, a prior `npm install`
+replaced the local `nuxeo-elements` symlinks. Re-link them:
+
+```bash
+rm -rf node_modules/@nuxeo/nuxeo-ui-elements && ln -s "../../../nuxeo-elements/ui" node_modules/@nuxeo/nuxeo-ui-elements
+rm -rf node_modules/@nuxeo/nuxeo-elements && ln -s "../../../nuxeo-elements/core" node_modules/@nuxeo/nuxeo-elements
+rm -rf node_modules/@nuxeo/nuxeo-dataviz-elements && ln -s "../../../nuxeo-elements/dataviz" node_modules/@nuxeo/nuxeo-dataviz-elements
+```
+
+Do not commit incidental `package-lock.json` churn (npm version differences add/remove
+`"peer": true` lines). Revert it: `git checkout -- package-lock.json`.
+
+## Branch naming
+
+`<type>-WEBUI-<id>-<kebab-summary>-<base-branch>`
+
+- type: `fix` (bug), `feat` (feature), `task` (chore/infra)
+- include the base branch suffix so the target is unambiguous, e.g.
+  `fix-WEBUI-1571-queue-view-navigation-multi-repository-lts-2025`
+
+## Commit message
+
+`WEBUI-<id>: <Concise summary>` (matches `git log` history; the squash-merge appends `(#PR)`).
+Add a body explaining the *why* (root cause + approach). Pass via heredoc to preserve formatting.
+
+## Access model — always push to origin (never a fork)
+
+**Always push the feature branch to `origin` (`nuxeo/nuxeo-web-ui`) and open a same-repo PR.**
+Do **not** use a fork.
+
+Why: the CI workflows (`.github/workflows/lint.yaml`, `test.yaml`, etc.) check out the branch
+**by name from the upstream repo** — `actions/checkout` with `ref: ${{ github.head_ref }}` and no
+`repository:` override, so it defaults to `nuxeo/nuxeo-web-ui`. A fork branch does not exist upstream,
+so a fork-based PR fails immediately at checkout (`The process '/usr/bin/git' failed with exit code 1`,
+surfacing as red **lint/unit-test/a11y**). A same-repo branch is found and CI runs correctly.
+
+Confirm you have push access, then push to origin:
+```bash
+gh api repos/nuxeo/nuxeo-web-ui --jq '.permissions'   # expect "push": true
+git push -u origin HEAD
+```
+If you ever lack push access, request it rather than falling back to a fork (fork PRs can't pass CI here).
+
+## Open the PR (per base branch)
+
+Same-repo head (just the branch name, no owner prefix):
+```bash
+gh pr create --repo nuxeo/nuxeo-web-ui \
+  --base <base-branch> \
+  --head <branch> \
+  --title "WEBUI-<id>: <summary> [<base-branch>]" \
+  --body "$(cat <<'EOF'
+<PR body — see template below>
+EOF
+)"
+```
+
+## Base branches & backports
+
+**Default rule: every fix targets BOTH bases.** For each fix, create a branch off `lts-2025`
+*and* a branch off `maintenance-3.1.x`, each named with the ticket id
+(`<type>-WEBUI-<id>-<kebab-summary>-<base>`), and open **one PR per base** (two PRs total).
+Only skip a base when the Jira `fixVersions` explicitly exclude it — call that out.
+
+- Primary development: `lts-2025`.
+- Maintenance/backport: `maintenance-3.1.x` (the repo default branch).
+- Match the Jira `fixVersions`. When a fix targets multiple versions, open one PR per base.
+  Backport by branching from the maintenance base and cherry-picking the commit:
+
+```bash
+git fetch origin maintenance-3.1.x
+git checkout -b <branch>-maintenance-3.1.x origin/maintenance-3.1.x
+git cherry-pick <sha>
+git push -u origin HEAD
+```
+
+## Keep both PRs in sync (post-creation changes)
+
+When a fix targets multiple bases, treat the PRs as a matched pair. **Any change made after the
+PRs exist — review feedback (Copilot/Sonar/reviewers), CI fixes, follow-up tweaks — must be applied
+to _every_ PR/base, not just one.** Never fix a review comment on one branch and leave the other
+diverged.
+
+- Make the change once, commit it (signed), then cherry-pick the same commit onto each other base
+  branch and push. Keep the branches' diffs identical apart from unavoidable base differences.
+- Re-run the local gate (`nuxeo-web-ui-pr-checks`) before each push.
+- After pushing, confirm CI is (re)running on **both** PRs.
+
+```bash
+# example: applied & committed the review fix on the current base, now mirror to the other base
+SHA=$(git rev-parse HEAD)
+git push origin HEAD
+git checkout <other-base-branch-branch>
+git cherry-pick "$SHA"
+git push origin HEAD
+```
+
+## PR body template
+
+```markdown
+## Problem
+<User-visible symptom + impact.> Jira: [WEBUI-<id>](https://hyland.atlassian.net/browse/WEBUI-<id>)
+
+## Root cause
+<Why it happens, naming the responsible code path.>
+
+## Changes
+* **`<file>`**: <what changed and why it is safe>.
+
+## Test plan
+- [x] `npm run lint` passes
+- [x] `npm test` passes
+- [ ] <Manual/functional verification steps, esp. anything CI can't cover>
+
+## Notes
+<Backport relationship, limitations, follow-ups.>
+```
+
+## Git safety
+
+- Never update git config; never force-push to `lts-2025`/`maintenance-3.1.x`.
+- Only commit when asked; keep the bug-fix PR focused (don't bundle unrelated files).


### PR DESCRIPTION
Backport of #3336 to `lts-2025`.

## What
Adds the Web UI team's Cursor agent skills (project scope, `.cursor/skills/`) so teammates get them automatically, plus a `.cursor/skills/README.md` onboarding guide.

## Included skills
- `fix-nuxeo-web-ui-bug` (orchestrator) + its `nuxeo-web-ui-pr` and `nuxeo-web-ui-pr-checks` dependencies
- `jira/create-qa-subtask`, `jira/raise-backend-jira-ticket`

## Onboarding
README covers one-time setup (Atlassian MCP, Jira API token, GitHub CLI, signed commits), how to use each skill, and troubleshooting. The bug-fix skill now has a first-time setup check that guides new users through MCP/auth prerequisites.

## Notes
Public repo — docs reference the team's Atlassian cloudId and internal workflow; no secrets (credentials stay in local `~/.jira_*` files).

Made with [Cursor](https://cursor.com)