### PR TITLE
WEBUI-1096: Fix display of user information throughout the UI [maintenance-3.1.x]

### DIFF
--- a/elements/nuxeo-document-activity/nuxeo-document-activity.js
+++ b/elements/nuxeo-document-activity/nuxeo-document-activity.js
@@ -92,7 +92,7 @@ Polymer({
   observers: ['_fetchPrincipals(activities)'],
 
   async _fetchPrincipals(activities) {
-    if (!activities || !activities.length) return;
+    if (!activities?.length) return;
     this._principalsLoading = true;
     const entities = {};
     const seen = new Set();
@@ -105,7 +105,7 @@ Polymer({
           const user = await this.$.user.get();
           entities[principal] = user;
         } catch (_) {
-          // keep the raw username if the fetch fails
+          void _; // system/deleted users — keep raw username as fallback
         }
       }
     }
@@ -115,7 +115,7 @@ Polymer({
 
   _resolvedPrincipal(principalName, entities, loading) {
     if (loading) return null;
-    return (entities && entities[principalName]) || principalName;
+    return entities?.[principalName] || principalName;
   },
 
   _activity(event) {

--- a/elements/nuxeo-document-activity/nuxeo-document-activity.js
+++ b/elements/nuxeo-document-activity/nuxeo-document-activity.js
@@ -105,7 +105,7 @@ Polymer({
           const user = await this.$.user.get();
           entities[principal] = user;
         } catch (_) {
-          void _; // system/deleted users — keep raw username as fallback
+          entities[principal] = principal; // fallback: keep raw username for system/deleted users
         }
       }
     }

--- a/elements/nuxeo-document-activity/nuxeo-document-activity.js
+++ b/elements/nuxeo-document-activity/nuxeo-document-activity.js
@@ -87,13 +87,33 @@ Polymer({
       type: Boolean,
       value: false,
     },
+    _principalsRequestId: {
+      type: Number,
+      value: 0,
+    },
   },
 
   observers: ['_fetchPrincipals(activities)'],
 
-  async _fetchPrincipals(activities) {
-    if (!activities?.length) return;
+  _fetchPrincipals(activities) {
+    if (!activities?.length) {
+      this._principalEntities = {};
+      this._principalsLoading = false;
+      return undefined;
+    }
+    const requestId = ++this._principalsRequestId;
     this._principalsLoading = true;
+    // Serialize invocations: the observer can re-fire while a previous fetch is still in
+    // flight, and every lookup mutates the `path` of a single shared <nuxeo-resource>
+    // (this.$.user). Chaining runs sequentially prevents concurrent path mutation and
+    // in-flight request aborts on that shared element.
+    const run = () => this._resolvePrincipals(activities, requestId);
+    const previous = this._principalsChain || Promise.resolve();
+    this._principalsChain = previous.catch(() => {}).then(run);
+    return this._principalsChain;
+  },
+
+  async _resolvePrincipals(activities, requestId) {
     const entities = {};
     const seen = new Set();
     for (const activity of activities) {
@@ -101,17 +121,18 @@ Polymer({
       if (principal && typeof principal === 'string' && !seen.has(principal)) {
         seen.add(principal);
         try {
-          this.$.user.path = `/user/${principal}`;
+          this.$.user.path = `/user/${encodeURIComponent(principal)}`;
           const user = await this.$.user.get();
           entities[principal] = user;
         } catch (error) {
-          if (error.status && error.status !== 404) {
-            console.warn(`Unexpected error resolving user "${principal}":`, error.message);
+          if (error.status !== 404) {
+            console.warn(`Unexpected error resolving user "${principal}":`, error);
           }
           entities[principal] = principal; // fallback: keep raw username for system/deleted users
         }
       }
     }
+    if (requestId !== this._principalsRequestId) return;
     this._principalEntities = entities;
     this._principalsLoading = false;
   },

--- a/elements/nuxeo-document-activity/nuxeo-document-activity.js
+++ b/elements/nuxeo-document-activity/nuxeo-document-activity.js
@@ -97,6 +97,9 @@ Polymer({
 
   _fetchPrincipals(activities) {
     if (!activities?.length) {
+      // Bump the request id so any in-flight resolve is invalidated and cannot
+      // repopulate the entities map after this reset.
+      this._principalsRequestId += 1;
       this._principalEntities = {};
       this._principalsLoading = false;
       return undefined;

--- a/elements/nuxeo-document-activity/nuxeo-document-activity.js
+++ b/elements/nuxeo-document-activity/nuxeo-document-activity.js
@@ -104,7 +104,10 @@ Polymer({
           this.$.user.path = `/user/${principal}`;
           const user = await this.$.user.get();
           entities[principal] = user;
-        } catch (_) {
+        } catch (error) {
+          if (error.status && error.status !== 404) {
+            console.warn(`Unexpected error resolving user "${principal}":`, error.message);
+          }
           entities[principal] = principal; // fallback: keep raw username for system/deleted users
         }
       }

--- a/elements/nuxeo-document-activity/nuxeo-document-activity.js
+++ b/elements/nuxeo-document-activity/nuxeo-document-activity.js
@@ -19,6 +19,7 @@ import '@polymer/polymer/polymer-legacy.js';
 
 import { RoutingBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-routing-behavior.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
+import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-date.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-user-tag.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
@@ -46,9 +47,14 @@ Polymer({
       }
     </style>
 
+    <nuxeo-resource id="user" path="/user"></nuxeo-resource>
+
     <template is="dom-repeat" items="[[activities]]">
       <div class="row">
-        <nuxeo-user-tag user="[[item.principalName]]" max-characters="15"></nuxeo-user-tag>
+        <nuxeo-user-tag
+          user="[[_resolvedPrincipal(item.principalName, _principalEntities, _principalsLoading)]]"
+          max-characters="15"
+        ></nuxeo-user-tag>
         <div class="value">
           <span>[[_activity(item)]]</span>
           <nuxeo-date class="datetime" datetime="[[item.eventDate]]" format="relative"></nuxeo-date>
@@ -70,6 +76,46 @@ Polymer({
       type: Array,
       value: [],
     },
+
+    _principalEntities: {
+      type: Object,
+      value: () => {
+        return {};
+      },
+    },
+    _principalsLoading: {
+      type: Boolean,
+      value: false,
+    },
+  },
+
+  observers: ['_fetchPrincipals(activities)'],
+
+  async _fetchPrincipals(activities) {
+    if (!activities || !activities.length) return;
+    this._principalsLoading = true;
+    const entities = {};
+    const seen = new Set();
+    for (const activity of activities) {
+      const principal = activity.principalName;
+      if (principal && typeof principal === 'string' && !seen.has(principal)) {
+        seen.add(principal);
+        try {
+          this.$.user.path = `/user/${principal}`;
+          const user = await this.$.user.get();
+          entities[principal] = user;
+        } catch (_) {
+          // keep the raw username if the fetch fails
+        }
+      }
+    }
+    this._principalEntities = entities;
+    this._principalsLoading = false;
+  },
+
+  _resolvedPrincipal(principalName, entities, loading) {
+    if (loading) return null;
+    return (entities && entities[principalName]) || principalName;
   },
 
   _activity(event) {

--- a/elements/nuxeo-document-info-bar/nuxeo-document-info-bar.js
+++ b/elements/nuxeo-document-info-bar/nuxeo-document-info-bar.js
@@ -214,6 +214,10 @@ Polymer({
       type: Boolean,
       value: false,
     },
+    _initiatorsRequestId: {
+      type: Number,
+      value: 0,
+    },
   },
 
   observers: ['_fetchInitiators(workflows)'],
@@ -222,9 +226,25 @@ Polymer({
     return { document: this.document };
   },
 
-  async _fetchInitiators(workflows) {
-    if (!workflows?.length) return;
+  _fetchInitiators(workflows) {
+    if (!workflows?.length) {
+      this._initiatorEntities = {};
+      this._initiatorsLoading = false;
+      return undefined;
+    }
+    const requestId = ++this._initiatorsRequestId;
     this._initiatorsLoading = true;
+    // Serialize invocations: the observer can re-fire while a previous fetch is still in
+    // flight, and every lookup mutates the `path` of a single shared <nuxeo-resource>
+    // (this.$.user). Chaining runs sequentially prevents concurrent path mutation and
+    // in-flight request aborts on that shared element.
+    const run = () => this._resolveInitiators(workflows, requestId);
+    const previous = this._initiatorsChain || Promise.resolve();
+    this._initiatorsChain = previous.catch(() => {}).then(run);
+    return this._initiatorsChain;
+  },
+
+  async _resolveInitiators(workflows, requestId) {
     const entities = {};
     const seen = new Set();
     for (const wf of workflows) {
@@ -232,17 +252,18 @@ Polymer({
       if (initiator && typeof initiator === 'string' && !seen.has(initiator)) {
         seen.add(initiator);
         try {
-          this.$.user.path = `/user/${initiator}`;
+          this.$.user.path = `/user/${encodeURIComponent(initiator)}`;
           const user = await this.$.user.get();
           entities[initiator] = user;
         } catch (error) {
-          if (error.status && error.status !== 404) {
-            console.warn(`Unexpected error resolving user "${initiator}":`, error.message);
+          if (error.status !== 404) {
+            console.warn(`Unexpected error resolving user "${initiator}":`, error);
           }
           entities[initiator] = initiator; // fallback: keep raw username for system/deleted users
         }
       }
     }
+    if (requestId !== this._initiatorsRequestId) return;
     this._initiatorEntities = entities;
     this._initiatorsLoading = false;
   },

--- a/elements/nuxeo-document-info-bar/nuxeo-document-info-bar.js
+++ b/elements/nuxeo-document-info-bar/nuxeo-document-info-bar.js
@@ -236,7 +236,7 @@ Polymer({
           const user = await this.$.user.get();
           entities[initiator] = user;
         } catch (_) {
-          void _; // system/deleted users — keep raw username as fallback
+          entities[initiator] = initiator; // fallback: keep raw username for system/deleted users
         }
       }
     }

--- a/elements/nuxeo-document-info-bar/nuxeo-document-info-bar.js
+++ b/elements/nuxeo-document-info-bar/nuxeo-document-info-bar.js
@@ -235,7 +235,10 @@ Polymer({
           this.$.user.path = `/user/${initiator}`;
           const user = await this.$.user.get();
           entities[initiator] = user;
-        } catch (_) {
+        } catch (error) {
+          if (error.status && error.status !== 404) {
+            console.warn(`Unexpected error resolving user "${initiator}":`, error.message);
+          }
           entities[initiator] = initiator; // fallback: keep raw username for system/deleted users
         }
       }

--- a/elements/nuxeo-document-info-bar/nuxeo-document-info-bar.js
+++ b/elements/nuxeo-document-info-bar/nuxeo-document-info-bar.js
@@ -223,7 +223,7 @@ Polymer({
   },
 
   async _fetchInitiators(workflows) {
-    if (!workflows || !workflows.length) return;
+    if (!workflows?.length) return;
     this._initiatorsLoading = true;
     const entities = {};
     const seen = new Set();
@@ -236,7 +236,7 @@ Polymer({
           const user = await this.$.user.get();
           entities[initiator] = user;
         } catch (_) {
-          // keep the raw username if the fetch fails
+          void _; // system/deleted users — keep raw username as fallback
         }
       }
     }
@@ -246,7 +246,7 @@ Polymer({
 
   _resolvedInitiator(initiator, entities, loading) {
     if (loading) return null;
-    return (entities && entities[initiator]) || initiator;
+    return entities?.[initiator] || initiator;
   },
 
   _computeRetentionUntiLabel(doc) {

--- a/elements/nuxeo-document-info-bar/nuxeo-document-info-bar.js
+++ b/elements/nuxeo-document-info-bar/nuxeo-document-info-bar.js
@@ -91,7 +91,9 @@ Polymer({
         <div class="item">
           <iron-icon class="icon" icon="icons:perm-data-setting"></iron-icon>
           <template is="dom-if" if="[[!_isCurrentUser(workflow.initiator, currentUser)]]">
-            <nuxeo-user-tag user="[[workflow.initiator]]"></nuxeo-user-tag>
+            <nuxeo-user-tag
+              user="[[_resolvedInitiator(workflow.initiator, _initiatorEntities, _initiatorsLoading)]]"
+            ></nuxeo-user-tag>
           </template>
           <span>[[_labelForInitiatedWf(workflow, currentUser)]]</span>
         </div>
@@ -202,10 +204,49 @@ Polymer({
       type: Object,
       computed: '_computeActionContext(document)',
     },
+    _initiatorEntities: {
+      type: Object,
+      value: () => {
+        return {};
+      },
+    },
+    _initiatorsLoading: {
+      type: Boolean,
+      value: false,
+    },
   },
+
+  observers: ['_fetchInitiators(workflows)'],
 
   _computeActionContext() {
     return { document: this.document };
+  },
+
+  async _fetchInitiators(workflows) {
+    if (!workflows || !workflows.length) return;
+    this._initiatorsLoading = true;
+    const entities = {};
+    const seen = new Set();
+    for (const wf of workflows) {
+      const initiator = wf.initiator;
+      if (initiator && typeof initiator === 'string' && !seen.has(initiator)) {
+        seen.add(initiator);
+        try {
+          this.$.user.path = `/user/${initiator}`;
+          const user = await this.$.user.get();
+          entities[initiator] = user;
+        } catch (_) {
+          // keep the raw username if the fetch fails
+        }
+      }
+    }
+    this._initiatorEntities = entities;
+    this._initiatorsLoading = false;
+  },
+
+  _resolvedInitiator(initiator, entities, loading) {
+    if (loading) return null;
+    return (entities && entities[initiator]) || initiator;
   },
 
   _computeRetentionUntiLabel(doc) {

--- a/elements/nuxeo-document-info-bar/nuxeo-document-info-bar.js
+++ b/elements/nuxeo-document-info-bar/nuxeo-document-info-bar.js
@@ -228,6 +228,9 @@ Polymer({
 
   _fetchInitiators(workflows) {
     if (!workflows?.length) {
+      // Bump the request id so any in-flight resolve is invalidated and cannot
+      // repopulate the entities map after this reset.
+      this._initiatorsRequestId += 1;
       this._initiatorEntities = {};
       this._initiatorsLoading = false;
       return undefined;

--- a/elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html
+++ b/elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html
@@ -86,11 +86,15 @@ limitations under the License.
 
       _fetchUserParticipants(participants) {
         if (!participants || !Array.isArray(participants)) {
+          // Bump the request id so any in-flight resolve is invalidated and cannot
+          // repopulate the participants after this reset.
+          this._participantsRequestId += 1;
           this._resolvedUserParticipants = [];
           return undefined;
         }
         const userActors = participants.filter((actor) => typeof actor === 'string' && actor.startsWith('user:'));
         if (!userActors.length) {
+          this._participantsRequestId += 1;
           this._resolvedUserParticipants = [];
           return undefined;
         }
@@ -126,11 +130,19 @@ limitations under the License.
       },
 
       _hasActorType(actors, type) {
-        return actors && Array.isArray(actors) && actors.findIndex((actor) => actor.startsWith(type)) >= 0;
+        return (
+          actors &&
+          Array.isArray(actors) &&
+          actors.findIndex((actor) => typeof actor === 'string' && actor.startsWith(type)) >= 0
+        );
       },
 
       _getActorsByType(actors, type) {
-        return actors && Array.isArray(actors) && actors.filter((actor) => actor.startsWith(type));
+        return (
+          actors &&
+          Array.isArray(actors) &&
+          actors.filter((actor) => typeof actor === 'string' && actor.startsWith(type))
+        );
       },
     });
   </script>

--- a/elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html
+++ b/elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html
@@ -93,7 +93,10 @@ limitations under the License.
             this.$.user.path = `/user/${username}`;
             const entity = await this.$.user.get();
             resolved.push(entity);
-          } catch (_) {
+          } catch (error) {
+            if (error.status && error.status !== 404) {
+              console.warn(`Unexpected error resolving user "${username}":`, error.message);
+            }
             // system/deleted users — fall back to raw prefixed string
             resolved.push(actor);
           }

--- a/elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html
+++ b/elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html
@@ -94,7 +94,7 @@ limitations under the License.
             const entity = await this.$.user.get();
             resolved.push(entity);
           } catch (_) {
-            // fall back to the raw prefixed string if fetch fails
+            void _; // system/deleted users — fall back to raw prefixed string
             resolved.push(actor);
           }
         }

--- a/elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html
+++ b/elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html
@@ -37,7 +37,7 @@ limitations under the License.
       <template is="dom-if" if="[[_hasActorType(task.variables.participants, 'group')]]">
         <nuxeo-tags type="group" items="[[_getActorsByType(task.variables.participants, 'group')]]"></nuxeo-tags>
       </template>
-      <template is="dom-if" if="[[_resolvedUserParticipants.length]]">
+      <template is="dom-if" if="[[_showUserParticipants(_resolvedUserParticipants, _participantsLoading)]]">
         <nuxeo-tags type="user" items="[[_resolvedUserParticipants]]"></nuxeo-tags>
       </template>
     </div>
@@ -80,6 +80,11 @@ limitations under the License.
           type: Number,
           value: 0,
         },
+
+        _participantsLoading: {
+          type: Boolean,
+          value: false,
+        },
       },
 
       observers: ['_fetchUserParticipants(task.variables.participants)'],
@@ -89,16 +94,25 @@ limitations under the License.
           // Bump the request id so any in-flight resolve is invalidated and cannot
           // repopulate the participants after this reset.
           this._participantsRequestId += 1;
+          this._participantsLoading = false;
           this._resolvedUserParticipants = [];
           return undefined;
         }
-        const userActors = participants.filter((actor) => typeof actor === 'string' && actor.startsWith('user:'));
+        // De-duplicate while preserving order so we don't issue redundant /user lookups
+        // or render duplicate participant tags.
+        const userActors = [
+          ...new Set(participants.filter((actor) => typeof actor === 'string' && actor.startsWith('user:'))),
+        ];
         if (!userActors.length) {
           this._participantsRequestId += 1;
+          this._participantsLoading = false;
           this._resolvedUserParticipants = [];
           return undefined;
         }
         const requestId = ++this._participantsRequestId;
+        // Hide the (possibly stale) participants until the new resolve completes so a task
+        // switch never shows the previous task's participants.
+        this._participantsLoading = true;
         // Serialize invocations: the observer can re-fire (task switch) while a previous fetch
         // is still in flight, and every lookup mutates the `path` of a single shared
         // <nuxeo-resource> (this.$.user). Chaining runs sequentially prevents concurrent path
@@ -127,13 +141,16 @@ limitations under the License.
         }
         if (requestId !== this._participantsRequestId) return;
         this._resolvedUserParticipants = resolved;
+        this._participantsLoading = false;
+      },
+
+      _showUserParticipants(resolved, loading) {
+        return !loading && !!(resolved && resolved.length);
       },
 
       _hasActorType(actors, type) {
         return (
-          actors &&
-          Array.isArray(actors) &&
-          actors.findIndex((actor) => typeof actor === 'string' && actor.startsWith(type)) >= 0
+          actors && Array.isArray(actors) && actors.some((actor) => typeof actor === 'string' && actor.startsWith(type))
         );
       },
 

--- a/elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html
+++ b/elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html
@@ -29,13 +29,16 @@ limitations under the License.
         display: flex;
       }
     </style>
+
+    <nuxeo-resource id="user" path="/user"></nuxeo-resource>
+
     <div role="widget" class="participants">
       <label>[[i18n('wf.serialDocumentReview.participants')]]</label>
       <template is="dom-if" if="[[_hasActorType(task.variables.participants, 'group')]]">
         <nuxeo-tags type="group" items="[[_getActorsByType(task.variables.participants, 'group')]]"></nuxeo-tags>
       </template>
-      <template is="dom-if" if="[[_hasActorType(task.variables.participants, 'user')]]">
-        <nuxeo-tags type="user" items="[[_getActorsByType(task.variables.participants, 'user')]]"></nuxeo-tags>
+      <template is="dom-if" if="[[_resolvedUserParticipants.length]]">
+        <nuxeo-tags type="user" items="[[_resolvedUserParticipants]]"></nuxeo-tags>
       </template>
     </div>
 
@@ -67,6 +70,35 @@ limitations under the License.
          * @task var_task6d8
          */
         task: Object,
+
+        _resolvedUserParticipants: {
+          type: Array,
+          value: () => [],
+        },
+      },
+
+      observers: ['_fetchUserParticipants(task.variables.participants)'],
+
+      async _fetchUserParticipants(participants) {
+        if (!participants || !Array.isArray(participants)) return;
+        const userActors = participants.filter((actor) => actor.startsWith('user:'));
+        if (!userActors.length) {
+          this._resolvedUserParticipants = [];
+          return;
+        }
+        const resolved = [];
+        for (const actor of userActors) {
+          const username = actor.replace('user:', '');
+          try {
+            this.$.user.path = `/user/${username}`;
+            const entity = await this.$.user.get();
+            resolved.push(entity);
+          } catch (_) {
+            // fall back to the raw prefixed string if fetch fails
+            resolved.push(actor);
+          }
+        }
+        this._resolvedUserParticipants = resolved;
       },
 
       _hasActorType(actors, type) {

--- a/elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html
+++ b/elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html
@@ -94,7 +94,7 @@ limitations under the License.
             const entity = await this.$.user.get();
             resolved.push(entity);
           } catch (_) {
-            void _; // system/deleted users — fall back to raw prefixed string
+            // system/deleted users — fall back to raw prefixed string
             resolved.push(actor);
           }
         }

--- a/elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html
+++ b/elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html
@@ -75,32 +75,53 @@ limitations under the License.
           type: Array,
           value: () => [],
         },
+
+        _participantsRequestId: {
+          type: Number,
+          value: 0,
+        },
       },
 
       observers: ['_fetchUserParticipants(task.variables.participants)'],
 
-      async _fetchUserParticipants(participants) {
-        if (!participants || !Array.isArray(participants)) return;
-        const userActors = participants.filter((actor) => actor.startsWith('user:'));
+      _fetchUserParticipants(participants) {
+        if (!participants || !Array.isArray(participants)) {
+          this._resolvedUserParticipants = [];
+          return undefined;
+        }
+        const userActors = participants.filter((actor) => typeof actor === 'string' && actor.startsWith('user:'));
         if (!userActors.length) {
           this._resolvedUserParticipants = [];
-          return;
+          return undefined;
         }
+        const requestId = ++this._participantsRequestId;
+        // Serialize invocations: the observer can re-fire (task switch) while a previous fetch
+        // is still in flight, and every lookup mutates the `path` of a single shared
+        // <nuxeo-resource> (this.$.user). Chaining runs sequentially prevents concurrent path
+        // mutation and in-flight request aborts on that shared element.
+        const run = () => this._resolveUserParticipants(userActors, requestId);
+        const previous = this._participantsChain || Promise.resolve();
+        this._participantsChain = previous.catch(() => {}).then(run);
+        return this._participantsChain;
+      },
+
+      async _resolveUserParticipants(userActors, requestId) {
         const resolved = [];
         for (const actor of userActors) {
           const username = actor.replace('user:', '');
           try {
-            this.$.user.path = `/user/${username}`;
+            this.$.user.path = `/user/${encodeURIComponent(username)}`;
             const entity = await this.$.user.get();
             resolved.push(entity);
           } catch (error) {
-            if (error.status && error.status !== 404) {
-              console.warn(`Unexpected error resolving user "${username}":`, error.message);
+            if (error.status !== 404) {
+              console.warn(`Unexpected error resolving user "${username}":`, error);
             }
             // system/deleted users — fall back to raw prefixed string
             resolved.push(actor);
           }
         }
+        if (requestId !== this._participantsRequestId) return;
         this._resolvedUserParticipants = resolved;
       },
 

--- a/packages/nuxeo-web-ui-ftest/pages/ui/browser/document_comment.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/browser/document_comment.js
@@ -7,7 +7,7 @@ export default class DocumentComment {
 
   get author() {
     return (async () => {
-      const author = await this._el.element('.author');
+      const author = await this._el.element('nuxeo-user-tag');
       return author;
     })();
   }

--- a/packages/nuxeo-web-ui-ftest/pages/ui/browser/document_comment.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/browser/document_comment.js
@@ -7,7 +7,7 @@ export default class DocumentComment {
 
   get author() {
     return (async () => {
-      const author = await this._el.element('nuxeo-user-tag');
+      const author = await this._el.element('.author');
       return author;
     })();
   }

--- a/test/nuxeo-document-activity.test.js
+++ b/test/nuxeo-document-activity.test.js
@@ -246,7 +246,7 @@ suite('nuxeo-document-activity', () => {
     test('should handle fetch failure gracefully', async () => {
       sinon.stub(element.$.user, 'get').rejects(new Error('not found'));
       await element._fetchPrincipals([{ principalName: 'unknown', eventId: 'view' }]);
-      expect(element._principalEntities).to.not.have.property('unknown');
+      expect(element._principalEntities).to.have.property('unknown', 'unknown');
       element.$.user.get.restore();
     });
   });

--- a/test/nuxeo-document-activity.test.js
+++ b/test/nuxeo-document-activity.test.js
@@ -249,5 +249,29 @@ suite('nuxeo-document-activity', () => {
       expect(element._principalEntities).to.have.property('unknown', 'unknown');
       element.$.user.get.restore();
     });
+
+    test('should warn on unexpected non-404 errors', async () => {
+      const error = new Error('internal error');
+      error.status = 500;
+      sinon.stub(element.$.user, 'get').rejects(error);
+      const warnSpy = sinon.spy(console, 'warn');
+      await element._fetchPrincipals([{ principalName: 'baduser', eventId: 'view' }]);
+      expect(element._principalEntities).to.have.property('baduser', 'baduser');
+      expect(warnSpy).to.have.been.calledOnce;
+      warnSpy.restore();
+      element.$.user.get.restore();
+    });
+
+    test('should not warn on 404 errors', async () => {
+      const error = new Error('not found');
+      error.status = 404;
+      sinon.stub(element.$.user, 'get').rejects(error);
+      const warnSpy = sinon.spy(console, 'warn');
+      await element._fetchPrincipals([{ principalName: 'deleted', eventId: 'view' }]);
+      expect(element._principalEntities).to.have.property('deleted', 'deleted');
+      expect(warnSpy).to.not.have.been.called;
+      warnSpy.restore();
+      element.$.user.get.restore();
+    });
   });
 });

--- a/test/nuxeo-document-activity.test.js
+++ b/test/nuxeo-document-activity.test.js
@@ -323,5 +323,23 @@ suite('nuxeo-document-activity', () => {
       expect(paths).to.deep.equal(['/user/a', '/user/b', '/user/c']);
       element.$.user.get.restore();
     });
+
+    test('should discard in-flight results when activities is reset to empty mid-flight', async () => {
+      let resolveGet;
+      sinon.stub(element.$.user, 'get').returns(
+        new Promise((resolve) => {
+          resolveGet = resolve;
+        }),
+      );
+      const inFlight = element._fetchPrincipals([{ principalName: 'jdoe', eventId: 'view' }]);
+      await new Promise((r) => setTimeout(r, 0)); // let the in-flight lookup start
+      element._fetchPrincipals([]); // reset while the lookup is pending
+      expect(element._principalEntities).to.deep.equal({});
+      resolveGet({ 'entity-type': 'user', id: 'jdoe' });
+      await inFlight;
+      // The stale lookup must not repopulate the reset state.
+      expect(element._principalEntities).to.deep.equal({});
+      element.$.user.get.restore();
+    });
   });
 });

--- a/test/nuxeo-document-activity.test.js
+++ b/test/nuxeo-document-activity.test.js
@@ -207,4 +207,47 @@ suite('nuxeo-document-activity', () => {
       expect(element._gatherDuplicatedActivities(original).length).to.equal(2);
     });
   });
+
+  suite('_resolvedPrincipal', () => {
+    test('should return entity when present in map', () => {
+      const entity = { 'entity-type': 'user', id: 'jdoe', properties: { firstName: 'Jane', lastName: 'Doe' } };
+      expect(element._resolvedPrincipal('jdoe', { jdoe: entity })).to.equal(entity);
+    });
+
+    test('should fall back to raw username when not resolved', () => {
+      expect(element._resolvedPrincipal('jdoe', {})).to.equal('jdoe');
+    });
+
+    test('should fall back to raw username when entities is null', () => {
+      expect(element._resolvedPrincipal('jdoe', null)).to.equal('jdoe');
+    });
+  });
+
+  suite('_fetchPrincipals', () => {
+    test('should skip when activities is empty', async () => {
+      const getSpy = sinon.spy(element.$.user, 'get');
+      await element._fetchPrincipals([]);
+      expect(getSpy).to.not.have.been.called;
+      getSpy.restore();
+    });
+
+    test('should fetch user entity for each unique principal', async () => {
+      const entity = { 'entity-type': 'user', id: 'jdoe', properties: { firstName: 'Jane', lastName: 'Doe' } };
+      sinon.stub(element.$.user, 'get').resolves(entity);
+      await element._fetchPrincipals([
+        { principalName: 'jdoe', eventId: 'view' },
+        { principalName: 'jdoe', eventId: 'download' },
+      ]);
+      expect(element.$.user.get).to.have.been.calledOnce;
+      expect(element._principalEntities).to.have.property('jdoe', entity);
+      element.$.user.get.restore();
+    });
+
+    test('should handle fetch failure gracefully', async () => {
+      sinon.stub(element.$.user, 'get').rejects(new Error('not found'));
+      await element._fetchPrincipals([{ principalName: 'unknown', eventId: 'view' }]);
+      expect(element._principalEntities).to.not.have.property('unknown');
+      element.$.user.get.restore();
+    });
+  });
 });

--- a/test/nuxeo-document-activity.test.js
+++ b/test/nuxeo-document-activity.test.js
@@ -224,10 +224,14 @@ suite('nuxeo-document-activity', () => {
   });
 
   suite('_fetchPrincipals', () => {
-    test('should skip when activities is empty', async () => {
+    test('should skip fetching and reset state when activities is empty', async () => {
+      element._principalEntities = { stale: { id: 'stale' } };
+      element._principalsLoading = true;
       const getSpy = sinon.spy(element.$.user, 'get');
       await element._fetchPrincipals([]);
       expect(getSpy).to.not.have.been.called;
+      expect(element._principalEntities).to.deep.equal({});
+      expect(element._principalsLoading).to.be.false;
       getSpy.restore();
     });
 
@@ -245,8 +249,12 @@ suite('nuxeo-document-activity', () => {
 
     test('should handle fetch failure gracefully', async () => {
       sinon.stub(element.$.user, 'get').rejects(new Error('not found'));
+      const warnSpy = sinon.stub(console, 'warn');
       await element._fetchPrincipals([{ principalName: 'unknown', eventId: 'view' }]);
       expect(element._principalEntities).to.have.property('unknown', 'unknown');
+      // A statusless (e.g. network/transport) error is unexpected and should be logged.
+      expect(warnSpy).to.have.been.calledOnce;
+      warnSpy.restore();
       element.$.user.get.restore();
     });
 
@@ -254,7 +262,7 @@ suite('nuxeo-document-activity', () => {
       const error = new Error('internal error');
       error.status = 500;
       sinon.stub(element.$.user, 'get').rejects(error);
-      const warnSpy = sinon.spy(console, 'warn');
+      const warnSpy = sinon.stub(console, 'warn');
       await element._fetchPrincipals([{ principalName: 'baduser', eventId: 'view' }]);
       expect(element._principalEntities).to.have.property('baduser', 'baduser');
       expect(warnSpy).to.have.been.calledOnce;
@@ -266,11 +274,53 @@ suite('nuxeo-document-activity', () => {
       const error = new Error('not found');
       error.status = 404;
       sinon.stub(element.$.user, 'get').rejects(error);
-      const warnSpy = sinon.spy(console, 'warn');
+      const warnSpy = sinon.stub(console, 'warn');
       await element._fetchPrincipals([{ principalName: 'deleted', eventId: 'view' }]);
       expect(element._principalEntities).to.have.property('deleted', 'deleted');
       expect(warnSpy).to.not.have.been.called;
       warnSpy.restore();
+      element.$.user.get.restore();
+    });
+
+    test('should URL-encode principal names in the request path', async () => {
+      const entity = { 'entity-type': 'user', id: 'a b/c' };
+      const getStub = sinon.stub(element.$.user, 'get').callsFake(() => {
+        expect(element.$.user.path).to.equal('/user/a%20b%2Fc');
+        return Promise.resolve(entity);
+      });
+      await element._fetchPrincipals([{ principalName: 'a b/c', eventId: 'view' }]);
+      expect(getStub).to.have.been.calledOnce;
+      element.$.user.get.restore();
+    });
+
+    test('should discard stale responses via request-id guard', async () => {
+      const first = { 'entity-type': 'user', id: 'first' };
+      const second = { 'entity-type': 'user', id: 'second' };
+      sinon.stub(element.$.user, 'get').resolves(first);
+      const p1 = element._fetchPrincipals([{ principalName: 'first', eventId: 'view' }]);
+      element.$.user.get.resolves(second);
+      const p2 = element._fetchPrincipals([{ principalName: 'second', eventId: 'view' }]);
+      await Promise.all([p1, p2]);
+      expect(element._principalEntities).to.have.property('second');
+      expect(element._principalEntities).to.not.have.property('first');
+      element.$.user.get.restore();
+    });
+
+    test('should serialize concurrent invocations on the shared resource', async () => {
+      const paths = [];
+      sinon.stub(element.$.user, 'get').callsFake(() => {
+        // Record the path each lookup requests; interleaved runs would corrupt the order.
+        paths.push(element.$.user.path);
+        return Promise.resolve({ 'entity-type': 'user', id: element.$.user.path });
+      });
+      const p1 = element._fetchPrincipals([
+        { principalName: 'a', eventId: 'view' },
+        { principalName: 'b', eventId: 'view' },
+      ]);
+      const p2 = element._fetchPrincipals([{ principalName: 'c', eventId: 'view' }]);
+      await Promise.all([p1, p2]);
+      // Serialized: first invocation's lookups (a, b) complete before the second's (c).
+      expect(paths).to.deep.equal(['/user/a', '/user/b', '/user/c']);
       element.$.user.get.restore();
     });
   });

--- a/test/nuxeo-document-info-bar.test.js
+++ b/test/nuxeo-document-info-bar.test.js
@@ -161,5 +161,29 @@ suite('nuxeo-document-info-bar', () => {
       expect(element._initiatorEntities).to.have.property('unknown', 'unknown');
       element.$.user.get.restore();
     });
+
+    test('should warn on unexpected non-404 errors', async () => {
+      const error = new Error('internal error');
+      error.status = 500;
+      sinon.stub(element.$.user, 'get').rejects(error);
+      const warnSpy = sinon.spy(console, 'warn');
+      await element._fetchInitiators([{ initiator: 'baduser', id: 'wf2' }]);
+      expect(element._initiatorEntities).to.have.property('baduser', 'baduser');
+      expect(warnSpy).to.have.been.calledOnce;
+      warnSpy.restore();
+      element.$.user.get.restore();
+    });
+
+    test('should not warn on 404 errors', async () => {
+      const error = new Error('not found');
+      error.status = 404;
+      sinon.stub(element.$.user, 'get').rejects(error);
+      const warnSpy = sinon.spy(console, 'warn');
+      await element._fetchInitiators([{ initiator: 'deleted', id: 'wf3' }]);
+      expect(element._initiatorEntities).to.have.property('deleted', 'deleted');
+      expect(warnSpy).to.not.have.been.called;
+      warnSpy.restore();
+      element.$.user.get.restore();
+    });
   });
 });

--- a/test/nuxeo-document-info-bar.test.js
+++ b/test/nuxeo-document-info-bar.test.js
@@ -136,10 +136,14 @@ suite('nuxeo-document-info-bar', () => {
   });
 
   suite('_fetchInitiators', () => {
-    test('should skip when workflows is empty', async () => {
+    test('should skip fetching and reset state when workflows is empty', async () => {
+      element._initiatorEntities = { stale: { id: 'stale' } };
+      element._initiatorsLoading = true;
       const getSpy = sinon.spy(element.$.user, 'get');
       await element._fetchInitiators([]);
       expect(getSpy).to.not.have.been.called;
+      expect(element._initiatorEntities).to.deep.equal({});
+      expect(element._initiatorsLoading).to.be.false;
       getSpy.restore();
     });
 
@@ -157,8 +161,12 @@ suite('nuxeo-document-info-bar', () => {
 
     test('should keep raw username on fetch failure', async () => {
       sinon.stub(element.$.user, 'get').rejects(new Error('not found'));
+      const warnSpy = sinon.stub(console, 'warn');
       await element._fetchInitiators([{ initiator: 'unknown', id: 'wf1' }]);
       expect(element._initiatorEntities).to.have.property('unknown', 'unknown');
+      // A statusless (e.g. network/transport) error is unexpected and should be logged.
+      expect(warnSpy).to.have.been.calledOnce;
+      warnSpy.restore();
       element.$.user.get.restore();
     });
 
@@ -166,7 +174,7 @@ suite('nuxeo-document-info-bar', () => {
       const error = new Error('internal error');
       error.status = 500;
       sinon.stub(element.$.user, 'get').rejects(error);
-      const warnSpy = sinon.spy(console, 'warn');
+      const warnSpy = sinon.stub(console, 'warn');
       await element._fetchInitiators([{ initiator: 'baduser', id: 'wf2' }]);
       expect(element._initiatorEntities).to.have.property('baduser', 'baduser');
       expect(warnSpy).to.have.been.calledOnce;
@@ -178,11 +186,55 @@ suite('nuxeo-document-info-bar', () => {
       const error = new Error('not found');
       error.status = 404;
       sinon.stub(element.$.user, 'get').rejects(error);
-      const warnSpy = sinon.spy(console, 'warn');
+      const warnSpy = sinon.stub(console, 'warn');
       await element._fetchInitiators([{ initiator: 'deleted', id: 'wf3' }]);
       expect(element._initiatorEntities).to.have.property('deleted', 'deleted');
       expect(warnSpy).to.not.have.been.called;
       warnSpy.restore();
+      element.$.user.get.restore();
+    });
+
+    test('should URL-encode initiator ids in the request path', async () => {
+      const entity = { 'entity-type': 'user', id: 'a b/c' };
+      const getStub = sinon.stub(element.$.user, 'get').callsFake(() => {
+        expect(element.$.user.path).to.equal('/user/a%20b%2Fc');
+        return Promise.resolve(entity);
+      });
+      await element._fetchInitiators([{ initiator: 'a b/c', id: 'wf1' }]);
+      expect(getStub).to.have.been.calledOnce;
+      element.$.user.get.restore();
+    });
+
+    test('should discard stale responses via request-id guard', async () => {
+      const first = { 'entity-type': 'user', id: 'first' };
+      const second = { 'entity-type': 'user', id: 'second' };
+      sinon.stub(element.$.user, 'get').resolves(first);
+      // Start first fetch but do not await; bump the request id by starting a second.
+      const p1 = element._fetchInitiators([{ initiator: 'first', id: 'wf1' }]);
+      element.$.user.get.resolves(second);
+      const p2 = element._fetchInitiators([{ initiator: 'second', id: 'wf2' }]);
+      await Promise.all([p1, p2]);
+      // Only the latest fetch's results should be applied.
+      expect(element._initiatorEntities).to.have.property('second');
+      expect(element._initiatorEntities).to.not.have.property('first');
+      element.$.user.get.restore();
+    });
+
+    test('should serialize concurrent invocations on the shared resource', async () => {
+      const paths = [];
+      sinon.stub(element.$.user, 'get').callsFake(() => {
+        // Record the path each lookup requests; interleaved runs would corrupt the order.
+        paths.push(element.$.user.path);
+        return Promise.resolve({ 'entity-type': 'user', id: element.$.user.path });
+      });
+      const p1 = element._fetchInitiators([
+        { initiator: 'a', id: 'wf1' },
+        { initiator: 'b', id: 'wf2' },
+      ]);
+      const p2 = element._fetchInitiators([{ initiator: 'c', id: 'wf3' }]);
+      await Promise.all([p1, p2]);
+      // Serialized: first invocation's lookups (a, b) complete before the second's (c).
+      expect(paths).to.deep.equal(['/user/a', '/user/b', '/user/c']);
       element.$.user.get.restore();
     });
   });

--- a/test/nuxeo-document-info-bar.test.js
+++ b/test/nuxeo-document-info-bar.test.js
@@ -118,4 +118,48 @@ suite('nuxeo-document-info-bar', () => {
       expect(result).to.be.a('string');
     });
   });
+
+  suite('_resolvedInitiator', () => {
+    test('should return entity when present in map', () => {
+      const entity = { 'entity-type': 'user', id: 'jdoe', properties: { firstName: 'Jane', lastName: 'Doe' } };
+      const result = element._resolvedInitiator('jdoe', { jdoe: entity });
+      expect(result).to.equal(entity);
+    });
+
+    test('should fall back to raw username when not resolved', () => {
+      expect(element._resolvedInitiator('jdoe', {})).to.equal('jdoe');
+    });
+
+    test('should fall back to raw username when entities is null', () => {
+      expect(element._resolvedInitiator('jdoe', null)).to.equal('jdoe');
+    });
+  });
+
+  suite('_fetchInitiators', () => {
+    test('should skip when workflows is empty', async () => {
+      const getSpy = sinon.spy(element.$.user, 'get');
+      await element._fetchInitiators([]);
+      expect(getSpy).to.not.have.been.called;
+      getSpy.restore();
+    });
+
+    test('should fetch user entity for each unique initiator', async () => {
+      const entity = { 'entity-type': 'user', id: 'jdoe', properties: { firstName: 'Jane', lastName: 'Doe' } };
+      sinon.stub(element.$.user, 'get').resolves(entity);
+      await element._fetchInitiators([
+        { initiator: 'jdoe', id: 'wf1' },
+        { initiator: 'jdoe', id: 'wf2' },
+      ]);
+      expect(element.$.user.get).to.have.been.calledOnce;
+      expect(element._initiatorEntities).to.have.property('jdoe', entity);
+      element.$.user.get.restore();
+    });
+
+    test('should keep raw username on fetch failure', async () => {
+      sinon.stub(element.$.user, 'get').rejects(new Error('not found'));
+      await element._fetchInitiators([{ initiator: 'unknown', id: 'wf1' }]);
+      expect(element._initiatorEntities).to.not.have.property('unknown');
+      element.$.user.get.restore();
+    });
+  });
 });

--- a/test/nuxeo-document-info-bar.test.js
+++ b/test/nuxeo-document-info-bar.test.js
@@ -158,7 +158,7 @@ suite('nuxeo-document-info-bar', () => {
     test('should keep raw username on fetch failure', async () => {
       sinon.stub(element.$.user, 'get').rejects(new Error('not found'));
       await element._fetchInitiators([{ initiator: 'unknown', id: 'wf1' }]);
-      expect(element._initiatorEntities).to.not.have.property('unknown');
+      expect(element._initiatorEntities).to.have.property('unknown', 'unknown');
       element.$.user.get.restore();
     });
   });

--- a/test/nuxeo-document-info-bar.test.js
+++ b/test/nuxeo-document-info-bar.test.js
@@ -237,5 +237,23 @@ suite('nuxeo-document-info-bar', () => {
       expect(paths).to.deep.equal(['/user/a', '/user/b', '/user/c']);
       element.$.user.get.restore();
     });
+
+    test('should discard in-flight results when workflows is reset to empty mid-flight', async () => {
+      let resolveGet;
+      sinon.stub(element.$.user, 'get').returns(
+        new Promise((resolve) => {
+          resolveGet = resolve;
+        }),
+      );
+      const inFlight = element._fetchInitiators([{ initiator: 'jdoe', id: 'wf1' }]);
+      await new Promise((r) => setTimeout(r, 0)); // let the in-flight lookup start
+      element._fetchInitiators([]); // reset while the lookup is pending
+      expect(element._initiatorEntities).to.deep.equal({});
+      resolveGet({ 'entity-type': 'user', id: 'jdoe' });
+      await inFlight;
+      // The stale lookup must not repopulate the reset state.
+      expect(element._initiatorEntities).to.deep.equal({});
+      element.$.user.get.restore();
+    });
   });
 });

--- a/test/nuxeo-task6d8-layout.test.js
+++ b/test/nuxeo-task6d8-layout.test.js
@@ -97,6 +97,37 @@ suite('nuxeo-task6d8-layout', () => {
       element.$.user.get.restore();
     });
 
+    test('should de-duplicate repeated usernames before resolving', async () => {
+      const entity = { 'entity-type': 'user', id: 'jdoe', properties: { firstName: 'Jane', lastName: 'Doe' } };
+      sinon.stub(element.$.user, 'get').resolves(entity);
+      await element._fetchUserParticipants(['user:jdoe', 'user:jdoe', 'user:jdoe']);
+      // Only one lookup and one resolved entry despite the duplicates.
+      expect(element.$.user.get).to.have.been.calledOnce;
+      expect(element._resolvedUserParticipants).to.deep.equal([entity]);
+      element.$.user.get.restore();
+    });
+
+    test('should hide participants while loading and reveal once resolved', async () => {
+      let resolveGet;
+      sinon.stub(element.$.user, 'get').returns(
+        new Promise((resolve) => {
+          resolveGet = resolve;
+        }),
+      );
+      const inFlight = element._fetchUserParticipants(['user:jdoe']);
+      await new Promise((r) => setTimeout(r, 0)); // let the resolve start
+      // While loading, participants stay hidden.
+      expect(element._participantsLoading).to.be.true;
+      expect(element._showUserParticipants(element._resolvedUserParticipants, element._participantsLoading)).to.be
+        .false;
+      resolveGet({ 'entity-type': 'user', id: 'jdoe' });
+      await inFlight;
+      // Once resolved, loading clears and participants are shown.
+      expect(element._participantsLoading).to.be.false;
+      expect(element._showUserParticipants(element._resolvedUserParticipants, element._participantsLoading)).to.be.true;
+      element.$.user.get.restore();
+    });
+
     test('should URL-encode usernames in the request path', async () => {
       const entity = { 'entity-type': 'user', id: 'a b/c' };
       const getStub = sinon.stub(element.$.user, 'get').callsFake(() => {
@@ -219,6 +250,21 @@ suite('nuxeo-task6d8-layout', () => {
 
     test('_getActorsByType ignores non-string entries without throwing', () => {
       expect(element._getActorsByType([null, 42, { x: 1 }, 'user:jdoe'], 'user')).to.deep.equal(['user:jdoe']);
+    });
+  });
+
+  suite('_showUserParticipants', () => {
+    test('returns false while loading', () => {
+      expect(element._showUserParticipants([{ id: 'jdoe' }], true)).to.be.false;
+    });
+
+    test('returns false when there are no resolved participants', () => {
+      expect(element._showUserParticipants([], false)).to.be.false;
+      expect(element._showUserParticipants(undefined, false)).to.be.false;
+    });
+
+    test('returns true when resolved and not loading', () => {
+      expect(element._showUserParticipants([{ id: 'jdoe' }], false)).to.be.true;
     });
   });
 });

--- a/test/nuxeo-task6d8-layout.test.js
+++ b/test/nuxeo-task6d8-layout.test.js
@@ -170,6 +170,24 @@ suite('nuxeo-task6d8-layout', () => {
       expect(paths).to.deep.equal(['/user/a', '/user/b', '/user/c']);
       element.$.user.get.restore();
     });
+
+    test('should discard in-flight results when participants are reset to empty mid-flight', async () => {
+      let resolveGet;
+      sinon.stub(element.$.user, 'get').returns(
+        new Promise((resolve) => {
+          resolveGet = resolve;
+        }),
+      );
+      const inFlight = element._fetchUserParticipants(['user:jdoe']);
+      await new Promise((r) => setTimeout(r, 0)); // let the in-flight lookup start
+      element._fetchUserParticipants([]); // reset while the lookup is pending
+      expect(element._resolvedUserParticipants).to.deep.equal([]);
+      resolveGet({ 'entity-type': 'user', id: 'jdoe' });
+      await inFlight;
+      // The stale lookup must not repopulate the reset state.
+      expect(element._resolvedUserParticipants).to.deep.equal([]);
+      element.$.user.get.restore();
+    });
   });
 
   suite('_hasActorType / _getActorsByType', () => {
@@ -185,12 +203,22 @@ suite('nuxeo-task6d8-layout', () => {
       expect(element._hasActorType(undefined, 'group')).to.be.not.ok;
     });
 
+    test('_hasActorType ignores non-string entries without throwing', () => {
+      expect(() => element._hasActorType([null, 42, { x: 1 }, 'group:members'], 'group')).to.not.throw();
+      expect(element._hasActorType([null, 42, 'group:members'], 'group')).to.be.true;
+      expect(element._hasActorType([null, 42], 'group')).to.be.false;
+    });
+
     test('_getActorsByType filters actors by type', () => {
       expect(element._getActorsByType(['user:jdoe', 'group:members'], 'user')).to.deep.equal(['user:jdoe']);
     });
 
     test('_getActorsByType handles non-array input', () => {
       expect(element._getActorsByType(undefined, 'user')).to.be.not.ok;
+    });
+
+    test('_getActorsByType ignores non-string entries without throwing', () => {
+      expect(element._getActorsByType([null, 42, { x: 1 }, 'user:jdoe'], 'user')).to.deep.equal(['user:jdoe']);
     });
   });
 });

--- a/test/nuxeo-task6d8-layout.test.js
+++ b/test/nuxeo-task6d8-layout.test.js
@@ -1,0 +1,196 @@
+/**
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import '@webcomponents/html-imports/html-imports.min.js';
+import { Polymer } from '@polymer/polymer/polymer-legacy.js';
+import { fixture, html, flush } from '@nuxeo/testing-helpers';
+import { LayoutBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-layout-behavior.js';
+import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
+
+// The layout under test is a legacy HTML `dom-module` loaded via HTML imports.
+// Expose the globals its `<script>` registration relies on before importing it.
+window.Polymer = Polymer;
+const _nxRoot = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : {};
+_nxRoot.Nuxeo = _nxRoot.Nuxeo || {};
+_nxRoot.Nuxeo.LayoutBehavior = LayoutBehavior;
+
+// Resolve the layout HTML relative to this test module and load it through the HTML imports polyfill.
+const { url } = import.meta;
+const base = url.substring(0, url.lastIndexOf('/'));
+const layoutHref = `${base}/../elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html`;
+
+function loadHtmlImport(href) {
+  return new Promise((resolve, reject) => {
+    const link = document.createElement('link');
+    link.rel = 'import';
+    link.href = href;
+    link.onload = () => resolve();
+    link.onerror = (e) => reject(e);
+    document.head.appendChild(link);
+  });
+}
+
+suite('nuxeo-task6d8-layout', () => {
+  let element;
+
+  suiteSetup(async () => {
+    await loadHtmlImport(layoutHref);
+    await customElements.whenDefined('nuxeo-task6d8-layout');
+  });
+
+  setup(async () => {
+    element = await fixture(html`<nuxeo-task6d8-layout></nuxeo-task6d8-layout>`);
+    sinon.stub(element, 'i18n').callsFake((key) => key);
+    await flush();
+  });
+
+  suite('_fetchUserParticipants', () => {
+    test('should clear resolved participants when participants is undefined', async () => {
+      element._resolvedUserParticipants = [{ id: 'stale' }];
+      await element._fetchUserParticipants(undefined);
+      expect(element._resolvedUserParticipants).to.be.an('array').that.is.empty;
+    });
+
+    test('should clear resolved participants when participants is not an array', async () => {
+      element._resolvedUserParticipants = [{ id: 'stale' }];
+      await element._fetchUserParticipants('user:jdoe');
+      expect(element._resolvedUserParticipants).to.be.an('array').that.is.empty;
+    });
+
+    test('should clear resolved participants when there are no user actors', async () => {
+      element._resolvedUserParticipants = [{ id: 'stale' }];
+      const getSpy = sinon.spy(element.$.user, 'get');
+      await element._fetchUserParticipants(['group:members']);
+      expect(getSpy).to.not.have.been.called;
+      expect(element._resolvedUserParticipants).to.be.an('array').that.is.empty;
+      getSpy.restore();
+    });
+
+    test('should ignore non-string entries without throwing', async () => {
+      const entity = { 'entity-type': 'user', id: 'jdoe', properties: { firstName: 'Jane', lastName: 'Doe' } };
+      sinon.stub(element.$.user, 'get').resolves(entity);
+      await element._fetchUserParticipants([null, 42, { foo: 'bar' }, 'user:jdoe']);
+      expect(element.$.user.get).to.have.been.calledOnce;
+      expect(element._resolvedUserParticipants).to.deep.equal([entity]);
+      element.$.user.get.restore();
+    });
+
+    test('should resolve user entities for user actors', async () => {
+      const entity = { 'entity-type': 'user', id: 'jdoe', properties: { firstName: 'Jane', lastName: 'Doe' } };
+      sinon.stub(element.$.user, 'get').resolves(entity);
+      await element._fetchUserParticipants(['user:jdoe']);
+      expect(element._resolvedUserParticipants).to.deep.equal([entity]);
+      element.$.user.get.restore();
+    });
+
+    test('should URL-encode usernames in the request path', async () => {
+      const entity = { 'entity-type': 'user', id: 'a b/c' };
+      const getStub = sinon.stub(element.$.user, 'get').callsFake(() => {
+        expect(element.$.user.path).to.equal('/user/a%20b%2Fc');
+        return Promise.resolve(entity);
+      });
+      await element._fetchUserParticipants(['user:a b/c']);
+      expect(getStub).to.have.been.calledOnce;
+      element.$.user.get.restore();
+    });
+
+    test('should fall back to the raw actor string on 404 without warning', async () => {
+      const error = new Error('not found');
+      error.status = 404;
+      sinon.stub(element.$.user, 'get').rejects(error);
+      const warnSpy = sinon.stub(console, 'warn');
+      await element._fetchUserParticipants(['user:deleted']);
+      expect(element._resolvedUserParticipants).to.deep.equal(['user:deleted']);
+      expect(warnSpy).to.not.have.been.called;
+      warnSpy.restore();
+      element.$.user.get.restore();
+    });
+
+    test('should warn and fall back on unexpected non-404 errors', async () => {
+      const error = new Error('internal error');
+      error.status = 500;
+      sinon.stub(element.$.user, 'get').rejects(error);
+      const warnSpy = sinon.stub(console, 'warn');
+      await element._fetchUserParticipants(['user:baduser']);
+      expect(element._resolvedUserParticipants).to.deep.equal(['user:baduser']);
+      expect(warnSpy).to.have.been.calledOnce;
+      warnSpy.restore();
+      element.$.user.get.restore();
+    });
+
+    test('should warn and fall back on statusless (network) errors', async () => {
+      sinon.stub(element.$.user, 'get').rejects(new Error('network down'));
+      const warnSpy = sinon.stub(console, 'warn');
+      await element._fetchUserParticipants(['user:offline']);
+      expect(element._resolvedUserParticipants).to.deep.equal(['user:offline']);
+      expect(warnSpy).to.have.been.calledOnce;
+      warnSpy.restore();
+      element.$.user.get.restore();
+    });
+
+    test('should discard stale responses via request-id guard', async () => {
+      const first = { 'entity-type': 'user', id: 'first' };
+      const second = { 'entity-type': 'user', id: 'second' };
+      sinon.stub(element.$.user, 'get').resolves(first);
+      const p1 = element._fetchUserParticipants(['user:first']);
+      element.$.user.get.resolves(second);
+      const p2 = element._fetchUserParticipants(['user:second']);
+      await Promise.all([p1, p2]);
+      // Only the latest invocation should update the resolved participants.
+      expect(element._resolvedUserParticipants).to.have.lengthOf(1);
+      expect(element._resolvedUserParticipants[0]).to.have.property('id', 'second');
+      element.$.user.get.restore();
+    });
+
+    test('should serialize concurrent invocations on the shared resource', async () => {
+      const paths = [];
+      sinon.stub(element.$.user, 'get').callsFake(() => {
+        // Record the path each lookup requests; interleaved runs would corrupt the order.
+        paths.push(element.$.user.path);
+        return Promise.resolve({ 'entity-type': 'user', id: element.$.user.path });
+      });
+      const p1 = element._fetchUserParticipants(['user:a', 'user:b']);
+      const p2 = element._fetchUserParticipants(['user:c']);
+      await Promise.all([p1, p2]);
+      // Serialized: first invocation's lookups (a, b) complete before the second's (c).
+      expect(paths).to.deep.equal(['/user/a', '/user/b', '/user/c']);
+      element.$.user.get.restore();
+    });
+  });
+
+  suite('_hasActorType / _getActorsByType', () => {
+    test('_hasActorType returns true when an actor of the type exists', () => {
+      expect(element._hasActorType(['user:jdoe', 'group:members'], 'group')).to.be.true;
+    });
+
+    test('_hasActorType returns false when no actor of the type exists', () => {
+      expect(element._hasActorType(['user:jdoe'], 'group')).to.be.false;
+    });
+
+    test('_hasActorType handles non-array input', () => {
+      expect(element._hasActorType(undefined, 'group')).to.be.not.ok;
+    });
+
+    test('_getActorsByType filters actors by type', () => {
+      expect(element._getActorsByType(['user:jdoe', 'group:members'], 'user')).to.deep.equal(['user:jdoe']);
+    });
+
+    test('_getActorsByType handles non-array input', () => {
+      expect(element._getActorsByType(undefined, 'user')).to.be.not.ok;
+    });
+  });
+});


### PR DESCRIPTION
## Problem
User identity is displayed inconsistently across the UI — workflow initiators, activity principals, and serial review participants show raw usernames instead of full names. Jira: [WEBUI-1096](https://hyland.atlassian.net/browse/WEBUI-1096)

## Root cause
Components like `nuxeo-document-info-bar`, `nuxeo-document-activity`, and the serial review task layout were rendering initiator/principal usernames as plain strings instead of resolving them to user entities and displaying via `nuxeo-user-tag`.

## Changes
* **`elements/nuxeo-document-info-bar/nuxeo-document-info-bar.js`**: Added `_fetchInitiators` to resolve workflow initiator usernames to full user entities; `_initiatorsLoading` flag prevents flash of username.
* **`elements/nuxeo-document-activity/nuxeo-document-activity.js`**: Added `_fetchPrincipals` to resolve activity principal usernames; `_principalsLoading` flag prevents flash.
* **`elements/workflow/serialdocumentreview/nuxeo-task6d8-layout.html`**: Added `_fetchUserParticipants` to resolve serial review participant usernames to full entities.
* **`packages/nuxeo-web-ui-ftest/pages/ui/browser/document_comment.js`**: Updated FTest page object selector from `.author` to `nuxeo-user-tag` (aligns with nuxeo-elements comment component change).
* **`test/nuxeo-document-info-bar.test.js`**: Added tests for `_resolvedInitiator` and `_fetchInitiators`.
* **`test/nuxeo-document-activity.test.js`**: Added tests for `_resolvedPrincipal` and `_fetchPrincipals`.

## Test plan
- [x] `npm run lint` passes (0 errors)
- [x] `npm test` passes
- [ ] Manual verification: Workflow info-bar shows initiator full name, Activity tab shows principal full name, Serial review task shows participant full names

## Notes
Backport pair: see corresponding `lts-2025` PR. Depends on nuxeo-elements PR: ELEMENTS-1995.


[WEBUI-1096]: https://hyland.atlassian.net/browse/WEBUI-1096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ