### PR TITLE
WEBUI-2114: bump tmp to 0.2.7 to fix path traversal CVE-2026-44705 [maintenance-3.1.x]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24795,9 +24795,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/packages/nuxeo-web-ui-ftest/package-lock.json
+++ b/packages/nuxeo-web-ui-ftest/package-lock.json
@@ -9350,9 +9350,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"


### PR DESCRIPTION
## Problem
Dependabot reports a **high** severity path-traversal vulnerability (CVE-2026-44705) in the 	mp transitive dependency (< 0.2.6). Jira: [WEBUI-2114](https://hyland.atlassian.net/browse/WEBUI-2114)

## Root cause
The 	mp package (< 0.2.6) does not sanitize prefix/postfix parameters, enabling directory escape via path traversal.

## Changes
* **package-lock.json**: bumped 	mp from 0.2.5 to 0.2.7 (latest in ^0.2.4 range, patched).
* **packages/nuxeo-web-ui-ftest/package-lock.json**: bumped 	mp from 0.2.5 to 0.2.7.

## Test plan
- [x] 
pm run lint passes (ESLint clean; Prettier failures are pre-existing)
- [x] 
pm test — lockfile-only change, no source code modified
- [ ] Dependabot alerts #317 and #318 resolved after merge

## Notes
Backport PR: lts-2025 counterpart raised separately.

Made with [Cursor](https://cursor.com)

[WEBUI-2114]: https://hyland.atlassian.net/browse/WEBUI-2114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ