### PR TITLE
WEBUI-2117: upgrade launch-editor to 2.14.1 (CVE-2026-53632) [LTS-2025]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18447,14 +18447,14 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.2.tgz",
-      "integrity": "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.1.1",
-        "shell-quote": "^1.8.3"
+        "shell-quote": "^1.8.4"
       }
     },
     "node_modules/lazystream": {
@@ -23658,9 +23658,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     },
     "replace": {
       "minimatch": "^3.1.4"
-    }
+    },
+    "launch-editor": "^2.14.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary

Bump `launch-editor` from 2.13.2 to **2.14.1** via npm override to fix **medium** severity vulnerability (CVE-2026-53632 — NTLMv2 hash disclosure via UNC path handling on Windows).

Resolves Dependabot alert [#326](https://github.com/nuxeo/nuxeo-web-ui/security/dependabot).

Jira: [WEBUI-2117](https://hyland.atlassian.net/browse/WEBUI-2117)

## Changes

- Added `"launch-editor": "^2.14.1"` to `overrides` in `package.json`
- `package-lock.json` updated: `launch-editor` 2.13.2 → 2.14.1, `shell-quote` 1.8.3 → 1.10.0

## Acceptance Criteria

- [x] Dependabot alert #326 resolved
- [x] `npm run lint:eslint` passes
- [x] SonarQube Quality Gate passed


[WEBUI-2117]: https://hyland.atlassian.net/browse/WEBUI-2117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ