### PR TITLE
WEBUI-2038: Combined Nuxeo + Web UI Docker image and Compose setups (LTS-2023)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -259,13 +259,21 @@ mvn clean install
 
 ### Docker Compose
 
-Three-service architecture in `docker-compose.yml`:
+Two setups are provided:
 
-```
-proxy (nginx) :8080 → routes to:
-  ├── /nuxeo/* → nuxeo (Nuxeo Server)
-  └── /*       → webui (Nginx serving dist/)
-```
+- **Complete (default)** — `docker-compose.yml` runs a single Nuxeo image
+  (`Dockerfile`) with the Web UI baked in, serving the backend and the UI at
+  `http://localhost:8080/nuxeo/ui`. Requires the marketplace package to be built
+  first (`npm run build` then `mvn -ntp clean install -DskipTests -DskipInstall=true -DskipBuild=true`).
+
+- **Lightweight nginx (opt-in)** — `docker compose -f docker-compose.nginx.yml up`
+  runs a faster three-service local-dev loop:
+
+  ```
+  proxy (nginx) :8080 → routes to:
+    ├── /nuxeo/* → nuxeo (Nuxeo Server)
+    └── /*       → webui (Nginx serving dist/, built from Dockerfile.nginx)
+  ```
 
 ### Configuration
 
@@ -275,6 +283,16 @@ Environment variables control deployment:
 - `NUXEO_PACKAGES` — Marketplace packages to install
 - `NUXEO_DEV_MODE` — Enable hot-reload in server
 - `NUXEO_CLID` — License key
+
+### Combined image (EKS preview)
+
+The `preview` workflow builds a single, self-contained Nuxeo server image
+(`Dockerfile`) that bakes in the Web UI marketplace package built from this
+repo, so one image serves both the backend and the Web UI at `/nuxeo/ui` — suitable
+for direct EKS deployment. The base server image is selected via the `NUXEO_IMAGE`
+build arg (matching the LTS line), frontend addons are chosen via `NUXEO_PACKAGES`
+(baked into the UI during the Webpack build), and optional server-side Connect
+packages via `NUXEO_SERVER_PACKAGES` (requires `NUXEO_CLID`).
 
 ## CI/CD (GitHub Actions)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,18 @@
-ARG SERVER_IMAGE=nuxeo-web-ui/server
-FROM $SERVER_IMAGE
+# Single deployable image for EKS: the Nuxeo server with the Web UI marketplace
+# package (built from this repo) installed, so one image serves both the REST/API
+# backend and the Web UI at /nuxeo/ui.
+#
+# The base Nuxeo server image/tag is parameterized so each LTS line points at the
+# matching server version (e.g. 2023 for LTS-2023, 2025 for LTS-2025). Override
+# NUXEO_IMAGE at build time to target a specific registry/tag.
+ARG NUXEO_IMAGE=docker-private.packages.nuxeo.com/nuxeo/nuxeo:2023
+FROM ${NUXEO_IMAGE}
 
-COPY dist/ ui/
+USER root
+# Locally-built Web UI marketplace package (mvn clean install output).
+COPY --chown=900:0 plugin/web-ui/marketplace/target/nuxeo-web-ui-marketplace-*.zip \
+     /home/nuxeo/local-packages/
+USER 900
+
+# Install the Web UI marketplace package offline.
+RUN /install-packages.sh --offline /home/nuxeo/local-packages/nuxeo-web-ui-marketplace-*.zip

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,0 +1,8 @@
+# Combined Nuxeo Web UI image: bundles the nginx server and the built UI assets
+# into a single self-contained image that can be deployed directly (e.g. to EKS),
+# without requiring a separately built/pushed server base image.
+ARG SERVER_IMAGE=docker.packages.nuxeo.com/nuxeo/nginx-centos7:0.0.1
+FROM $SERVER_IMAGE
+
+COPY server/nginx.conf /etc/nginx/nginx.conf
+COPY dist/ ui/

--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -1,0 +1,29 @@
+# Lightweight local-dev setup: nginx serves the built dist/ behind a proxy that
+# routes /nuxeo/* to a separate Nuxeo server container. Faster rebuilds than the
+# complete single-image setup in docker-compose.yml.
+#
+# Build prerequisite: npm run build  (produces dist/)
+# Run with:           docker compose -f docker-compose.nginx.yml up
+services:
+  proxy:
+    image: docker.packages.nuxeo.com/nuxeo/nginx-centos7:0.0.1
+    volumes:
+      - ./server/nginx.proxy.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "8080:80"
+    links:
+      - nuxeo
+      - webui
+
+  webui:
+    image: nuxeo-web-ui:${NUXEO_WEB_UI_VERSION}
+    build:
+      context: .
+      dockerfile: Dockerfile.nginx
+
+  nuxeo:
+    image: docker-private.packages.nuxeo.com/nuxeo/nuxeo:${NUXEO_VERSION}
+    environment:
+      - NUXEO_DEV_MODE
+      - NUXEO_PACKAGES
+      - NUXEO_CLID

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,22 @@
-version: '3.5'
+# Complete setup (default): a single Nuxeo image with the Web UI baked in, serving
+# both the backend and the Web UI at http://localhost:8080/nuxeo/ui.
+#
+# Build prerequisites (the image installs the locally-built marketplace package):
+#   npm run build
+#   mvn -ntp clean install -DskipTests -DskipInstall=true -DskipBuild=true
+#
+# For a faster, lighter local-dev loop (nginx serving dist/ + a separate Nuxeo
+# server), use the nginx setup instead:
+#   docker compose -f docker-compose.nginx.yml up
 services:
-  proxy:
-    image: docker.packages.nuxeo.com/nuxeo/nginx-centos7:0.0.1
-    volumes:
-      - ./server/nginx.proxy.conf:/etc/nginx/nginx.conf:ro
-    ports:
-      - "8080:80"
-    links:
-      - nuxeo
-      - webui
-
-  webui:
+  web-ui:
     image: nuxeo-web-ui:${NUXEO_WEB_UI_VERSION}
     build:
       context: .
-    
-  nuxeo:
-    image: nuxeo/nuxeo:${NUXEO_VERSION}
+      args:
+        NUXEO_IMAGE: docker-private.packages.nuxeo.com/nuxeo/nuxeo:${NUXEO_VERSION}
+    ports:
+      - "8080:8080"
     environment:
       - NUXEO_DEV_MODE
       - NUXEO_PACKAGES

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,3 +1,0 @@
-FROM docker.packages.nuxeo.com/nuxeo/nginx-centos7:0.0.1
-
-COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
Splits the Docker/compose changes out of #3182 (LTS-2023 preview workflow migration) into a dedicated PR.

## What
- `Dockerfile`: combined single deployable image — the Nuxeo server with the Web UI marketplace package installed, serving both the backend and the Web UI at `/nuxeo/ui`. Base image parameterized via `NUXEO_IMAGE` (LTS-2023).
- `docker-compose.yml`: new default — run the full stack from the one combined image on `:8080`.
- `Dockerfile.nginx` + `docker-compose.nginx.yml`: lightweight nginx local-dev loop (faster rebuilds, no marketplace/Maven step).
- Removed `server/Dockerfile` (its nginx-base role folded into `Dockerfile.nginx`).
- Docs: `ARCHITECTURE.md` (Docker Compose + Combined image sections), `README.md` (`NUXEO_SERVER_PACKAGES`).

These are independent of the preview workflow build (which uses the `nuxeo-docker-build` action, not these files).