### PR TITLE
ELEMENTS-1595: resolve workflow graph transition labels via i18n (maintenance-3.1.x)

### DIFF
--- a/elements/nuxeo-workflow-graph/nuxeo-workflow-graph.js
+++ b/elements/nuxeo-workflow-graph/nuxeo-workflow-graph.js
@@ -317,12 +317,17 @@ Polymer({
   },
 
   _transitionOverlay(transition) {
+    // Transition labels come from the `/graph` REST endpoint exactly as configured in Studio.
+    // Built-in transitions expose a human-readable label, but custom transitions expose an i18n
+    // key (e.g. `command.remove`) that the platform does not resolve, so translate it here like
+    // every other Web UI label. `i18n` falls back to the key itself when no translation exists.
+    const label = this.i18n(transition.label);
     return [
       ['Arrow', { location: 0.8 }, { foldback: 0.9, fill: '#92e1aa', width: 14 }],
       [
         'Label',
         {
-          label: `<span title="${transition.label}">${transition.label}</span>`,
+          label: `<span title="${label}">${label}</span>`,
           cssClass: 'workflow_connection_label',
           location: 0.6,
         },

--- a/elements/nuxeo-workflow-graph/nuxeo-workflow-graph.js
+++ b/elements/nuxeo-workflow-graph/nuxeo-workflow-graph.js
@@ -23,6 +23,7 @@ import '@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js';
 import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
 import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { I18nBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-i18n-behavior.js';
+import { escapeHTML } from '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-selectivity.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-dialog.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
@@ -321,7 +322,10 @@ Polymer({
     // Built-in transitions expose a human-readable label, but custom transitions expose an i18n
     // key (e.g. `command.remove`) that the platform does not resolve, so translate it here like
     // every other Web UI label. `i18n` falls back to the key itself when no translation exists.
-    const label = this.i18n(transition.label);
+    // Escape the result before interpolating it into the overlay markup: labels (and their
+    // translations) are admin/Studio-configured and may contain quotes or HTML-significant
+    // characters that would otherwise break the markup or allow injection.
+    const label = escapeHTML(this.i18n(transition.label));
     return [
       ['Arrow', { location: 0.8 }, { foldback: 0.9, fill: '#92e1aa', width: 14 }],
       [

--- a/test/nuxeo-workflow-graph.test.js
+++ b/test/nuxeo-workflow-graph.test.js
@@ -87,6 +87,17 @@ suite('nuxeo-workflow-graph', () => {
       expect(element.i18n).to.have.been.calledWith('command.remove');
       expect(labelOverlay[1].label).to.equal('<span title="Remove">Remove</span>');
     });
+
+    test('should escape HTML in the transition label to prevent injection (ELEMENTS-1595)', () => {
+      // Labels are admin/Studio-configured and their translations may contain quotes or markup;
+      // they must be escaped before being interpolated into the overlay HTML.
+      element.i18n.withArgs('evil').returns('"><img src=x onerror=alert(1)>');
+      const result = element._transitionOverlay({ label: 'evil', path: '1-2' });
+      const labelOverlay = result.find((overlay) => overlay[0] === 'Label');
+      expect(labelOverlay[1].label).to.not.contain('<img');
+      expect(labelOverlay[1].label).to.contain('&lt;img');
+      expect(labelOverlay[1].label).to.contain('&quot;');
+    });
   });
 
   suite('show', () => {

--- a/test/nuxeo-workflow-graph.test.js
+++ b/test/nuxeo-workflow-graph.test.js
@@ -77,6 +77,16 @@ suite('nuxeo-workflow-graph', () => {
       const result = element._transitionOverlay(transition);
       expect(result).to.be.an('array');
     });
+
+    test('should translate the transition label via i18n (ELEMENTS-1595)', () => {
+      // Custom transitions expose an i18n key (e.g. `command.remove`) rather than a resolved
+      // string; the overlay must display the translation, not the raw key.
+      element.i18n.withArgs('command.remove').returns('Remove');
+      const result = element._transitionOverlay({ label: 'command.remove', path: '1-2' });
+      const labelOverlay = result.find((overlay) => overlay[0] === 'Label');
+      expect(element.i18n).to.have.been.calledWith('command.remove');
+      expect(labelOverlay[1].label).to.equal('<span title="Remove">Remove</span>');
+    });
   });
 
   suite('show', () => {


### PR DESCRIPTION
Backport of #3351 to `maintenance-3.1.x` (ticket fixVersion **3.1.x**).

## Problem
In the workflow graph (**View graph**), a custom Studio transition whose label is an i18n key (e.g. `command.remove`) displayed the **raw key** instead of its translation, while built-in transitions (*Approve*/*Reject*) rendered correctly. See [ELEMENTS-1595](https://hyland.atlassian.net/browse/ELEMENTS-1595).

## Root cause
`elements/nuxeo-workflow-graph/nuxeo-workflow-graph.js` → `_transitionOverlay(transition)` interpolated `transition.label` verbatim; the `/graph` endpoint returns custom-transition labels as unresolved i18n keys, and the graph never ran them through `i18n()`.

## Changes
- Translate `transition.label` via the `I18nBehavior` `i18n()` helper (visible text + `title` tooltip). `i18n()` falls back to the key when no translation exists, so resolved labels are unchanged.
- Unit test asserting translation (`command.remove` → `Remove`).

## Test plan
- `npm run lint` — clean (pre-commit hook).
- `npm test` — full suite (see CI).
- A/B verified in a live instance; before/after screenshots + recordings attached to the ticket.

Made with [Cursor](https://cursor.com)

[ELEMENTS-1595]: https://hyland.atlassian.net/browse/ELEMENTS-1595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ