### PR TITLE
CI: Cancel superseded cross-repo ftest runs via concurrency group [maintenance-3.1.x] (https://hyland.atlassian.net/browse/WEBUI-2171)

### DIFF
--- a/.github/workflows/cross-repo.yaml
+++ b/.github/workflows/cross-repo.yaml
@@ -48,11 +48,11 @@ on:
 
 # Cancel a superseded in-flight run for the same source branch when a newer commit is dispatched, so
 # rapid pushes don't stack multiple ~1h ftest runs (previously done by manually cancelling old runs).
-# Keyed by BOTH the target base branch (github.ref, e.g. lts-2025 vs maintenance-3.1.x) and the
-# dispatching source branch, so parallel runs for different bases never cancel each other even when
-# they share the same branch_name.
+# Keyed by BOTH the target base branch (github.ref_name, e.g. lts-2025 vs maintenance-3.1.x — the bare
+# name, without the refs/heads/ prefix) and the dispatching source branch, so parallel runs for
+# different bases never cancel each other even when they share the same branch_name.
 concurrency:
-  group: cross-repo-${{ github.ref }}-${{ github.event.inputs.branch_name }}
+  group: cross-repo-${{ github.ref_name }}-${{ github.event.inputs.branch_name }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/cross-repo.yaml
+++ b/.github/workflows/cross-repo.yaml
@@ -46,10 +46,13 @@ on:
         type: string
         required: false
 
-# Cancel an in-flight cross-repo run for the same branch when a newer one is dispatched, so
+# Cancel a superseded in-flight run for the same source branch when a newer commit is dispatched, so
 # rapid pushes don't stack multiple ~1h ftest runs (previously done by manually cancelling old runs).
+# Keyed by BOTH the target base branch (github.ref, e.g. lts-2025 vs maintenance-3.1.x) and the
+# dispatching source branch, so parallel runs for different bases never cancel each other even when
+# they share the same branch_name.
 concurrency:
-  group: cross-repo-${{ github.event.inputs.branch_name }}
+  group: cross-repo-${{ github.ref }}-${{ github.event.inputs.branch_name }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/cross-repo.yaml
+++ b/.github/workflows/cross-repo.yaml
@@ -46,6 +46,12 @@ on:
         type: string
         required: false
 
+# Cancel an in-flight cross-repo run for the same branch when a newer one is dispatched, so
+# rapid pushes don't stack multiple ~1h ftest runs (previously done by manually cancelling old runs).
+concurrency:
+  group: cross-repo-${{ github.event.inputs.branch_name }}
+  cancel-in-progress: true
+
 env:
   REFERENCE_BRANCH: maintenance-3.1.x
   NPM_REPOSITORY: https://packages.nuxeo.com/repository/npm-public/


### PR DESCRIPTION
## Summary
Adds a top-level `concurrency` group to the cross-repo check so that when a newer commit is pushed for the same source branch, the in-flight (~1h) functional-test run is **automatically cancelled** instead of running to completion alongside the new one.

```yaml
concurrency:
  group: cross-repo-${{ github.ref_name }}-${{ github.event.inputs.branch_name }}
  cancel-in-progress: true
```

The group is keyed by **both** the target base branch (`github.ref_name`, e.g. `lts-2025` vs `maintenance-3.1.x`) and the dispatching source branch, so parallel runs for different bases never cancel each other even when they share the same `branch_name`.

## Why
This is the workflow that actually runs the ftests (dispatched from the Elements `web-ui` check). Rapid pushes previously stacked multiple hour-long runs; maintainers were cancelling stale runs by hand. This makes that automatic and saves runner time. Ftests remain a mandatory check — this only cancels **superseded** runs for the same base + source branch.

## Related
- Flaky ftest failures seen on this PR (Nuxeo test server unavailable mid-run) are tracked separately in [WEBUI-2171](https://hyland.atlassian.net/browse/WEBUI-2171) and are unrelated to this change.

## Test plan
- [ ] Push twice in quick succession to a PR branch; confirm the first cross-repo run is cancelled when the second is dispatched.
- [ ] Confirm a single push still runs ftests to completion and reports status as before.
- [ ] Confirm a parallel run on the other base branch is **not** cancelled.

Made with [Cursor](https://cursor.com)

[WEBUI-2171]: https://hyland.atlassian.net/browse/WEBUI-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ