### PR TITLE
WEBUI-2115: Fix ws high CVE-2026-48779 (GHSA-96hv-2xvq-fx4p)

### DIFF
--- a/plugin/a11y/package-lock.json
+++ b/plugin/a11y/package-lock.json
@@ -8223,9 +8223,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
Bump the transitive runtime dependency ws from 8.20.1 to 8.21.0 in the plugin/a11y sub-package lockfile to resolve the high-severity DoS advisory GHSA-96hv-2xvq-fx4p, where a flood of tiny fragments/data chunks could exhaust memory (OOM) beyond the documented message-size limit. Pulled in via webdriver (^8.8.0), which accepts 8.21.0, so only plugin/a11y/package-lock.json changes.