### PR TITLE
WEBUI-2113: Fix form-data high CVE-2026-12143 (GHSA-hmw2-7cc7-3qxx)

### DIFF
--- a/packages/nuxeo-web-ui-ftest/package-lock.json
+++ b/packages/nuxeo-web-ui-ftest/package-lock.json
@@ -6011,9 +6011,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",


### PR DESCRIPTION
Bump the transitive runtime dependency form-data from 4.0.5 to 4.0.6 in the nuxeo-web-ui-ftest sub-package lockfile to resolve the high-severity CRLF-injection advisory GHSA-hmw2-7cc7-3qxx, where unescaped CR/LF/quote characters in multipart field names/filenames allowed header/field injection. Pulled in via nuxeo (^4.0.0), which accepts 4.0.6, so only packages/nuxeo-web-ui-ftest/package-lock.json changes.