### PR TITLE
WEBUI-2177: Keep spaces in filenames rendered by the template button [maintenance-3.1.x]

### DIFF
--- a/addons/nuxeo-template-rendering/elements/nuxeo-render-template-button.js
+++ b/addons/nuxeo-template-rendering/elements/nuxeo-render-template-button.js
@@ -274,13 +274,19 @@ Polymer({
    * (`"my file.pdf"` would be saved as `_my file.pdf_`).
    */
   _filenameFromContentDisposition(contentDisposition) {
-    const extended = contentDisposition.match(/filename\*\s*=\s*[^']*'[^']*'([^;\n]*)/i);
+    // The quoted and unquoted forms are matched separately so that no quantifier can consume the
+    // same character as the one after it, which keeps matching linear on long headers.
+    const extended = contentDisposition.match(/filename\*[ \t]*=[^';\n]*'[^';\n]*'([^;\n]*)/i);
     if (extended) {
       return decodeURIComponent(extended[1].trim());
     }
-    const plain = contentDisposition.match(/filename\s*=\s*("([^"]*)"|[^;\n]*)/i);
+    const quoted = contentDisposition.match(/filename[ \t]*=[ \t]*"([^"]*)"/i);
+    if (quoted) {
+      return decodeURI(quoted[1]);
+    }
+    const plain = contentDisposition.match(/filename[ \t]*=([^;\n]*)/i);
     if (plain) {
-      return decodeURI((plain[2] !== undefined ? plain[2] : plain[1]).trim());
+      return decodeURI(plain[1].trim());
     }
     return '';
   },

--- a/addons/nuxeo-template-rendering/elements/nuxeo-render-template-button.js
+++ b/addons/nuxeo-template-rendering/elements/nuxeo-render-template-button.js
@@ -264,13 +264,31 @@ Polymer({
     });
   },
 
+  /**
+   * Extracts the filename from a `Content-Disposition` header value.
+   *
+   * The RFC 5987 `filename*` form is preferred because it is percent-encoded and unquoted. The
+   * plain `filename` form is only a fallback, and its surrounding double quotes are stripped:
+   * servers quote the value whenever it is not a bare token (spaces, non-ASCII), and browsers
+   * replace those quotes with underscores when they end up in an anchor's `download` attribute
+   * (`"my file.pdf"` would be saved as `_my file.pdf_`).
+   */
+  _filenameFromContentDisposition(contentDisposition) {
+    const extended = contentDisposition.match(/filename\*\s*=\s*[^']*'[^']*'([^;\n]*)/i);
+    if (extended) {
+      return decodeURIComponent(extended[1].trim());
+    }
+    const plain = contentDisposition.match(/filename\s*=\s*("([^"]*)"|[^;\n]*)/i);
+    if (plain) {
+      return decodeURI((plain[2] !== undefined ? plain[2] : plain[1]).trim());
+    }
+    return '';
+  },
+
   _download(response) {
     const contentDisposition = response.headers.get('Content-Disposition');
     if (contentDisposition) {
-      const filenameMatches = contentDisposition
-        .match(/filename[^;=\n]*=([^;\n]*''([^;\n]*)|[^;\n]*)/)
-        .filter((match) => !!match);
-      const filename = decodeURI(filenameMatches[filenameMatches.length - 1]);
+      const filename = this._filenameFromContentDisposition(contentDisposition);
       return response.blob().then((blob) => {
         if (navigator.msSaveBlob) {
           // handle IE11 and Edge

--- a/addons/nuxeo-template-rendering/elements/nuxeo-render-template-button.js
+++ b/addons/nuxeo-template-rendering/elements/nuxeo-render-template-button.js
@@ -277,18 +277,43 @@ Polymer({
     // The quoted and unquoted forms are matched separately so that no quantifier can consume the
     // same character as the one after it, which keeps matching linear on long headers.
     const extended = contentDisposition.match(/filename\*[ \t]*=[^';\n]*'[^';\n]*'([^;\n]*)/i);
-    if (extended) {
-      return decodeURIComponent(extended[1].trim());
-    }
     const quoted = contentDisposition.match(/filename[ \t]*=[ \t]*"([^"]*)"/i);
-    if (quoted) {
-      return decodeURI(quoted[1]);
-    }
     const plain = contentDisposition.match(/filename[ \t]*=([^;\n]*)/i);
+    if (extended) {
+      const value = extended[1].trim();
+      const decoded = this._decodeFilename(value, decodeURIComponent);
+      if (decoded !== null) {
+        return decoded;
+      }
+      // An undecodable `filename*` still leaves the plain form usable, so only take the raw value
+      // when the server sent nothing else.
+      if (!quoted && !plain) {
+        return value;
+      }
+    }
+    if (quoted) {
+      const decoded = this._decodeFilename(quoted[1], decodeURI);
+      return decoded === null ? quoted[1] : decoded;
+    }
     if (plain) {
-      return decodeURI(plain[1].trim());
+      const value = plain[1].trim();
+      const decoded = this._decodeFilename(value, decodeURI);
+      return decoded === null ? value : decoded;
     }
     return '';
+  },
+
+  /**
+   * Decodes a filename read from the header, or returns `null` when it carries malformed
+   * percent-encoding: both decoders throw a `URIError` on such values, which would otherwise turn
+   * a cosmetic naming problem into a failed download.
+   */
+  _decodeFilename(value, decode) {
+    try {
+      return decode(value);
+    } catch (_) {
+      return null;
+    }
   },
 
   _download(response) {

--- a/addons/nuxeo-template-rendering/test/nuxeo-render-template-button.test.js
+++ b/addons/nuxeo-template-rendering/test/nuxeo-render-template-button.test.js
@@ -261,6 +261,11 @@ suite('nuxeo-render-template-button', () => {
         expected: 'rapport été.pdf',
       },
       {
+        name: 'keeps a semicolon that belongs to a quoted filename',
+        header: 'attachment; filename="draft; final.pdf"',
+        expected: 'draft; final.pdf',
+      },
+      {
         name: 'returns an empty name when the header carries no filename',
         header: 'attachment',
         expected: '',

--- a/addons/nuxeo-template-rendering/test/nuxeo-render-template-button.test.js
+++ b/addons/nuxeo-template-rendering/test/nuxeo-render-template-button.test.js
@@ -266,6 +266,21 @@ suite('nuxeo-render-template-button', () => {
         expected: 'draft; final.pdf',
       },
       {
+        name: 'falls back to the plain form when filename* is malformed',
+        header: `attachment; filename="my file.pdf"; filename*=UTF-8''my%file.pdf`,
+        expected: 'my file.pdf',
+      },
+      {
+        name: 'keeps a malformed filename* raw when it is the only form sent',
+        header: `attachment; filename*=UTF-8''my%file.pdf`,
+        expected: 'my%file.pdf',
+      },
+      {
+        name: 'keeps a malformed plain filename raw',
+        header: 'attachment; filename="my%file.pdf"',
+        expected: 'my%file.pdf',
+      },
+      {
         name: 'returns an empty name when the header carries no filename',
         header: 'attachment',
         expected: '',

--- a/addons/nuxeo-template-rendering/test/nuxeo-render-template-button.test.js
+++ b/addons/nuxeo-template-rendering/test/nuxeo-render-template-button.test.js
@@ -210,5 +210,65 @@ suite('nuxeo-render-template-button', () => {
         clickSpy.restore();
       }
     });
+
+    test('saves a filename with spaces without the quotes the server added', async () => {
+      const response = {
+        headers: {
+          get: (name) =>
+            name === 'Content-Disposition'
+              ? `attachment; filename="my file.pdf"; filename*=UTF-8''my%20file.pdf`
+              : null,
+        },
+        blob: () => Promise.resolve(new Blob(['x'])),
+      };
+      const createSpy = sinon.stub(URL, 'createObjectURL').returns('blob:mock-url');
+      const revokeSpy = sinon.stub(URL, 'revokeObjectURL');
+      let downloadAttr;
+      const clickSpy = sinon.stub(HTMLAnchorElement.prototype, 'click').callsFake(function () {
+        downloadAttr = this.getAttribute('download');
+      });
+      try {
+        await el._download(response);
+        expect(downloadAttr).to.equal('my file.pdf');
+      } finally {
+        createSpy.restore();
+        revokeSpy.restore();
+        clickSpy.restore();
+      }
+    });
+  });
+
+  suite('_filenameFromContentDisposition', () => {
+    [
+      {
+        name: 'prefers the unquoted filename* form over the quoted filename form',
+        header: `attachment; filename="my file.pdf"; filename*=UTF-8''my%20file.pdf`,
+        expected: 'my file.pdf',
+      },
+      {
+        name: 'reads an unquoted plain filename',
+        header: 'attachment; filename=plain.pdf',
+        expected: 'plain.pdf',
+      },
+      {
+        name: 'strips the quotes from a quoted plain filename',
+        header: 'attachment; filename="quoted file.pdf"',
+        expected: 'quoted file.pdf',
+      },
+      {
+        name: 'decodes a percent-encoded non-ASCII filename* value',
+        header: `attachment; filename*=UTF-8''rapport%20%C3%A9t%C3%A9.pdf`,
+        expected: 'rapport été.pdf',
+      },
+      {
+        name: 'returns an empty name when the header carries no filename',
+        header: 'attachment',
+        expected: '',
+      },
+    ].forEach(({ name, header, expected }) => {
+      test(name, () => {
+        expect(el._filenameFromContentDisposition(header)).to.equal(expected);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Problem
When Nuxeo Template Rendering renders a template whose filename contains spaces,
`nuxeo-render-template-button` saves it wrapped in underscores — `my file.docx` is written to disk as
`_my file.docx_` — and the file fails to open when double-clicked.
Jira: [WEBUI-2177](https://hyland.atlassian.net/browse/WEBUI-2177)

## Root cause
`_download()` read the filename out of `Content-Disposition` with a single regex,
`/filename[^;=\n]*=([^;\n]*''([^;\n]*)|[^;\n]*)/`, and took the last non-empty group.

Nuxeo emits both forms whenever the name is not a bare token (spaces, non-ASCII):

```
Content-Disposition: attachment; filename="my file.pdf"; filename*=UTF-8''my%20file.pdf
```

The regex matches the **first** `filename…=` occurrence, and its `''` alternative cannot match
inside that first `;`-delimited segment, so the fallback captured the quoted value *including its
double quotes*. Assigning `"my file.pdf"` to an anchor's `download` attribute makes the browser
replace the illegal `"` characters with underscores.

This is the same defect the reporter filed against `nuxeo-operation-button`; this element carries its
own copy of the parsing.

## Changes
* **`addons/nuxeo-template-rendering/elements/nuxeo-render-template-button.js`**: added
  `_filenameFromContentDisposition()`, which reads the RFC 5987 `filename*` form first
  (percent-encoded and unquoted, so it needs no unquoting) and strips the surrounding quotes when
  falling back to the plain `filename` form. It also returns an empty name instead of throwing a
  `TypeError` when the header carries no filename at all — the old code called `.filter()` on the
  `null` returned by `.match()`.
* **`addons/nuxeo-template-rendering/test/nuxeo-render-template-button.test.js`**: asserts the
  `download` attribute for the reported header and covers each header form directly.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes
- [ ] QA: render a template whose filename contains spaces and confirm the saved file keeps its name.

## Notes
- Paired with the same-titled PR on the other base branch; the two diffs are identical.
- The `nuxeo-operation-button` half of this ticket is fixed in nuxeo/nuxeo-elements#1527 (lts-2025)
  and nuxeo/nuxeo-elements#1528 (maintenance-3.1.x), where the app-level before/after evidence was
  captured; the code path here is identical.

Made with [Cursor](https://cursor.com)

[WEBUI-2170]: https://hyland.atlassian.net/browse/WEBUI-2170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WEBUI-2177]: https://hyland.atlassian.net/browse/WEBUI-2177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ