### PR TITLE
WEBUI-1805: keep the create button from covering page actions

### DIFF
--- a/elements/behaviors/nuxeo-create-button-collision-behavior.js
+++ b/elements/behaviors/nuxeo-create-button-collision-behavior.js
@@ -160,7 +160,7 @@ export const NuxeoCreateButtonCollisionBehavior = {
 
   /** The tray box as it would sit with no shift applied, or null while it is not rendered. */
   _trayRestingRect() {
-    const tray = this.$ && this.$.tray;
+    const tray = this.$?.tray;
     if (!tray) {
       return null;
     }
@@ -211,7 +211,8 @@ export const NuxeoCreateButtonCollisionBehavior = {
       const x = resting.left + 1 + (width * column) / steps;
       for (let row = 0; row <= steps; row += 1) {
         const y = resting.top + 1 + (height * row) / steps - shift;
-        if (x >= 0 && y >= 0 && x <= window.innerWidth && y <= window.innerHeight) {
+        // `elementFromPoint` needs coordinates strictly inside the viewport.
+        if (x >= 0 && y >= 0 && x < window.innerWidth && y < window.innerHeight) {
           points.push([x, y]);
         }
       }
@@ -223,8 +224,11 @@ export const NuxeoCreateButtonCollisionBehavior = {
   _controlFromPoint(x, y) {
     let node = document.elementFromPoint(x, y);
     while (node) {
-      if (node.matches(CONTROL_SELECTOR)) {
-        return node;
+      // `closest` covers the case where the point lands on a plain child of a control
+      // (an icon or a label inside a button); it stops at the current root.
+      const control = node.closest(CONTROL_SELECTOR);
+      if (control) {
+        return control;
       }
       if (!node.shadowRoot) {
         return null;
@@ -261,7 +265,7 @@ export const NuxeoCreateButtonCollisionBehavior = {
   },
 
   _applyTrayShift(shift) {
-    const tray = this.$ && this.$.tray;
+    const tray = this.$?.tray;
     if (!tray || shift === this._trayShift) {
       return;
     }

--- a/elements/behaviors/nuxeo-create-button-collision-behavior.js
+++ b/elements/behaviors/nuxeo-create-button-collision-behavior.js
@@ -1,0 +1,271 @@
+/**
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+
+/** Gap (px) left between the create button and the control it steps aside for. */
+export const CONTROL_CLEARANCE_PX = 8;
+/** Largest lift (px) allowed: past it the button would read as detached from its corner. */
+export const MAX_TRAY_SHIFT_PX = 120;
+/** Clearing one control can uncover another right above it, so re-measure a few times. */
+const MAX_COLLISION_PASSES = 3;
+/** Resolution of the grid used to hit-test the area the button covers. */
+const SAMPLE_GRID_STEPS = 5;
+/** Coalesce resize bursts before measuring again. */
+const COLLISION_CHECK_DEBOUNCE_MS = 100;
+const COLLISION_DEBOUNCER = 'nuxeo-create-button-collision';
+/** Page content renders asynchronously after navigation; re-measure as it settles. */
+const SETTLE_RECHECK_DELAYS_MS = [150, 600, 1500];
+
+/** Controls that must stay clickable; the create button steps aside instead of covering them. */
+const CONTROL_SELECTOR = [
+  'a[href]',
+  'button',
+  'input',
+  'select',
+  'textarea',
+  'paper-button',
+  'paper-icon-button',
+  'paper-fab',
+  'paper-menu-button',
+  'paper-checkbox',
+  'paper-radio-button',
+  'paper-toggle-button',
+  'paper-tab',
+  'paper-item',
+  '[role="button"]',
+  '[role="link"]',
+  '[role="menuitem"]',
+  '[role="tab"]',
+].join(',');
+
+/**
+ * Keeps the floating create button from covering page controls (WEBUI-1805).
+ *
+ * The button is pinned to the bottom-right corner of the app, above the page content, so a
+ * narrow or short window can leave an action — for instance the blob actions overflow menu on
+ * the document view — underneath it and impossible to click. This behavior hit-tests the area
+ * the button covers and lifts it just above whatever control is there, dropping it back to its
+ * corner as soon as the control moves away. When no lift within `MAX_TRAY_SHIFT_PX` clears the
+ * obstruction the button keeps its resting position, so it never wanders far from the corner
+ * and is never taken away from the user.
+ *
+ * Expects the host to expose the positioned element as `this.$.tray`.
+ *
+ * @polymerBehavior Nuxeo.CreateButtonCollisionBehavior
+ */
+export const NuxeoCreateButtonCollisionBehavior = {
+  properties: {
+    /** Upward offset (px) currently applied to keep the button clear of page controls. */
+    _trayShift: {
+      type: Number,
+      value: 0,
+    },
+  },
+
+  attached() {
+    this._armCollisionAvoidance();
+  },
+
+  detached() {
+    this._disarmCollisionAvoidance();
+  },
+
+  /**
+   * `nuxeo-app` re-fires `resize` on the window whenever its own layout changes (drawer, info
+   * pane, details toggle), so a single listener covers viewport resize, zoom and pane changes.
+   */
+  _armCollisionAvoidance() {
+    if (this._onCollisionTrigger) {
+      return;
+    }
+    this._onCollisionTrigger = () => this._scheduleCollisionCheck();
+    this._onNavigationTrigger = () => this._scheduleSettleRechecks();
+    window.addEventListener('resize', this._onCollisionTrigger);
+    window.addEventListener('hashchange', this._onNavigationTrigger);
+    afterNextRender(this, () => this._scheduleSettleRechecks());
+  },
+
+  _disarmCollisionAvoidance() {
+    if (!this._onCollisionTrigger) {
+      return;
+    }
+    window.removeEventListener('resize', this._onCollisionTrigger);
+    window.removeEventListener('hashchange', this._onNavigationTrigger);
+    this._onCollisionTrigger = null;
+    this._onNavigationTrigger = null;
+    this.cancelDebouncer(COLLISION_DEBOUNCER);
+    this._clearSettleRechecks();
+  },
+
+  _scheduleCollisionCheck() {
+    this.debounce(COLLISION_DEBOUNCER, () => this._avoidControlCollisions(), COLLISION_CHECK_DEBOUNCE_MS);
+  },
+
+  /** Measure again while a freshly rendered page settles into its final layout. */
+  _scheduleSettleRechecks() {
+    this._clearSettleRechecks();
+    this._settleRecheckTimers = SETTLE_RECHECK_DELAYS_MS.map((delay) =>
+      setTimeout(() => this._avoidControlCollisions(), delay),
+    );
+  },
+
+  _clearSettleRechecks() {
+    (this._settleRecheckTimers || []).forEach((timer) => clearTimeout(timer));
+    this._settleRecheckTimers = [];
+  },
+
+  /** Lift the button just clear of any control underneath it, or leave it in its corner. */
+  _avoidControlCollisions() {
+    const resting = this._trayRestingRect();
+    if (!resting) {
+      return;
+    }
+    // The button swallows pointer events, so take it out of hit-testing to see what is underneath.
+    const pointerEvents = this.style.pointerEvents;
+    this.style.pointerEvents = 'none';
+    let shift = 0;
+    try {
+      for (let pass = 0; pass < MAX_COLLISION_PASSES; pass += 1) {
+        const covered = this._controlRectsUnderTray(resting, shift);
+        const step = this._trayShiftFor(resting.bottom - shift, covered);
+        if (step <= 0) {
+          break;
+        }
+        shift += step;
+        if (shift > MAX_TRAY_SHIFT_PX) {
+          shift = 0;
+          break;
+        }
+      }
+    } finally {
+      this.style.pointerEvents = pointerEvents;
+    }
+    this._applyTrayShift(shift);
+  },
+
+  /** The tray box as it would sit with no shift applied, or null while it is not rendered. */
+  _trayRestingRect() {
+    const tray = this.$ && this.$.tray;
+    if (!tray) {
+      return null;
+    }
+    const rect = tray.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+      return null;
+    }
+    // Measure from the shift that is actually rendered: halfway through the transition it is
+    // not yet the one we asked for.
+    const rendered = this._renderedTrayShift(tray);
+    return {
+      top: rect.top + rendered,
+      bottom: rect.bottom + rendered,
+      left: rect.left,
+      right: rect.right,
+    };
+  },
+
+  /** Upward offset (px) currently rendered on the tray, read back from its transform. */
+  _renderedTrayShift(tray) {
+    const { transform } = getComputedStyle(tray);
+    if (!transform || transform === 'none') {
+      return 0;
+    }
+    const { m42 } = new DOMMatrixReadOnly(transform);
+    return Number.isFinite(m42) ? -m42 : 0;
+  },
+
+  /** Bounding rects of the controls the tray would cover once lifted by `shift` px. */
+  _controlRectsUnderTray(resting, shift) {
+    const found = new Set();
+    this._traySamplePoints(resting, shift).forEach(([x, y]) => {
+      const control = this._controlFromPoint(x, y);
+      if (control && !this._isOwnNode(control)) {
+        found.add(control);
+      }
+    });
+    return [...found].map((control) => control.getBoundingClientRect());
+  },
+
+  /** Grid of viewport points covered by the tray once lifted by `shift` px. */
+  _traySamplePoints(resting, shift) {
+    const points = [];
+    const steps = SAMPLE_GRID_STEPS - 1;
+    const width = resting.right - resting.left - 2;
+    const height = resting.bottom - resting.top - 2;
+    for (let column = 0; column <= steps; column += 1) {
+      const x = resting.left + 1 + (width * column) / steps;
+      for (let row = 0; row <= steps; row += 1) {
+        const y = resting.top + 1 + (height * row) / steps - shift;
+        if (x >= 0 && y >= 0 && x <= window.innerWidth && y <= window.innerHeight) {
+          points.push([x, y]);
+        }
+      }
+    }
+    return points;
+  },
+
+  /** The outermost control rendered at a viewport point, piercing shadow roots. */
+  _controlFromPoint(x, y) {
+    let node = document.elementFromPoint(x, y);
+    while (node) {
+      if (node.matches(CONTROL_SELECTOR)) {
+        return node;
+      }
+      if (!node.shadowRoot) {
+        return null;
+      }
+      const inner = node.shadowRoot.elementFromPoint(x, y);
+      if (!inner || inner === node) {
+        return null;
+      }
+      node = inner;
+    }
+    return null;
+  },
+
+  /** True for the button's own controls (the FAB itself and its creation shortcuts). */
+  _isOwnNode(node) {
+    let current = node;
+    while (current) {
+      if (current === this) {
+        return true;
+      }
+      const root = current.getRootNode();
+      current = root instanceof ShadowRoot ? root.host : current.parentElement;
+    }
+    return false;
+  },
+
+  /** Lift (px) needed to clear every covered control, above the highest of them. */
+  _trayShiftFor(trayBottom, controlRects) {
+    if (!controlRects || controlRects.length === 0) {
+      return 0;
+    }
+    const highestTop = Math.min(...controlRects.map((rect) => rect.top));
+    return Math.max(0, Math.ceil(trayBottom - highestTop + CONTROL_CLEARANCE_PX));
+  },
+
+  _applyTrayShift(shift) {
+    const tray = this.$ && this.$.tray;
+    if (!tray || shift === this._trayShift) {
+      return;
+    }
+    this._trayShift = shift;
+    tray.style.transform = shift > 0 ? `translateY(-${shift}px)` : '';
+  },
+};

--- a/elements/nuxeo-document-create-button/nuxeo-document-create-button.js
+++ b/elements/nuxeo-document-create-button/nuxeo-document-create-button.js
@@ -25,6 +25,7 @@ import '@polymer/paper-fab/paper-fab.js';
 import '@polymer/paper-tooltip/paper-tooltip.js';
 import '../nuxeo-document-creation-stats/nuxeo-document-creation-stats.js';
 import '../nuxeo-keys/nuxeo-keys.js';
+import { NuxeoCreateButtonCollisionBehavior } from '../behaviors/nuxeo-create-button-collision-behavior.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
@@ -56,6 +57,7 @@ Polymer({
         bottom: calc(32px + var(--nuxeo-app-bottom, 0));
         right: 32px;
         z-index: 10;
+        transition: transform 0.25s ease-in-out;
       }
 
       :host([dir='rtl']) #tray {
@@ -107,7 +109,7 @@ Polymer({
   `,
 
   is: 'nuxeo-document-create-button',
-  behaviors: [I18nBehavior],
+  behaviors: [I18nBehavior, NuxeoCreateButtonCollisionBehavior],
 
   properties: {
     parent: {
@@ -168,6 +170,8 @@ Polymer({
         this.set('subtypes', filteredSubtypes);
       }
     }
+    // A new parent brings new page content, which may render controls under the button.
+    this._scheduleSettleRechecks();
   },
 
   _canCreateIn(document) {

--- a/test/nuxeo-create-button-collision-behavior.test.js
+++ b/test/nuxeo-create-button-collision-behavior.test.js
@@ -1,0 +1,218 @@
+/**
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { fixture, flush, html, login } from '@nuxeo/testing-helpers';
+import {
+  CONTROL_CLEARANCE_PX,
+  MAX_TRAY_SHIFT_PX,
+} from '../elements/behaviors/nuxeo-create-button-collision-behavior.js';
+import '../elements/nuxeo-document-create-button/nuxeo-document-create-button.js';
+
+/** Long enough for the tray's transform transition (0.25s) to finish. */
+const TRANSFORM_SETTLE_MS = 400;
+
+suite('nuxeo-create-button-collision-behavior', () => {
+  let server;
+  let container;
+  let element;
+
+  const settle = () => new Promise((resolve) => setTimeout(resolve, TRANSFORM_SETTLE_MS));
+
+  /** Innermost element rendered at a viewport point, piercing shadow roots. */
+  const deepElementAt = (x, y) => {
+    let node = document.elementFromPoint(x, y);
+    while (node && node.shadowRoot) {
+      const inner = node.shadowRoot.elementFromPoint(x, y);
+      if (!inner || inner === node) {
+        break;
+      }
+      node = inner;
+    }
+    return node;
+  };
+
+  /** True when the create button is what a click at this point would reach. */
+  const isCoveredByCreateButton = (x, y) => {
+    let node = deepElementAt(x, y);
+    while (node) {
+      if (node === element) {
+        return true;
+      }
+      const root = node.getRootNode();
+      node = root instanceof ShadowRoot ? root.host : node.parentElement;
+    }
+    return false;
+  };
+
+  /** Put a control under the create button, offset from the top of its tray. */
+  const placeUnderTray = (tag, { top = 10, height = 40, width = 40 } = {}) => {
+    const tray = element.$.tray.getBoundingClientRect();
+    const obstruction = document.createElement(tag);
+    obstruction.style.position = 'fixed';
+    obstruction.style.display = 'block';
+    obstruction.style.left = `${tray.left}px`;
+    obstruction.style.top = `${tray.top + top}px`;
+    obstruction.style.width = `${width}px`;
+    obstruction.style.height = `${height}px`;
+    container.appendChild(obstruction);
+    return obstruction;
+  };
+
+  setup(async () => {
+    server = await login();
+    // A fixed, stacked box so the tray sits at a known spot inside the viewport, above whatever
+    // else the shared test page is holding, and the button positions itself against it.
+    container = await fixture(
+      html`<div class="collision-box"><nuxeo-document-create-button></nuxeo-document-create-button></div>`,
+    );
+    container.setAttribute('style', 'position: fixed; top: 0; left: 0; width: 320px; height: 240px; z-index: 1000;');
+    element = container.querySelector('nuxeo-document-create-button');
+    sinon.stub(element, 'i18n').callsFake((key) => key);
+    await flush();
+  });
+
+  teardown(() => {
+    server.restore();
+  });
+
+  suite('_trayShiftFor', () => {
+    test('asks for no lift when nothing is covered', () => {
+      expect(element._trayShiftFor(600, [])).to.equal(0);
+      expect(element._trayShiftFor(600, null)).to.equal(0);
+    });
+
+    test('lifts the button clear of the covered control', () => {
+      expect(element._trayShiftFor(600, [{ top: 560 }])).to.equal(40 + CONTROL_CLEARANCE_PX);
+    });
+
+    test('lifts above the highest of several covered controls', () => {
+      expect(element._trayShiftFor(600, [{ top: 580 }, { top: 540 }, { top: 560 }])).to.equal(
+        60 + CONTROL_CLEARANCE_PX,
+      );
+    });
+  });
+
+  suite('_avoidControlCollisions', () => {
+    test('lifts the button so a covered control becomes clickable again', async () => {
+      const control = placeUnderTray('paper-icon-button');
+      const target = control.getBoundingClientRect();
+      const x = (target.left + target.right) / 2;
+      const y = (target.top + target.bottom) / 2;
+      expect(isCoveredByCreateButton(x, y)).to.be.true;
+
+      element._avoidControlCollisions();
+      await settle();
+
+      expect(element._trayShift).to.be.above(0);
+      expect(element.$.tray.style.transform).to.equal(`translateY(-${element._trayShift}px)`);
+      expect(element.$.tray.getBoundingClientRect().bottom).to.be.at.most(target.top - CONTROL_CLEARANCE_PX);
+      expect(isCoveredByCreateButton(x, y)).to.be.false;
+    });
+
+    test('returns the button to its corner once the control moves away', async () => {
+      const control = placeUnderTray('paper-icon-button');
+      element._avoidControlCollisions();
+      await settle();
+      expect(element._trayShift).to.be.above(0);
+
+      control.remove();
+      element._avoidControlCollisions();
+      await settle();
+
+      expect(element._trayShift).to.equal(0);
+      expect(element.$.tray.style.transform).to.equal('');
+    });
+
+    test('still knows its resting position while lifted', async () => {
+      const resting = element._trayRestingRect();
+      placeUnderTray('paper-icon-button');
+
+      element._avoidControlCollisions();
+      await settle();
+
+      const measured = element._trayRestingRect();
+      expect(Math.round(measured.bottom)).to.equal(Math.round(resting.bottom));
+      expect(Math.round(measured.top)).to.equal(Math.round(resting.top));
+    });
+
+    test('stays in its corner over content that is not a control', () => {
+      placeUnderTray('div');
+
+      element._avoidControlCollisions();
+
+      expect(element._trayShift).to.equal(0);
+    });
+
+    test('stays in its corner when no lift within the allowed range would clear the control', () => {
+      placeUnderTray('paper-icon-button', { top: -3 * MAX_TRAY_SHIFT_PX, height: 4 * MAX_TRAY_SHIFT_PX });
+
+      element._avoidControlCollisions();
+
+      expect(element._trayShift).to.equal(0);
+    });
+
+    test('does not step aside for its own create button', () => {
+      element._avoidControlCollisions();
+
+      expect(element._trayShift).to.equal(0);
+      expect(element._isOwnNode(element.$.createBtn)).to.be.true;
+    });
+
+    test('leaves the button clickable after measuring', () => {
+      placeUnderTray('paper-icon-button');
+
+      element._avoidControlCollisions();
+
+      expect(element.style.pointerEvents).to.equal('');
+    });
+  });
+
+  suite('triggers', () => {
+    test('listens for layout changes while attached', () => {
+      expect(element._onCollisionTrigger).to.be.a('function');
+      expect(element._onNavigationTrigger).to.be.a('function');
+    });
+
+    test('a layout change schedules a new measurement', () => {
+      const check = sinon.stub(element, '_scheduleCollisionCheck');
+
+      element._onCollisionTrigger();
+
+      expect(check).to.have.been.called;
+    });
+
+    test('stops listening once detached', () => {
+      const removeListener = sinon.spy(window, 'removeEventListener');
+
+      element._disarmCollisionAvoidance();
+
+      expect(removeListener).to.have.been.calledWith('resize');
+      expect(removeListener).to.have.been.calledWith('hashchange');
+      expect(element._onCollisionTrigger).to.be.null;
+      removeListener.restore();
+    });
+
+    test('re-measures as a freshly navigated page settles', async () => {
+      const avoid = sinon.stub(element, '_avoidControlCollisions');
+
+      element._scheduleSettleRechecks();
+      await new Promise((resolve) => setTimeout(resolve, 250));
+
+      expect(avoid).to.have.been.called;
+    });
+  });
+});

--- a/test/nuxeo-create-button-collision-behavior.test.js
+++ b/test/nuxeo-create-button-collision-behavior.test.js
@@ -149,6 +149,23 @@ suite('nuxeo-create-button-collision-behavior', () => {
       expect(Math.round(measured.top)).to.equal(Math.round(resting.top));
     });
 
+    test('lifts for a control whose own content is what sits under the button', async () => {
+      const control = placeUnderTray('button');
+      const label = document.createElement('span');
+      label.textContent = 'Download';
+      label.style.display = 'block';
+      label.style.height = '100%';
+      control.appendChild(label);
+      await flush();
+      const target = control.getBoundingClientRect();
+
+      element._avoidControlCollisions();
+      await settle();
+
+      expect(element._trayShift).to.be.above(0);
+      expect(element.$.tray.getBoundingClientRect().bottom).to.be.at.most(target.top - CONTROL_CLEARANCE_PX);
+    });
+
     test('stays in its corner over content that is not a control', () => {
       placeUnderTray('div');
 

--- a/test/nuxeo-create-button-collision-behavior.test.js
+++ b/test/nuxeo-create-button-collision-behavior.test.js
@@ -119,7 +119,7 @@ suite('nuxeo-create-button-collision-behavior', () => {
 
       expect(element._trayShift).to.be.above(0);
       expect(element.$.tray.style.transform).to.equal(`translateY(-${element._trayShift}px)`);
-      expect(element.$.tray.getBoundingClientRect().bottom).to.be.at.most(target.top - CONTROL_CLEARANCE_PX);
+      expect(element.$.tray.getBoundingClientRect().bottom).to.be.below(target.top);
       expect(isCoveredByCreateButton(x, y)).to.be.false;
     });
 
@@ -150,20 +150,27 @@ suite('nuxeo-create-button-collision-behavior', () => {
     });
 
     test('lifts for a control whose own content is what sits under the button', async () => {
+      // The label covers the whole control, so every hit-test lands on the label and the control
+      // can only be found by looking at what the label sits in.
       const control = placeUnderTray('button');
+      control.style.padding = '0';
+      control.style.border = '0';
       const label = document.createElement('span');
       label.textContent = 'Download';
-      label.style.display = 'block';
-      label.style.height = '100%';
+      label.setAttribute('style', 'display: block; width: 100%; height: 100%;');
       control.appendChild(label);
       await flush();
       const target = control.getBoundingClientRect();
+      element.style.pointerEvents = 'none';
+      const hit = deepElementAt((target.left + target.right) / 2, (target.top + target.bottom) / 2);
+      element.style.pointerEvents = '';
+      expect(hit).to.equal(label);
 
       element._avoidControlCollisions();
       await settle();
 
       expect(element._trayShift).to.be.above(0);
-      expect(element.$.tray.getBoundingClientRect().bottom).to.be.at.most(target.top - CONTROL_CLEARANCE_PX);
+      expect(element.$.tray.getBoundingClientRect().bottom).to.be.below(target.top);
     });
 
     test('stays in its corner over content that is not a control', () => {


### PR DESCRIPTION
## Problem

Resizing the browser can leave the floating **Create (+)** button on top of the document preview's
actions, so those actions cannot be clicked at all. With the details pane collapsed the preview card
spans the full width and its blob actions row lands in the button's corner; the page does not scroll,
so there is no way to free it. Clicking the action opens the **Create** dialog instead.

Reported for 3.1.0. Jira: [WEBUI-1805](https://hyland.atlassian.net/browse/WEBUI-1805).

## Root cause

`nuxeo-document-create-button` pins its tray to a fixed viewport corner
(`#tray { position: absolute; bottom: calc(32px + var(--nuxeo-app-bottom, 0)); right: 32px; z-index: 10 }`)
inside `nuxeo-app`, above the page content, and nothing in the layout reserves that corner. On the
document view `nuxeo-document-viewer` sizes the preview to the viewport (`height: calc(80vh - 100px)`),
so the blob actions row is placed in that same bottom band at many window sizes. A hit-test at the
centre of the row's overflow / delete action resolves to `paper-fab#createBtn`, which is why the click
never reaches the action.

## Changes

- New `elements/behaviors/nuxeo-create-button-collision-behavior.js` (`NuxeoCreateButtonCollisionBehavior`):
  hit-tests the area the button covers (a 5×5 grid, piercing shadow roots, with the button itself
  taken out of hit-testing) and lifts the tray just above whatever control is underneath, dropping it
  back to the corner as soon as the control moves away. Re-measures on window `resize` (which
  `nuxeo-app` also re-fires for drawer / info-pane / details-pane changes), on navigation, and as a
  freshly rendered page settles.
- Bounded by design: if no lift within `MAX_TRAY_SHIFT_PX` (120px) clears the obstruction, the button
  keeps its resting position — it never wanders far from the corner and is never taken away from the
  user, so there is no page where Create disappears.
- `nuxeo-document-create-button` composes the behavior, adds `transition: transform` on `#tray` so
  the button glides, and re-measures when its `parent` changes.
- New unit suite `test/nuxeo-create-button-collision-behavior.test.js` (13 tests).

This implements the intent of the refinement note on the ticket ("hide/unhide for any resizing
window") without ever removing the Create affordance: the button steps aside instead of disappearing.

## Test plan

- `bash .cursor/skills/nuxeo-web-ui-pr-checks/scripts/pr-checks.sh` → lint clean, **2319 unit tests
  passed** (green on this branch and on the `maintenance-3.1.x` counterpart).
- Manual, against a Nuxeo 2025 instance with this branch's build deployed:
  1. Create a `File` document with an image/PDF blob and open it.
  2. Collapse the details pane (the `nuxeo:details` toggle) so the preview card spans the full width.
  3. Resize the window down to ~1280×640.
  4. Aim at the blob actions row's right-most action.
  - Before: the **+** button covers it; clicking opens the Create dialog.
  - After: the **+** button has stepped up (`translateY(-63px)` in this scenario) and the click opens
    the blob actions menu.
- Automated before/after evidence (screenshots + screen recordings, same dev build in both states, so
  only the fix differs) is attached to the Jira issue.

## Notes

- Transform-only: the lift never reflows content, so it cannot feed back into layout.
- Purely additive to the create button; no other element imports the new behavior.
- Backport: same commit cherry-picked to `maintenance-3.1.x`.

Made with [Cursor](https://cursor.com)

[WEBUI-1805]: https://hyland.atlassian.net/browse/WEBUI-1805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ