### PR TITLE
WEBUI-2009: Display full document names in the side panel [maintenance-3.1.x]

### DIFF
--- a/elements/nuxeo-document-tree/nuxeo-document-tree.js
+++ b/elements/nuxeo-document-tree/nuxeo-document-tree.js
@@ -149,8 +149,16 @@ Polymer({
         min-width: 1.3em;
       }
 
-      .parent {
+      /* Ancestor names wrap onto up to two lines before being clipped, so documents whose
+         names only differ near the end stay distinguishable in a narrow drawer. */
+      .parents .parent {
         padding: 0.12em 0 0;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        white-space: normal;
+        overflow-wrap: break-word;
+        line-height: 1.3em;
       }
 
       paper-spinner {
@@ -197,12 +205,17 @@ Polymer({
 
     <div class="content" role="tree">
       <div class="parents" hidden$="[[_noPermission]]">
-        <a href$="[[urlFor('document', '/')]]" class="layout horizontal" hidden$="[[_hideRoot(document)]]">
+        <a
+          href$="[[urlFor('document', '/')]]"
+          class="layout horizontal"
+          hidden$="[[_hideRoot(document)]]"
+          title$="[[i18n('browse.root')]]"
+        >
           <span aria-hidden="true"><iron-icon icon="[[toggleChevronIcon]]"></iron-icon></span>
           <span class="parent">[[i18n('browse.root')]]</span>
         </a>
         <template is="dom-repeat" items="[[parents]]" as="item">
-          <a href$="[[urlFor(item)]]">
+          <a href$="[[urlFor(item)]]" title$="[[item.title]]">
             <span><iron-icon icon="[[toggleChevronIcon]]"></iron-icon></span>
             <span class="parent">[[item.title]]</span>
           </a>
@@ -228,7 +241,7 @@ Polymer({
               </template>
             </template>
             <span class="node-name flex">
-              <a href$="[[urlFor(item)]]">[[_title(item)]]</a>
+              <a href$="[[urlFor(item)]]" title$="[[_title(item)]]">[[_title(item)]]</a>
             </span>
           </div>
         </template>

--- a/test/nuxeo-document-tree.test.js
+++ b/test/nuxeo-document-tree.test.js
@@ -344,6 +344,48 @@ suite('nuxeo-document-tree', () => {
       isElementVisible(documentTree.shadowRoot.querySelector('.parents'));
     });
 
+    test('Tree nodes expose their full name in a tooltip', async () => {
+      const nodes = getTreeNodes(documentTree);
+      expect(nodes).to.be.not.empty;
+      nodes.forEach((node) => {
+        const anchor = node.querySelector('.node-name a');
+        expect(anchor).to.be.not.null;
+        expect(anchor.getAttribute('title')).to.be.equal(anchor.textContent.trim());
+      });
+    });
+
+    test('Breadcrumb ancestors expose their full name in a tooltip', async () => {
+      // set the new document so the breadcrumb is populated with an ancestor
+      const [doc] = levelThreeDocuments;
+      documentTree.currentDocument = doc;
+      await flush();
+      await waitForChildListMutation(documentTree.$.tree);
+      await waitForTreeNodeLoading(documentTree);
+      await waitForTreeNodeCount(documentTree, 3);
+
+      const ancestors = documentTree.shadowRoot.querySelectorAll('.parents a');
+      expect(ancestors).to.be.not.empty;
+      ancestors.forEach((anchor) => {
+        const name = anchor.querySelector('.parent');
+        expect(anchor.getAttribute('title')).to.be.equal(name.textContent.trim());
+      });
+    });
+
+    test('Breadcrumb ancestor names wrap instead of being clipped to a single line', async () => {
+      const [doc] = levelThreeDocuments;
+      documentTree.currentDocument = doc;
+      await flush();
+      await waitForChildListMutation(documentTree.$.tree);
+      await waitForTreeNodeLoading(documentTree);
+      await waitForTreeNodeCount(documentTree, 3);
+
+      const name = documentTree.shadowRoot.querySelector('.parents .parent');
+      expect(name).to.be.not.null;
+      const styles = getComputedStyle(name);
+      expect(styles.whiteSpace).to.be.equal('normal');
+      expect(styles.webkitLineClamp).to.be.equal('2');
+    });
+
     test('Tree breadcrumb is present with root document', async () => {
       // set the new document that contains the breadcrumb
 


### PR DESCRIPTION
## Problem

In the side panel, ancestor document names were clipped to a single line with an ellipsis, so documents whose names only differ near the end (e.g. `Contract Documentation And Legal Agreements 2025 - Region North` vs `… - Region South`) were indistinguishable — only the beginning of each name was visible, and hovering revealed nothing. Users had to open each document in turn to find the right one. Reported by a customer with 10k+ users as their 2nd most impactful UX issue.

Jira: [WEBUI-2009](https://hyland.atlassian.net/browse/WEBUI-2009)

## Root cause

`elements/nuxeo-document-tree/nuxeo-document-tree.js` styled the breadcrumb ancestor rows with `white-space: nowrap` + `text-overflow: ellipsis` on `.parents span`, forcing every ancestor name onto one line regardless of available height. Neither the ancestor links nor the tree-node links carried a `title`, so no tooltip was available for the clipped text.

Measured in the drawer at its default width on a seeded instance: ancestor rows reported `scrollWidth: 398` against `clientWidth: 272` (clipped) with `title: null` on every row.

## Changes

* **`elements/nuxeo-document-tree/nuxeo-document-tree.js`**
  * `.parents .parent` now wraps onto up to two lines before falling back to an ellipsis (`display: -webkit-box` + `-webkit-line-clamp: 2` + `white-space: normal` + `overflow-wrap: break-word`) — the same idiom already used by `.name` in `elements/document/nuxeo-document-import.js`. The selector is qualified (`.parents .parent`) so it wins over the more specific `.parents span` rule; the chevron span is left untouched.
  * Added `title$=` to the root link, the ancestor links and the tree-node links, so the full name is available on hover (and on keyboard focus) at any drawer width. A native `title` is used rather than `nuxeo-tooltip` to avoid adding an extra element plus five event listeners per node in trees that can hold hundreds of nodes.
* **`test/nuxeo-document-tree.test.js`** — three tests: tree nodes expose their full name in a tooltip, breadcrumb ancestors expose theirs, and ancestor names are no longer clipped to a single line.

## Test plan

- [x] `npm test` passes — **2308 tests, 0 failed**, exit code 0
- [x] `npx eslint` clean on both changed files. The repo-wide `prettier --list-different` noise seen locally is a Windows `core.autocrlf=true` artifact (prettier defaults to `endOfLine: lf`); both changed files verified prettier-clean individually, and the committed content is LF.
- [x] Verified end to end against a throwaway Nuxeo 2025 container seeded with a deep folder chain plus five sibling folders whose names only differ near the end. Before: ancestors rendered as `Global Customer Contracts Repository 2…` on one line, `title: null`. After: full names on two lines, `truncated: false`, `title` populated on every ancestor and tree node. Before/after screenshots and screen recordings are attached to the Jira ticket.

## Notes

* Backport pair — the identical commit is applied to both `lts-2025` and `maintenance-3.1.x`; `nuxeo-document-tree.js` is byte-identical on the two bases, so the cherry-pick is clean.
* Tree-node names already wrapped freely, so only the ancestor rows changed layout. Ancestor rows grow from 23px to ~35px only when the name actually needs a second line.
* `title` is set unconditionally rather than only when the text is clipped: the drawer is user-resizable, so a measure-and-toggle approach would need to re-measure on every resize for no user-visible benefit.


[WEBUI-2009]: https://hyland.atlassian.net/browse/WEBUI-2009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ