### PR TITLE
WEBUI-2009: Show full result names in the search drawer [lts-2025]

### DIFF
--- a/elements/search/nuxeo-search-form.js
+++ b/elements/search/nuxeo-search-form.js
@@ -237,19 +237,6 @@ Polymer({
         @apply --layout-center;
       }
 
-      /* Show the name on up to two lines before clipping it, so results sharing a long
-         prefix stay distinguishable. Kept self-contained rather than leaning on the
-         .ellipsis class these spans also carry, which the panel header still needs for
-         single-line truncation. */
-      .list-item-title {
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
-        overflow: hidden;
-        overflow-wrap: break-word;
-        white-space: normal;
-      }
-
       .list-item-property {
         opacity: 0.5;
         margin-right: 0.2em;
@@ -377,7 +364,10 @@ Polymer({
                     <div class="vertical layout center">
                       <nuxeo-document-thumbnail document="[[item]]"></nuxeo-document-thumbnail>
                     </div>
-                    <span class="list-item-title ellipsis" on-mouseenter="_showTitleIfTruncated">[[item.title]]</span>
+                    <span class="list-item-title ellipsis">[[item.title]]</span>
+                    <!-- Kept outside the span so the name text stays exactly the title, and
+                         anchored on the parent row since an id would not be unique per stamp. -->
+                    <nuxeo-tooltip aria-hidden="true">[[item.title]]</nuxeo-tooltip>
                   </div>
                 </div>
               </div>
@@ -784,19 +774,6 @@ Polymer({
       classes += ' selected';
     }
     return classes;
-  },
-
-  // Whether a name is clipped depends on rendered geometry, not on the document, so it
-  // cannot be expressed as a binding: the drawer is resizable and iron-list recycles rows
-  // into different documents. Measuring on hover keeps the tooltip accurate at the current
-  // width without re-measuring every row on resize or scroll.
-  _showTitleIfTruncated(e) {
-    const el = e.currentTarget;
-    if (el.scrollHeight > el.clientHeight + 1) {
-      el.setAttribute('title', el.textContent.trim());
-    } else {
-      el.removeAttribute('title');
-    }
   },
 
   _selectedDocChanged(doc, old) {

--- a/elements/search/nuxeo-search-form.js
+++ b/elements/search/nuxeo-search-form.js
@@ -44,6 +44,9 @@ import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 import { FormatBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-format-behavior.js';
+import { ensureSearchResultTooltipStyles } from './nuxeo-search-result-tooltip-styles.js';
+
+ensureSearchResultTooltipStyles();
 
 /**
  `nuxeo-search-form`
@@ -366,8 +369,13 @@ Polymer({
                     </div>
                     <span class="list-item-title ellipsis">[[item.title]]</span>
                     <!-- Kept outside the span so the name text stays exactly the title, and
-                         anchored on the parent row since an id would not be unique per stamp. -->
-                    <nuxeo-tooltip aria-hidden="true">[[item.title]]</nuxeo-tooltip>
+                         anchored on the parent row since an id would not be unique per stamp.
+                         Opens to the right of the row so it never covers the result list, and the
+                         name is wrapped in an element so the document-level rule that caps its
+                         width can match it once nuxeo-tooltip clones it onto the body. -->
+                    <nuxeo-tooltip position="right" offset="8" aria-hidden="true"
+                      ><span class="nuxeo-search-result-tooltip-name">[[item.title]]</span></nuxeo-tooltip
+                    >
                   </div>
                 </div>
               </div>

--- a/elements/search/nuxeo-search-form.js
+++ b/elements/search/nuxeo-search-form.js
@@ -238,12 +238,14 @@ Polymer({
       }
 
       /* Show the name on up to two lines before clipping it, so results sharing a long
-         prefix stay distinguishable. Overrides the single-line .ellipsis rule, which the
-         panel header still relies on. */
+         prefix stay distinguishable. Kept self-contained rather than leaning on the
+         .ellipsis class these spans also carry, which the panel header still needs for
+         single-line truncation. */
       .list-item-title {
         display: -webkit-box;
         -webkit-line-clamp: 2;
         -webkit-box-orient: vertical;
+        overflow: hidden;
         overflow-wrap: break-word;
         white-space: normal;
       }

--- a/elements/search/nuxeo-search-form.js
+++ b/elements/search/nuxeo-search-form.js
@@ -237,6 +237,17 @@ Polymer({
         @apply --layout-center;
       }
 
+      /* Show the name on up to two lines before clipping it, so results sharing a long
+         prefix stay distinguishable. Overrides the single-line .ellipsis rule, which the
+         panel header still relies on. */
+      .list-item-title {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow-wrap: break-word;
+        white-space: normal;
+      }
+
       .list-item-property {
         opacity: 0.5;
         margin-right: 0.2em;
@@ -364,7 +375,7 @@ Polymer({
                     <div class="vertical layout center">
                       <nuxeo-document-thumbnail document="[[item]]"></nuxeo-document-thumbnail>
                     </div>
-                    <span class="list-item-title ellipsis">[[item.title]]</span>
+                    <span class="list-item-title ellipsis" on-mouseenter="_showTitleIfTruncated">[[item.title]]</span>
                   </div>
                 </div>
               </div>
@@ -771,6 +782,19 @@ Polymer({
       classes += ' selected';
     }
     return classes;
+  },
+
+  // Whether a name is clipped depends on rendered geometry, not on the document, so it
+  // cannot be expressed as a binding: the drawer is resizable and iron-list recycles rows
+  // into different documents. Measuring on hover keeps the tooltip accurate at the current
+  // width without re-measuring every row on resize or scroll.
+  _showTitleIfTruncated(e) {
+    const el = e.currentTarget;
+    if (el.scrollHeight > el.clientHeight + 1) {
+      el.setAttribute('title', el.textContent.trim());
+    } else {
+      el.removeAttribute('title');
+    }
   },
 
   _selectedDocChanged(doc, old) {

--- a/elements/search/nuxeo-search-result-tooltip-styles.js
+++ b/elements/search/nuxeo-search-result-tooltip-styles.js
@@ -1,0 +1,50 @@
+/**
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const STYLES_ID = 'nuxeo-search-result-tooltip-styles';
+
+/**
+ * Styles the document name inside a search result's `nuxeo-tooltip`.
+ *
+ * `nuxeo-tooltip` clones its content into a `paper-tooltip` on `document.body`, so rules declared
+ * in a consumer's shadow root never reach the rendered node and these have to live on the document.
+ * The class name travels with the clone, which is what keeps this scoped to search results.
+ *
+ * `paper-tooltip` sizes itself to its content and only repositions when it does not fit, so without
+ * a width cap a name with no break opportunity renders wider than the viewport with part of it
+ * off-screen. The cap is relative as well as absolute so it still holds when the user zooms in.
+ *
+ * Idempotent: safe to call from every module that stamps one of these tooltips.
+ */
+export function ensureSearchResultTooltipStyles() {
+  if (document.getElementById(STYLES_ID)) {
+    return;
+  }
+  const style = document.createElement('style');
+  style.id = STYLES_ID;
+  style.textContent = `
+    .nuxeo-search-result-tooltip-name {
+      display: block;
+      max-width: min(400px, 40vw);
+      white-space: normal;
+      overflow-wrap: break-word;
+      line-height: 1.4;
+      text-align: start;
+    }
+  `;
+  document.head.appendChild(style);
+}

--- a/test/nuxeo-search-form.test.js
+++ b/test/nuxeo-search-form.test.js
@@ -645,13 +645,9 @@ suite('nuxeo-search-form', () => {
       expect(styles).to.not.contain('-webkit-line-clamp');
     });
 
-    test('every rendered row gets its own tooltip', async () => {
+    const stampRows = async (items) => {
       searchForm.queue = true;
-      searchForm.$.list.items = [
-        { uid: '1', type: 'File', path: '/a', title: 'D-DF-ASTURL61CZRIE-LSPS-PLANNING-2025-REV-01' },
-        { uid: '2', type: 'File', path: '/b', title: 'D-DF-ASTURL61CZRIE-LSPS-PLANNING-2025-REV-02' },
-        { uid: '3', type: 'File', path: '/c', title: 'Short' },
-      ];
+      searchForm.$.list.items = items;
       // iron-list decides how many rows to stamp, so poll rather than assume a count
       for (let i = 0; i < 40 && searchForm.$.list.querySelectorAll('.list-item-info').length === 0; i++) {
         await flush();
@@ -660,10 +656,71 @@ suite('nuxeo-search-form', () => {
       }
       const rows = searchForm.$.list.querySelectorAll('.list-item-info');
       expect(rows.length).to.be.at.least(1);
+      return rows;
+    };
+
+    test('every rendered row gets its own tooltip', async () => {
+      const rows = await stampRows([
+        { uid: '1', type: 'File', path: '/a', title: 'D-DF-ASTURL61CZRIE-LSPS-PLANNING-2025-REV-01' },
+        { uid: '2', type: 'File', path: '/b', title: 'D-DF-ASTURL61CZRIE-LSPS-PLANNING-2025-REV-02' },
+        { uid: '3', type: 'File', path: '/c', title: 'Short' },
+      ]);
       rows.forEach((row) => {
         const name = row.querySelector('.list-item-title').textContent.trim();
         expect(row.querySelector('nuxeo-tooltip'), `tooltip for "${name}"`).to.not.be.null;
       });
+    });
+
+    test('the tooltip opens beside the row so it never covers the result list', () => {
+      const tooltip = rowTooltip();
+      expect(tooltip.getAttribute('position')).to.equal('right');
+      // Tighter than nuxeo-tooltip's default 14, which reads as a gap rather than a pointer
+      // when the tooltip sits alongside its row instead of below it.
+      expect(tooltip.getAttribute('offset')).to.equal('8');
+    });
+
+    test('the name is wrapped in an element the document-level cap can match', () => {
+      // nuxeo-tooltip clones its content onto document.body, so a rule in this shadow root
+      // would never reach it: the class travels with the clone and the cap lives on the
+      // document (see nuxeo-search-result-tooltip-styles). A bare text node could not be
+      // targeted at all.
+      const content = rowTooltip().firstElementChild;
+      expect(content, 'tooltip content element').to.not.be.null;
+      expect(content.classList.contains('nuxeo-search-result-tooltip-name')).to.be.true;
+      expect(content.textContent.trim()).to.equal('[[item.title]]');
+      expect(content.hasAttribute('style'), 'width cap belongs in the stylesheet, not inline').to.be.false;
+    });
+
+    test('a name with no break opportunity stays inside the viewport', async () => {
+      // paper-tooltip sets no max-width and its fitToVisibleBounds only repositions the box,
+      // so an unbreakable name used to lay out wider than the viewport with the start of the
+      // name pushed off-screen. Placement is asserted structurally above; here the box itself
+      // has to stay on screen whichever side fitToVisibleBounds settles on.
+      const rows = await stampRows([
+        { uid: '1', type: 'File', path: '/a', title: 'Short' },
+        { uid: '2', type: 'File', path: '/b', title: `D${'X'.repeat(240)}` },
+      ]);
+      const rowFor = (prefix) =>
+        [...rows].find((row) => row.querySelector('.list-item-title').textContent.trim().startsWith(prefix));
+
+      const measure = async (row) => {
+        const tooltip = row.querySelector('nuxeo-tooltip');
+        tooltip.show();
+        await flush();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        const rect = tooltip._tooltip.getBoundingClientRect();
+        tooltip.hide();
+        return rect;
+      };
+
+      const single = await measure(rowFor('Short'));
+      const wrapped = await measure(rowFor('DXXX'));
+
+      expect(wrapped.width).to.be.below(window.innerWidth);
+      expect(Math.floor(wrapped.left)).to.be.at.least(0);
+      expect(Math.ceil(wrapped.right)).to.be.at.most(window.innerWidth);
+      // Capped and wrapped onto several lines rather than stretched into one long one.
+      expect(wrapped.height).to.be.above(single.height);
     });
   });
 });

--- a/test/nuxeo-search-form.test.js
+++ b/test/nuxeo-search-form.test.js
@@ -598,6 +598,53 @@ suite('nuxeo-search-form', () => {
       expect(searchForm.$.provider.quickFilters).to.deep.equal([]);
     });
   });
+
+  suite('result name tooltip (WEBUI-2009)', () => {
+    // Result names wrap onto two lines and are clamped beyond that, so the tooltip is
+    // applied on hover only when the name is actually clipped. Heights are stubbed because
+    // a detached node has no layout.
+    const nameNode = (text, clientHeight, scrollHeight) => {
+      const node = document.createElement('span');
+      node.textContent = text;
+      Object.defineProperty(node, 'clientHeight', { value: clientHeight });
+      Object.defineProperty(node, 'scrollHeight', { value: scrollHeight });
+      return node;
+    };
+
+    test('adds the full name as a tooltip when the name is clipped', () => {
+      const name = 'D-DF-ASTURL61CZRIE-LSPS-PLANNING-PLATEFORME-SUD-2025-REVISION-A-01';
+      const node = nameNode(name, 40, 80);
+      searchForm._showTitleIfTruncated({ currentTarget: node });
+      expect(node.getAttribute('title')).to.equal(name);
+    });
+
+    test('adds no tooltip when the name fits within the two lines shown', () => {
+      const node = nameNode('Short name', 40, 40);
+      searchForm._showTitleIfTruncated({ currentTarget: node });
+      expect(node.hasAttribute('title')).to.be.false;
+    });
+
+    test('tolerates sub-pixel line-height rounding rather than reporting a false clip', () => {
+      const node = nameNode('Short name', 40, 41);
+      searchForm._showTitleIfTruncated({ currentTarget: node });
+      expect(node.hasAttribute('title')).to.be.false;
+    });
+
+    test('drops a stale tooltip when a recycled row now holds a name that fits', () => {
+      // iron-list reuses row nodes, so a node that was clipped can be rebound to a
+      // shorter name; the tooltip from the previous document must not survive.
+      const node = nameNode('Short name', 40, 40);
+      node.setAttribute('title', 'A much longer name from the document previously in this row');
+      searchForm._showTitleIfTruncated({ currentTarget: node });
+      expect(node.hasAttribute('title')).to.be.false;
+    });
+
+    test('trims surrounding whitespace so the tooltip matches the rendered name', () => {
+      const node = nameNode('  Padded name  ', 40, 80);
+      searchForm._showTitleIfTruncated({ currentTarget: node });
+      expect(node.getAttribute('title')).to.equal('Padded name');
+    });
+  });
 });
 
 /**

--- a/test/nuxeo-search-form.test.js
+++ b/test/nuxeo-search-form.test.js
@@ -600,49 +600,70 @@ suite('nuxeo-search-form', () => {
   });
 
   suite('result name tooltip (WEBUI-2009)', () => {
-    // Result names wrap onto two lines and are clamped beyond that, so the tooltip is
-    // applied on hover only when the name is actually clipped. Heights are stubbed because
-    // a detached node has no layout.
-    const nameNode = (text, clientHeight, scrollHeight) => {
-      const node = document.createElement('span');
-      node.textContent = text;
-      Object.defineProperty(node, 'clientHeight', { value: clientHeight });
-      Object.defineProperty(node, 'scrollHeight', { value: scrollHeight });
-      return node;
+    // Names stay truncated to one line, so every row carries a tooltip with the full name.
+    // These read the class-level template: iron-list templatizes the row template at
+    // runtime, which empties the instance's copy.
+    const rowTemplate = () => {
+      const template = searchForm.constructor.template.content.querySelector('#list template');
+      expect(template, 'result row template').to.not.be.null;
+      return template;
     };
+    const rowTooltip = () => rowTemplate().content.querySelector('nuxeo-tooltip');
+    const rowName = () => rowTemplate().content.querySelector('.list-item-title');
 
-    test('adds the full name as a tooltip when the name is clipped', () => {
-      const name = 'D-DF-ASTURL61CZRIE-LSPS-PLANNING-PLATEFORME-SUD-2025-REVISION-A-01';
-      const node = nameNode(name, 40, 80);
-      searchForm._showTitleIfTruncated({ currentTarget: node });
-      expect(node.getAttribute('title')).to.equal(name);
+    test('the tooltip exposes the untruncated name', () => {
+      const tooltip = rowTooltip();
+      expect(tooltip, 'result row tooltip').to.not.be.null;
+      expect(tooltip.textContent.trim()).to.equal('[[item.title]]');
     });
 
-    test('adds no tooltip when the name fits within the two lines shown', () => {
-      const node = nameNode('Short name', 40, 40);
-      searchForm._showTitleIfTruncated({ currentTarget: node });
-      expect(node.hasAttribute('title')).to.be.false;
+    test('the tooltip sits outside the name so the name text is unchanged', () => {
+      // Nesting it inside would append a duplicate of the title to the span's textContent.
+      expect(rowName().querySelector('nuxeo-tooltip')).to.be.null;
+      expect(rowName().textContent.trim()).to.equal('[[item.title]]');
     });
 
-    test('tolerates sub-pixel line-height rounding rather than reporting a false clip', () => {
-      const node = nameNode('Short name', 40, 41);
-      searchForm._showTitleIfTruncated({ currentTarget: node });
-      expect(node.hasAttribute('title')).to.be.false;
+    test('the tooltip is anchored on its parent row rather than by id', () => {
+      // The row template is stamped once per result into the same shadow root, so a "for"
+      // attribute would resolve every row's tooltip to the first matching id.
+      const tooltip = rowTooltip();
+      expect(tooltip.hasAttribute('for')).to.be.false;
+      expect(tooltip.parentElement.classList.contains('list-item-info')).to.be.true;
     });
 
-    test('drops a stale tooltip when a recycled row now holds a name that fits', () => {
-      // iron-list reuses row nodes, so a node that was clipped can be rebound to a
-      // shorter name; the tooltip from the previous document must not survive.
-      const node = nameNode('Short name', 40, 40);
-      node.setAttribute('title', 'A much longer name from the document previously in this row');
-      searchForm._showTitleIfTruncated({ currentTarget: node });
-      expect(node.hasAttribute('title')).to.be.false;
+    test('the tooltip is hidden from the accessibility tree', () => {
+      // The name is already exposed as row text; announcing it twice is noise.
+      expect(rowTooltip().getAttribute('aria-hidden')).to.equal('true');
     });
 
-    test('trims surrounding whitespace so the tooltip matches the rendered name', () => {
-      const node = nameNode('  Padded name  ', 40, 80);
-      searchForm._showTitleIfTruncated({ currentTarget: node });
-      expect(node.getAttribute('title')).to.equal('Padded name');
+    test('the name stays on a single truncated line', () => {
+      // .ellipsis supplies the single-line truncation; no local rule may reintroduce wrapping
+      expect(rowName().classList.contains('ellipsis')).to.be.true;
+      const styles = [...searchForm.constructor.template.content.querySelectorAll('style')]
+        .map((s) => s.textContent)
+        .join('\n');
+      expect(styles).to.not.contain('-webkit-line-clamp');
+    });
+
+    test('every rendered row gets its own tooltip', async () => {
+      searchForm.queue = true;
+      searchForm.$.list.items = [
+        { uid: '1', type: 'File', path: '/a', title: 'D-DF-ASTURL61CZRIE-LSPS-PLANNING-2025-REV-01' },
+        { uid: '2', type: 'File', path: '/b', title: 'D-DF-ASTURL61CZRIE-LSPS-PLANNING-2025-REV-02' },
+        { uid: '3', type: 'File', path: '/c', title: 'Short' },
+      ];
+      // iron-list decides how many rows to stamp, so poll rather than assume a count
+      for (let i = 0; i < 40 && searchForm.$.list.querySelectorAll('.list-item-info').length === 0; i++) {
+        await flush();
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      const rows = searchForm.$.list.querySelectorAll('.list-item-info');
+      expect(rows.length).to.be.at.least(1);
+      rows.forEach((row) => {
+        const name = row.querySelector('.list-item-title').textContent.trim();
+        expect(row.querySelector('nuxeo-tooltip'), `tooltip for "${name}"`).to.not.be.null;
+      });
     });
   });
 });

--- a/test/nuxeo-search-result-tooltip-styles.test.js
+++ b/test/nuxeo-search-result-tooltip-styles.test.js
@@ -51,7 +51,7 @@ suite('nuxeo-search-result-tooltip-styles', () => {
     ensureSearchResultTooltipStyles();
     ensureSearchResultTooltipStyles();
 
-    expect(document.querySelectorAll(`#${STYLES_ID}`).length).to.equal(1);
+    expect(document.querySelectorAll(`#${STYLES_ID}`)).to.have.lengthOf(1);
     expect(document.getElementById(STYLES_ID)).to.equal(first);
   });
 

--- a/test/nuxeo-search-result-tooltip-styles.test.js
+++ b/test/nuxeo-search-result-tooltip-styles.test.js
@@ -1,0 +1,76 @@
+/**
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { ensureSearchResultTooltipStyles } from '../elements/search/nuxeo-search-result-tooltip-styles.js';
+
+const STYLES_ID = 'nuxeo-search-result-tooltip-styles';
+
+suite('nuxeo-search-result-tooltip-styles', () => {
+  // Importing nuxeo-search-form.js injects these already, so start from a known state.
+  setup(() => {
+    const existing = document.getElementById(STYLES_ID);
+    if (existing) {
+      existing.remove();
+    }
+  });
+
+  // Every test file shares one document, and nuxeo-search-form's own suite relies on these
+  // styles being present, so hand the document back in the state its import leaves it in.
+  teardown(() => {
+    ensureSearchResultTooltipStyles();
+  });
+
+  test('injects the stylesheet on the document, where cloned tooltip content lives', () => {
+    ensureSearchResultTooltipStyles();
+
+    const style = document.getElementById(STYLES_ID);
+    expect(style, 'injected stylesheet').to.not.be.null;
+    expect(style.parentElement).to.equal(document.head);
+    expect(style.textContent).to.contain('.nuxeo-search-result-tooltip-name');
+  });
+
+  test('is idempotent so repeated imports do not stack stylesheets', () => {
+    ensureSearchResultTooltipStyles();
+    const first = document.getElementById(STYLES_ID);
+
+    // Exercises the early return.
+    ensureSearchResultTooltipStyles();
+    ensureSearchResultTooltipStyles();
+
+    expect(document.querySelectorAll(`#${STYLES_ID}`).length).to.equal(1);
+    expect(document.getElementById(STYLES_ID)).to.equal(first);
+  });
+
+  test('caps the width against both an absolute and a viewport-relative limit', () => {
+    // The viewport-relative half is what keeps the cap correct when the user zooms in, since
+    // zooming shrinks the CSS viewport while an absolute cap would stay put.
+    ensureSearchResultTooltipStyles();
+
+    const rules = document.getElementById(STYLES_ID).textContent;
+    expect(rules).to.contain('max-width: min(400px, 40vw)');
+  });
+
+  test('lets a name with no break opportunity wrap instead of overflowing', () => {
+    ensureSearchResultTooltipStyles();
+
+    const rules = document.getElementById(STYLES_ID).textContent;
+    expect(rules).to.contain('white-space: normal');
+    expect(rules).to.contain('overflow-wrap: break-word');
+    // A capped box only helps if the box is a block that the cap can apply to.
+    expect(rules).to.contain('display: block');
+  });
+});


### PR DESCRIPTION
## Problem

In the search drawer, each result name is rendered on a single line and clipped with an
ellipsis, with no tooltip. When several documents share a long common prefix — the
reporter's case is `D-DF-ASTURL61CZRIE-LSPS-PLANNING-2025-REV-01`, `-REV-02`, `-REV-03` —
every row renders as the same truncated string, so the list is unusable: the only way to
tell the results apart is to open each one.

Reported on [WEBUI-2009](https://hyland.atlassian.net/browse/WEBUI-2009).

## Root cause

`elements/search/nuxeo-search-form.js` renders each result name as
`<span class="list-item-title ellipsis">`. The element's local `.ellipsis` rule is
`text-overflow: ellipsis; overflow: hidden; white-space: nowrap`, so the name is truncated
and nothing exposes the untruncated value.

Measured on a live instance before the change: of 36 rendered rows, 2 were clipped and 0
carried any tooltip.

## Change

Every result row gets a `nuxeo-tooltip` carrying `[[item.title]]`, opening to the right of
the row:

```html
<span class="list-item-title ellipsis">[[item.title]]</span>
<nuxeo-tooltip position="right" offset="8" aria-hidden="true"
  ><span class="nuxeo-search-result-tooltip-name">[[item.title]]</span></nuxeo-tooltip
>
```

Names deliberately stay on a single truncated line, and every row gets the tooltip rather
than only the clipped ones. Four details are load-bearing:

- **The tooltip sits outside the name span.** Nesting it would append a duplicate of the
  title to the span's own `textContent`.
- **It is anchored on the parent row, not by `for`.** This template is stamped once per
  result into the same shadow root, so an `id` would not be unique and every row's tooltip
  would resolve to the first match.
- **It opens to the right.** Below the row it would cover the next results while the user
  is scanning the list.
- **It is `aria-hidden`.** The name is already exposed as the row's text; announcing it a
  second time is noise.

### Why a document-level stylesheet

`nuxeo-tooltip` does not render its content in place: on `show()` it creates a
`paper-tooltip`, appends it to `document.body`, and clones the slot content into it. The
rendered node therefore lives outside this element's shadow root, so a rule in the Polymer
template never matches it — the widget's own JSDoc says as much, and it solves the same
problem for itself with `ensureClonedContentStyles()` and its `resize-handle` role.

Without a cap the bubble is sized purely by its content, so a name with no break
opportunity runs off-screen. Measured on another consumer of the same widget (the grid
thumbnail): a 241-character name renders **2067px wide with ~787px off-screen** at a
1280px viewport.

`nuxeo-search-result-tooltip-styles.js` therefore injects one document-level rule, scoped
by a class name that travels with the clone:

```css
.nuxeo-search-result-tooltip-name {
  display: block;
  max-width: min(400px, 40vw);
  white-space: normal;
  overflow-wrap: break-word;
  line-height: 1.4;
  text-align: start;
}
```

The cap is absolute *and* viewport-relative so it still holds when the user zooms in, which
shrinks the CSS viewport while an absolute cap would stay put. Injection is idempotent.

`nuxeo-search-form` backs the `defaultSearch`, `expiredSearch`, `assetsSearch` and `trash`
drawers, so all four benefit.

## Test plan

Local gate, the same checks CI gates on:

- `npx eslint` and `npx prettier --check` on all four changed files — clean.
- `npm test` — **2318 passed, 0 failed**, including the coverage gate.
- SonarCloud — quality gate passed, **0 new issues**, 100% coverage on new code.

Thirteen new unit tests: nine in `test/nuxeo-search-form.test.js` pin the binding text, the
placement outside the span, the parent anchoring, `aria-hidden`, the single-line truncation
with no `-webkit-line-clamp`, the right-hand placement, the wrapper element the cap matches,
that a name with no break opportunity stays inside the viewport, and that every row
`iron-list` stamps gets its own tooltip. Four in
`test/nuxeo-search-result-tooltip-styles.test.js` cover the injection, its idempotence, the
width cap and the wrapping declarations. The stylesheet tests were mutation-checked by
removing the injection and confirming they fail.

Verified against a live instance (Nuxeo 2025 plus the webpack dev server), search drawer,
results-list view:

| Check | Before | After |
|---|---|---|
| Rows carrying a tooltip | 0 of 36 | 36 of 36 |
| Tooltip text matching the row title exactly | — | 36 of 36 |
| `white-space` / `text-overflow` on the name | `nowrap` / `ellipsis` | unchanged |
| Lines shown per name | 1 | 1 |
| `-webkit-line-clamp` anywhere in the element | none | none |
| Tooltip placement | — | right of the row |
| Bubble containment, 241-char unbreakable name | runs off-screen | inside the viewport |
| Panel header `white-space` | `nowrap` | `nowrap` (unchanged) |

Containment was probed at 1280px and 640px viewport widths against three seeded names — one
broken by spaces, one by hyphens, and one 241-character token with no break opportunity at
all — including rows scrolled to the very top and bottom of the list, where `paper-tooltip`
has to flip to stay in bounds.

## Notes

- A tooltip on every row was a deliberate product decision, rather than measuring geometry
  to tooltip only the clipped rows. It keeps the template declarative: whether a name is
  clipped depends on the drawer's current width and `iron-list` recycles rows between
  documents, so a conditional tooltip needs hover-time measurement to stay correct.
- `paper-tooltip` fades in via a compositor-driven opacity animation that Chrome's
  screenshot rasteriser does not reflect. It is hit-testable and reports `opacity: 0.9` yet
  comes out invisible in in-page captures, so the attached evidence is a desktop grab from a
  headful browser.
- The same single-line truncation exists in the Favorites, Clipboard, Collections and
  Recently viewed drawers. Those were deliberately left out to keep this PR scoped to what
  was reported.
- The missing width cap is a `nuxeo-tooltip` gap rather than a search one — any consumer
  passing long content hits it. Worth a follow-up in nuxeo-elements; the measurements above
  are the starting evidence.

[WEBUI-2009]: https://hyland.atlassian.net/browse/WEBUI-2009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
