### PR TITLE
WEBUI-2178: Clear stored table column preferences on reset [lts-2025]

### DIFF
--- a/elements/nuxeo-results/nuxeo-results.js
+++ b/elements/nuxeo-results/nuxeo-results.js
@@ -889,7 +889,13 @@ Polymer({
     this.view.notifyResize();
   },
 
-  _saveViewSettings() {
+  _saveViewSettings(e) {
+    // A reset has to drop what is already stored; saving would just persist the defaults on top of it
+    // and the previous width/order would come back from the backend on the next load (WEBUI-2178).
+    if (e && e.detail && e.detail.source === 'reset') {
+      this._clearViewSettings();
+      return;
+    }
     if (this.view.settings && !this._isRestoring) {
       this.set('_settings.displayMode', this.displayMode);
       this.saveSettings();
@@ -947,6 +953,48 @@ Polymer({
       // This branch runs when neither doc nor global prefs are applicable
       this.set(`_settings.${this.displayMode}`, this.view.settings);
       this.saveSettings();
+    }
+  },
+
+  // Drops the stored table preferences for this result set, in local storage and in whichever backend
+  // holds them, so the layout defaults survive a reload. Mirrors the branches of _saveViewSettings.
+  _clearViewSettings() {
+    if (this._isRestoring) {
+      return;
+    }
+
+    // Empty settings read back as "no preferences", so the table falls through to its defaults.
+    this.set(`_settings.${this.displayMode}`, {});
+    this.saveSettings();
+
+    if (this.displayMode !== 'table') {
+      return;
+    }
+
+    // ---- doc level (content views) ----
+    if (this.document && this.document.path) {
+      const docKey = this._getDocResultsPrefsKey();
+      this._debounceSave('_docPrefsSaveDebouncer', () => {
+        this.saveDocPrefs(this.document.path, docKey, {}).catch((error) => {
+          // eslint-disable-next-line no-console
+          console.warn('Failed to clear document results preferences in the backend', {
+            path: this.document && this.document.path,
+            key: docKey,
+            error,
+          });
+        });
+      });
+      return;
+    }
+
+    // ---- global level (search providers) ----
+    if (this._shouldUseGlobalPrefs) {
+      this._debounceSave('_prefsSaveDebouncer', () => {
+        this.saveGlobalResultsPrefs({}).catch((error) => {
+          // eslint-disable-next-line no-console
+          console.warn('Failed to clear global results preferences in the backend', error);
+        });
+      });
     }
   },
 

--- a/elements/nuxeo-results/nuxeo-results.js
+++ b/elements/nuxeo-results/nuxeo-results.js
@@ -974,6 +974,7 @@ Polymer({
     // ---- doc level (content views) ----
     if (this.document && this.document.path) {
       const docKey = this._getDocResultsPrefsKey();
+      this._clearCachedDocPrefs(this.document.path, docKey);
       this._debounceSave('_docPrefsSaveDebouncer', () => {
         this.saveDocPrefs(this.document.path, docKey, {}).catch((error) => {
           // eslint-disable-next-line no-console
@@ -989,6 +990,7 @@ Polymer({
 
     // ---- global level (search providers) ----
     if (this._shouldUseGlobalPrefs) {
+      this._clearCachedGlobalPrefs();
       this._debounceSave('_prefsSaveDebouncer', () => {
         this.saveGlobalResultsPrefs({}).catch((error) => {
           // eslint-disable-next-line no-console
@@ -996,6 +998,27 @@ Polymer({
         });
       });
     }
+  },
+
+  // The backend write is debounced, so drop the in-session copy up front. Until that write lands the
+  // _applyDocPrefs observer would otherwise re-apply the stale cached prefs and undo the reset.
+  _clearCachedDocPrefs(docPath, key) {
+    const userId = this._getUserId();
+    if (userId) {
+      __docPrefsCache.set(this._docCacheKey(userId, docPath, key), {});
+    }
+    this.__hasBackendDocPrefs = false;
+    this.docPrefs = {};
+  },
+
+  // Same reasoning as _clearCachedDocPrefs, for the global (search provider) preferences.
+  _clearCachedGlobalPrefs() {
+    const userId = this._getUserId();
+    const providerName = this._getProviderName(this.nxProvider);
+    if (userId && providerName) {
+      __globalPrefsCache.set(this._cacheKey(userId, providerName), {});
+    }
+    this.globalPrefs = {};
   },
 
   _providerChanged(provider, oldProvider) {

--- a/elements/nuxeo-results/nuxeo-results.js
+++ b/elements/nuxeo-results/nuxeo-results.js
@@ -892,7 +892,7 @@ Polymer({
   _saveViewSettings(e) {
     // A reset has to drop what is already stored; saving would just persist the defaults on top of it
     // and the previous width/order would come back from the backend on the next load (WEBUI-2178).
-    if (e && e.detail && e.detail.source === 'reset') {
+    if (e?.detail?.source === 'reset') {
       this._clearViewSettings();
       return;
     }
@@ -972,14 +972,14 @@ Polymer({
     }
 
     // ---- doc level (content views) ----
-    if (this.document && this.document.path) {
+    if (this.document?.path) {
       const docKey = this._getDocResultsPrefsKey();
       this._clearCachedDocPrefs(this.document.path, docKey);
       this._debounceSave('_docPrefsSaveDebouncer', () => {
         this.saveDocPrefs(this.document.path, docKey, {}).catch((error) => {
           // eslint-disable-next-line no-console
           console.warn('Failed to clear document results preferences in the backend', {
-            path: this.document && this.document.path,
+            path: this.document?.path,
             key: docKey,
             error,
           });

--- a/test/nuxeo-results.test.js
+++ b/test/nuxeo-results.test.js
@@ -630,6 +630,58 @@ suite('nuxeo-results', () => {
       results.nxProvider = null;
     });
 
+    test('_clearViewSettings logs and swallows a doc prefs backend failure', async () => {
+      results._isRestoring = false;
+      results.displayMode = 'table';
+      results._settings = {};
+      results.name = 'default';
+      results.document = { path: '/default-domain' };
+      const debounceStub = sinon.stub(results, '_debounceSave').callsFake((_, fn) => fn());
+      const saveDocStub = sinon.stub(results, 'saveDocPrefs').rejects(new Error('boom'));
+      const warnStub = sinon.stub(console, 'warn');
+
+      results._clearViewSettings();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(warnStub).to.have.been.calledWith(
+        'Failed to clear document results preferences in the backend',
+        sinon.match.object,
+      );
+
+      debounceStub.restore();
+      saveDocStub.restore();
+      warnStub.restore();
+      results.document = null;
+    });
+
+    test('_clearViewSettings logs and swallows a global prefs backend failure', async () => {
+      results._isRestoring = false;
+      results.displayMode = 'table';
+      results._settings = {};
+      results.document = null;
+      const allPrefsStub = sinon.stub(results, '_getAllGlobalPreferencesOnce').resolves({});
+      const provider = createMockProvider();
+      provider.provider = 'default_search';
+      results.nxProvider = provider;
+      const debounceStub = sinon.stub(results, '_debounceSave').callsFake((_, fn) => fn());
+      const saveGlobalStub = sinon.stub(results, 'saveGlobalResultsPrefs').rejects(new Error('boom'));
+      const warnStub = sinon.stub(console, 'warn');
+
+      results._clearViewSettings();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(warnStub).to.have.been.calledWith(
+        'Failed to clear global results preferences in the backend',
+        sinon.match.instanceOf(Error),
+      );
+
+      debounceStub.restore();
+      saveGlobalStub.restore();
+      warnStub.restore();
+      allPrefsStub.restore();
+      results.nxProvider = null;
+    });
+
     test('_clearViewSettings leaves the backend alone outside the table display mode', () => {
       results._isRestoring = false;
       results.displayMode = 'grid';

--- a/test/nuxeo-results.test.js
+++ b/test/nuxeo-results.test.js
@@ -630,6 +630,56 @@ suite('nuxeo-results', () => {
       results.nxProvider = null;
     });
 
+    test('_clearViewSettings drops the in-session doc prefs before the debounced backend write', () => {
+      results._isRestoring = false;
+      results.displayMode = 'table';
+      results._settings = {};
+      results.name = 'default';
+      results._connectedUserId = 'jdoe';
+      results.document = { path: '/default-domain' };
+      results.docPrefs = { columns: { 'dc:title': { width: '620px' } } };
+      results.__hasBackendDocPrefs = true;
+      // Never run the backend call, so this asserts the state before it would have resolved.
+      const debounceStub = sinon.stub(results, '_debounceSave');
+
+      results._clearViewSettings();
+
+      expect(results.docPrefs).to.deep.equal({});
+      expect(results.__hasBackendDocPrefs).to.be.false;
+
+      // The module-level cache was cleared too, so re-loading does not resurrect the old prefs.
+      results.docPrefs = { columns: { 'dc:title': { width: '620px' } } };
+      results._loadDocPrefs(true, results.document, 'jdoe');
+      expect(results.docPrefs).to.deep.equal({});
+
+      debounceStub.restore();
+      results.document = null;
+      results._connectedUserId = null;
+    });
+
+    test('_clearViewSettings drops the in-session global prefs before the debounced backend write', () => {
+      results._isRestoring = false;
+      results.displayMode = 'table';
+      results._settings = {};
+      results.document = null;
+      results._connectedUserId = 'jdoe';
+      const allPrefsStub = sinon.stub(results, '_getAllGlobalPreferencesOnce').resolves({});
+      const provider = createMockProvider();
+      provider.provider = 'default_search';
+      results.nxProvider = provider;
+      results.globalPrefs = { columns: { 'dc:title': { width: '620px' } } };
+      const debounceStub = sinon.stub(results, '_debounceSave');
+
+      results._clearViewSettings();
+
+      expect(results.globalPrefs).to.deep.equal({});
+
+      debounceStub.restore();
+      allPrefsStub.restore();
+      results.nxProvider = null;
+      results._connectedUserId = null;
+    });
+
     test('_clearViewSettings logs and swallows a doc prefs backend failure', async () => {
       results._isRestoring = false;
       results.displayMode = 'table';

--- a/test/nuxeo-results.test.js
+++ b/test/nuxeo-results.test.js
@@ -543,6 +543,123 @@ suite('nuxeo-results', () => {
     });
   });
 
+  suite('Reset Clears Stored Prefs (WEBUI-2178)', () => {
+    test('_saveViewSettings clears stored prefs instead of saving them on a reset', () => {
+      results._isRestoring = false;
+      results.displayMode = 'table';
+      results.view = createMockView({ settings: { order: ['dc:title'] } });
+      const clearStub = sinon.stub(results, '_clearViewSettings');
+      const saveSpy = sinon.spy(results, 'saveSettings');
+
+      results._saveViewSettings({ detail: { source: 'reset' } });
+
+      expect(clearStub).to.have.been.calledOnce;
+      expect(saveSpy).to.not.have.been.called;
+
+      clearStub.restore();
+      saveSpy.restore();
+    });
+
+    test('_saveViewSettings still saves for other settings-changed sources', () => {
+      results._isRestoring = false;
+      results.displayMode = 'grid';
+      results._settings = {};
+      results.view = createMockView({ settings: { density: 'compact' } });
+      const clearStub = sinon.stub(results, '_clearViewSettings');
+
+      results._saveViewSettings({ detail: { source: 'column-resize' } });
+
+      expect(clearStub).to.not.have.been.called;
+      clearStub.restore();
+    });
+
+    test('_clearViewSettings empties the local storage entry for the display mode', () => {
+      results._isRestoring = false;
+      results.displayMode = 'table';
+      results._settings = { displayMode: 'table', table: { columns: { 'dc:title': { width: '400px' } } } };
+      results.document = null;
+      const saveSpy = sinon.spy(results, 'saveSettings');
+
+      results._clearViewSettings();
+
+      expect(results._settings.table).to.deep.equal({});
+      expect(results._settings.displayMode).to.equal('table');
+      expect(saveSpy).to.have.been.called;
+      saveSpy.restore();
+    });
+
+    test('_clearViewSettings writes empty doc prefs in document context', () => {
+      results._isRestoring = false;
+      results.displayMode = 'table';
+      results._settings = {};
+      results.name = 'default';
+      results.document = { path: '/default-domain' };
+      const debounceStub = sinon.stub(results, '_debounceSave').callsFake((_, fn) => fn());
+      const saveDocStub = sinon.stub(results, 'saveDocPrefs').resolves();
+
+      results._clearViewSettings();
+
+      expect(saveDocStub).to.have.been.calledWith('/default-domain', 'documentPrefs.default', {});
+
+      debounceStub.restore();
+      saveDocStub.restore();
+      results.document = null;
+    });
+
+    test('_clearViewSettings writes empty global prefs for search providers', () => {
+      results._isRestoring = false;
+      results.displayMode = 'table';
+      results._settings = {};
+      results.document = null;
+      // _shouldUseGlobalPrefs is computed, so drive it through its inputs rather than assigning it.
+      const allPrefsStub = sinon.stub(results, '_getAllGlobalPreferencesOnce').resolves({});
+      const provider = createMockProvider();
+      provider.provider = 'default_search';
+      results.nxProvider = provider;
+      const debounceStub = sinon.stub(results, '_debounceSave').callsFake((_, fn) => fn());
+      const saveGlobalStub = sinon.stub(results, 'saveGlobalResultsPrefs').resolves();
+
+      results._clearViewSettings();
+
+      expect(results._shouldUseGlobalPrefs).to.be.true;
+      expect(saveGlobalStub).to.have.been.calledWith({});
+
+      debounceStub.restore();
+      saveGlobalStub.restore();
+      allPrefsStub.restore();
+      results.nxProvider = null;
+    });
+
+    test('_clearViewSettings leaves the backend alone outside the table display mode', () => {
+      results._isRestoring = false;
+      results.displayMode = 'grid';
+      results._settings = {};
+      results.document = { path: '/default-domain' };
+      const saveDocStub = sinon.stub(results, 'saveDocPrefs').resolves();
+
+      results._clearViewSettings();
+
+      expect(saveDocStub).to.not.have.been.called;
+
+      saveDocStub.restore();
+      results.document = null;
+    });
+
+    test('_clearViewSettings does nothing while restoring', () => {
+      results._isRestoring = true;
+      results.displayMode = 'table';
+      results._settings = { table: { columns: {} } };
+      const saveSpy = sinon.spy(results, 'saveSettings');
+
+      results._clearViewSettings();
+
+      expect(saveSpy).to.not.have.been.called;
+
+      saveSpy.restore();
+      results._isRestoring = false;
+    });
+  });
+
   suite('Column Management', () => {
     test('updates columns when columns-changed event is fired', () => {
       const newColumns = [


### PR DESCRIPTION
## Problem
Resetting `nuxeo-data-table` column settings does not stick. Even once the dialog restores the columns in the browser, the width and order the user had before come straight back on the next page load, because the stored preferences are never cleared. Jira: [WEBUI-2178](https://hyland.atlassian.net/browse/WEBUI-2178) (the `nuxeo-web-ui` half of [WEBUI-2086](https://hyland.atlassian.net/browse/WEBUI-2086))

## Root cause
`nuxeo-results` persists table settings to three places — the document `@preferences` in a content view, `/me/preferences/<provider>` on a search page, and the `<userId>-nuxeo-results-<name>` local-storage entry — but `_saveViewSettings()` only ever **writes the current settings**. There is no code path that clears a preference already stored, and the event detail was ignored, so a reset was indistinguishable from an ordinary column change and just re-saved the on-screen state.

## Changes
* **`elements/nuxeo-results/nuxeo-results.js`**:
  * `_saveViewSettings(e)` now inspects the event detail and delegates to a new `_clearViewSettings()` when the dialog reports `source: 'reset'` (added in nuxeo/nuxeo-elements#1536).
  * `_clearViewSettings()` mirrors the branches of `_saveViewSettings`: it empties the local-storage entry for the current display mode, and — in table mode only — writes empty preferences to the document `@preferences` or to the global provider preferences. Writing empty preferences reuses `saveDocPrefs` / `saveGlobalResultsPrefs`, which also refresh the in-session caches, so the reset holds without a reload. Backend failures are logged and swallowed, as on the save path.
  * Empty settings read back as "no preferences", so the existing `_applyPrefsToView(view, {})` path restores the layout defaults.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes — 2312 passed, 0 failed
- [x] Seven new unit tests cover the reset branch, the non-reset sources, local-storage clearing, the doc-prefs and global-prefs backends, the non-table display mode, and the restoring guard
- [x] Manually verified end to end on a 2025 server (evidence attached to the Jira): resized Title to 620px, reordered two columns and hid one, confirmed the preferences were stored server-side, pressed Reset, then reloaded. Before the fix the stored prefs still read `"width":"620px"` and the customisation returned; after the fix both the server prefs and local storage are empty and the table stays at its defaults.

## Notes
Depends on nuxeo/nuxeo-elements#1536 for the `source: 'reset'` signal; without it this code is inert, so the two can land independently. Backport to `maintenance-3.1.x` follows.

Made with [Cursor](https://cursor.com)

[WEBUI-2178]: https://hyland.atlassian.net/browse/WEBUI-2178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBUI-2086]: https://hyland.atlassian.net/browse/WEBUI-2086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ