### PR TITLE
WEBUI-1853: Allow published documents to be reorganised with the clipboard

### DIFF
--- a/elements/nuxeo-clipboard/nuxeo-clipboard.js
+++ b/elements/nuxeo-clipboard/nuxeo-clipboard.js
@@ -268,9 +268,21 @@ Polymer({
     if (!documents || documents.length === 0 || !this.hasFacet(doc, 'Folderish')) {
       return false;
     }
-    return doc.contextParameters && doc.contextParameters.subtypes
-      ? documents.every((entry) => doc.contextParameters.subtypes.map((e) => e.type).indexOf(entry.type) > -1)
-      : true;
+    const subtypes = doc.contextParameters && doc.contextParameters.subtypes;
+    return documents.every((entry) => this._isAllowedInTarget(entry, doc, subtypes));
+  },
+
+  /**
+   * A proxy is only accepted in a publication space. The publishing service creates proxies
+   * there without consulting the accepted child types, so a section never lists the published
+   * document's type among its subtypes and the regular subtype check can't apply to it.
+   * Anywhere else, and for any non-proxy document, the target's accepted child types decide.
+   */
+  _isAllowedInTarget(entry, target, subtypes) {
+    if (this.isProxy(entry)) {
+      return this.hasFacet(target, 'PublishSpace');
+    }
+    return subtypes ? subtypes.some((subtype) => subtype.type === entry.type) : true;
   },
 
   execute(evt) {

--- a/elements/nuxeo-clipboard/nuxeo-clipboard.js
+++ b/elements/nuxeo-clipboard/nuxeo-clipboard.js
@@ -276,7 +276,8 @@ Polymer({
    * A proxy is only accepted in a publication space. The publishing service creates proxies
    * there without consulting the accepted child types, so a section never lists the published
    * document's type among its subtypes and the regular subtype check can't apply to it.
-   * Anywhere else, and for any non-proxy document, the target's accepted child types decide.
+   * Anywhere else, and for any non-proxy document, the target's accepted child types decide,
+   * falling back to allowing the paste when the target doesn't expose its subtypes.
    */
   _isAllowedInTarget(entry, target, subtypes) {
     if (this.isProxy(entry)) {

--- a/elements/nuxeo-document-actions/nuxeo-clipboard-toggle-button.js
+++ b/elements/nuxeo-document-actions/nuxeo-clipboard-toggle-button.js
@@ -93,7 +93,7 @@ Polymer({
   },
 
   _isAvailable(doc) {
-    return !this.isTrashed(doc) && !this.hasType(doc, 'Favorites') && !this.isVersion(doc) && !this.isProxy(doc);
+    return !this.isTrashed(doc) && !this.hasType(doc, 'Favorites') && !this.isVersion(doc);
   },
 
   toggle() {

--- a/elements/nuxeo-document-bulk-actions/nuxeo-clipboard-documents-button.js
+++ b/elements/nuxeo-document-bulk-actions/nuxeo-clipboard-documents-button.js
@@ -92,8 +92,7 @@ Polymer({
           (this.isCollectionMember(doc) || doc.facets.includes('Collection')) &&
           !this.isTrashed(doc) &&
           !this.hasType(doc, 'Favorites') &&
-          !this.isVersion(doc) &&
-          !this.isProxy(doc),
+          !this.isVersion(doc),
       )
     );
   },

--- a/elements/nuxeo-document-storage/nuxeo-document-storage.js
+++ b/elements/nuxeo-document-storage/nuxeo-document-storage.js
@@ -85,6 +85,9 @@ Polymer({
     }
     const document = {
       'entity-type': 'document',
+      // consumers need to tell a proxy apart from a regular document after a reload, since the
+      // stored entry is all they get back (the clipboard restricts where a proxy can be pasted)
+      isProxy: !!doc.isProxy,
       lastViewed: new Date(),
       path: doc.path,
       repository: doc.repository,

--- a/ftest/features/clipboard.feature
+++ b/ftest/features/clipboard.feature
@@ -63,6 +63,49 @@ Feature: Clipboard
     When I browse to the document with path "/default-domain"
     Then I can see clipboard actions disabled
 
+  Scenario: Move a published document to another section using the clipboard
+    Given I have the following documents
+      | doctype | title    | nature  | subjects           | coverage        | creator | path                     | collections | tag | file |
+      | Section | SectionA | booklet | sciences/astronomy | europe/Portugal | BJones  | /default-domain/sections |             |     |      |
+      | Section | SectionB | booklet | sciences/astronomy | europe/Portugal | BJones  | /default-domain/sections |             |     |      |
+    And I have the following permissions to the documents
+      | permission | path                              |
+      | ReadWrite  | /default-domain/sections/SectionA |
+      | ReadWrite  | /default-domain/sections/SectionB |
+    And I browse to the document with path "/default-domain/Src"
+    And I select the "File1" document
+    And I can see the selection toolbar
+    And I can publish selection to "SectionA"
+    When I browse to the document with path "/default-domain/sections/SectionA"
+    Then I can see the document has 1 children
+    When I select the "File1" document
+    And I can see the selection toolbar
+    And I can add selection to clipboard
+    And I browse to the document with path "/default-domain/sections/SectionB"
+    And I click the clipboard move action
+    Then I can see the document has 1 children
+    When I browse to the document with path "/default-domain/sections/SectionA"
+    Then I can see the document has 0 children
+
+  Scenario: Can't use clipboard to paste a published document outside the publication area
+    Given I have the following documents
+      | doctype | title    | nature  | subjects           | coverage        | creator | path                     | collections | tag | file |
+      | Section | SectionA | booklet | sciences/astronomy | europe/Portugal | BJones  | /default-domain/sections |             |     |      |
+    And I have the following permissions to the documents
+      | permission | path                              |
+      | ReadWrite  | /default-domain/sections/SectionA |
+      | ReadWrite  | /default-domain/Dest              |
+    And I browse to the document with path "/default-domain/Src"
+    And I select the "File1" document
+    And I can see the selection toolbar
+    And I can publish selection to "SectionA"
+    When I browse to the document with path "/default-domain/sections/SectionA"
+    And I select the "File1" document
+    And I can see the selection toolbar
+    And I can add selection to clipboard
+    And I browse to the document with path "/default-domain/Dest"
+    Then I can see clipboard actions disabled
+
   Scenario: Clipboard is updated when document's title changes
     Given I have permission ReadWrite for the document with path "/default-domain/Src/File1"
     And I browse to the document with path "/default-domain/Src"

--- a/ftest/features/clipboard.feature
+++ b/ftest/features/clipboard.feature
@@ -70,6 +70,7 @@ Feature: Clipboard
       | Section | SectionB | booklet | sciences/astronomy | europe/Portugal | BJones  | /default-domain/sections |             |     |      |
     And I have the following permissions to the documents
       | permission | path                              |
+      | ReadWrite  | /default-domain/Src               |
       | ReadWrite  | /default-domain/sections/SectionA |
       | ReadWrite  | /default-domain/sections/SectionB |
     And I browse to the document with path "/default-domain/Src"
@@ -93,6 +94,7 @@ Feature: Clipboard
       | Section | SectionA | booklet | sciences/astronomy | europe/Portugal | BJones  | /default-domain/sections |             |     |      |
     And I have the following permissions to the documents
       | permission | path                              |
+      | ReadWrite  | /default-domain/Src               |
       | ReadWrite  | /default-domain/sections/SectionA |
       | ReadWrite  | /default-domain/Dest              |
     And I browse to the document with path "/default-domain/Src"

--- a/test/nuxeo-clipboard-documents-button.test.js
+++ b/test/nuxeo-clipboard-documents-button.test.js
@@ -81,11 +81,13 @@ suite('nuxeo-clipboard-documents-button', () => {
       expect(element._isAvailable()).to.be.false;
     });
 
-    test('should return false when a document is a proxy', () => {
+    // a published document must be able to reach the clipboard so it can be reorganised
+    // within the publication area; where it may then be pasted is up to nuxeo-clipboard
+    test('should return true when a document is a proxy', () => {
       element.documents = [doc()];
       element.isCollectionMember.returns(true);
       element.isProxy.returns(true);
-      expect(element._isAvailable()).to.be.false;
+      expect(element._isAvailable()).to.be.true;
     });
   });
 

--- a/test/nuxeo-clipboard-toggle-button.test.js
+++ b/test/nuxeo-clipboard-toggle-button.test.js
@@ -70,10 +70,12 @@ suite('nuxeo-clipboard-toggle-button', () => {
       expect(element._isAvailable(doc)).to.be.false;
     });
 
-    test('should return false for proxy document', () => {
+    // a published document must be able to reach the clipboard so it can be reorganised
+    // within the publication area; where it may then be pasted is up to nuxeo-clipboard
+    test('should return true for proxy document', () => {
       const doc = { uid: '1', type: 'File' };
       element.isProxy.returns(true);
-      expect(element._isAvailable(doc)).to.be.false;
+      expect(element._isAvailable(doc)).to.be.true;
     });
   });
 

--- a/test/nuxeo-clipboard.test.js
+++ b/test/nuxeo-clipboard.test.js
@@ -78,6 +78,22 @@ suite('nuxeo-clipboard', () => {
   });
 
   suite('canPaste', () => {
+    // a section only ever accepts Section children, so a published File never matches its subtypes
+    const section = { uid: 's', type: 'Section', contextParameters: { subtypes: [{ type: 'Section' }] } };
+    const workspace = {
+      uid: 'w',
+      type: 'Workspace',
+      contextParameters: { subtypes: [{ type: 'File' }, { type: 'Folder' }] },
+    };
+    const proxy = { uid: 'p', type: 'File', isProxy: true };
+    const file = { uid: 'f', type: 'File' };
+
+    const folderish = (target, publishSpace) => {
+      element.hasFacet.withArgs(target, 'Folderish').returns(true);
+      element.hasFacet.withArgs(target, 'PublishSpace').returns(!!publishSpace);
+      return target;
+    };
+
     test('should return false when documents is empty', () => {
       expect(element.canPaste([], { uid: '1' })).to.be.false;
     });
@@ -89,6 +105,34 @@ suite('nuxeo-clipboard', () => {
     test('should return false when target is not Folderish', () => {
       element.hasFacet.returns(false);
       expect(element.canPaste([{ uid: '1' }], { uid: '2' })).to.be.false;
+    });
+
+    test('should allow a proxy in a publication space despite the accepted subtypes', () => {
+      expect(element.canPaste([proxy], folderish(section, true))).to.be.true;
+    });
+
+    test('should not allow a proxy outside a publication space', () => {
+      expect(element.canPaste([proxy], folderish(workspace, false))).to.be.false;
+    });
+
+    test('should allow a regular document whose type is an accepted subtype', () => {
+      expect(element.canPaste([file], folderish(workspace, false))).to.be.true;
+    });
+
+    test('should not allow a regular document in a publication space', () => {
+      expect(element.canPaste([file], folderish(section, true))).to.be.false;
+    });
+
+    test('should not allow a mixed selection of a proxy and a regular document in a publication space', () => {
+      expect(element.canPaste([proxy, file], folderish(section, true))).to.be.false;
+    });
+
+    test('should allow any regular document when the target does not expose subtypes', () => {
+      expect(element.canPaste([file], folderish({ uid: 'n', type: 'Folder' }, false))).to.be.true;
+    });
+
+    test('should not allow a proxy when the target exposes no subtypes and is not a publication space', () => {
+      expect(element.canPaste([proxy], folderish({ uid: 'n', type: 'Folder' }, false))).to.be.false;
     });
   });
 

--- a/test/nuxeo-document-storage.test.js
+++ b/test/nuxeo-document-storage.test.js
@@ -64,7 +64,7 @@ suite('nuxeo-document-storage', () => {
       expect(element.documents).to.have.lengthOf(1);
     });
 
-    test('should retain whether the document is a proxy', () => {
+    test('should copy the proxy flag into the stored document', () => {
       element.documents = [];
       element.add(doc('1', { isProxy: true }));
       expect(element.documents[0].isProxy).to.be.true;

--- a/test/nuxeo-document-storage.test.js
+++ b/test/nuxeo-document-storage.test.js
@@ -64,6 +64,18 @@ suite('nuxeo-document-storage', () => {
       expect(element.documents).to.have.lengthOf(1);
     });
 
+    test('should retain whether the document is a proxy', () => {
+      element.documents = [];
+      element.add(doc('1', { isProxy: true }));
+      expect(element.documents[0].isProxy).to.be.true;
+    });
+
+    test('should store a non-proxy document as not a proxy', () => {
+      element.documents = [];
+      element.add(doc('1'));
+      expect(element.documents[0].isProxy).to.be.false;
+    });
+
     test('should keep only whitelisted thumbnail context parameters', () => {
       element.documents = [];
       element.add(doc('1', { contextParameters: { thumbnail: { url: 'http://x/thumb.png' }, extra: 'drop' } }));


### PR DESCRIPTION
## Problem

A document published into a section (a proxy) cannot be moved to another section. The clipboard action is not offered for it, so reorganising a publication area means deleting and republishing the document — which changes its reference and breaks every permanent link pointing at it. A customer hit exactly this: they shared a permanent link, later wanted to file the published document under a new sub-section, and had to republish and then chase down every reference.

See [WEBUI-1853](https://hyland.atlassian.net/browse/WEBUI-1853).

## Root cause

Two independent checks block the flow, and only the first is commonly known:

1. `_isAvailable` in `nuxeo-clipboard-toggle-button.js` and `nuxeo-clipboard-documents-button.js` rejected any proxy. Added by #825 for [NXP-27835](https://hyland.atlassian.net/browse/NXP-27835).
2. `canPaste` in `nuxeo-clipboard.js` requires the clipboard entry's `type` to be an accepted child type of the target. A section only accepts `Section`, while a published `File` proxy reports `type: "File"`, so `COPY`/`MOVE` stay disabled even once the proxy is in the clipboard.

Measured on a live LTS-2025 instance, before the fix:

| Paste attempt | `canPaste` |
| --- | --- |
| proxy into a Section (what the user wants) | `false` |
| proxy into a Workspace (what [SUPNXP-27219](https://hyland.atlassian.net/browse/SUPNXP-27219) complained about) | `true` |

So lifting only check 1 — the change suggested on the ticket — would enable the paste nobody asked for and still block the one the customer needs. NXP-27835 originally asked for the subtype check to be relaxed for sections, and that half was never implemented.

## Changes

- `nuxeo-clipboard-toggle-button.js`, `nuxeo-clipboard-documents-button.js`: drop the `isProxy` rejection so a published document can reach the clipboard. Where it may then be pasted is decided by `nuxeo-clipboard`.
- `nuxeo-clipboard.js`: `canPaste` now delegates per entry to `_isAllowedInTarget`. A proxy is accepted only when the target carries the `PublishSpace` facet — the publishing service creates proxies there without consulting accepted child types, so the subtype check cannot meaningfully apply. Every non-proxy document keeps the existing subtype rule.
- `nuxeo-document-storage.js`: persist `isProxy` on the stored entry. The clipboard survives navigation via localStorage and the trimmed entry is all `canPaste` gets back, so the flag has to be stored.

Deliberately preserved boundaries: the clipboard still cannot be used to publish (a regular document is still refused by a section), and a proxy still cannot be pasted outside a publication area.

## Test plan

- `npm run lint` and `npm test` green on both bases — 2314 unit tests pass.
- New unit tests: `canPaste` for proxy into publication space, proxy outside it, regular document in/outside a publication space, a mixed selection, and both no-subtypes fallbacks. Storage tests assert `isProxy` round-trips.
- Updated the two unit tests that pinned the old "proxy is not clipboardable" behaviour.
- New functional scenarios in `ftest/features/clipboard.feature`: moving a published document into another section, and the boundary case that it cannot be pasted into a workspace.
- Verified manually on a throwaway LTS-2025 container (`nuxeo:2025`, dev build deployed into `nuxeo.war/ui`): published a `File` into a section, moved it into a sub-section through the clipboard. Before/after screenshots and screen recordings are attached to the ticket.
- Confirmed server-side that both operations behave on a proxy: `Document.Move` preserves the proxy uid (so the permanent link keeps resolving) and `Document.Copy` produces another proxy.

## Notes

- Backport of the same commit is open against `maintenance-3.1.x`. The ticket's `fixVersions` lists only `3.1.x`, but the affected code is identical on both bases, so shipping both keeps them from diverging.
- `isProxy` is additive in localStorage. Entries stored before an upgrade simply lack the flag and are treated as regular documents, which is the pre-existing behaviour; no migration needed.
- `nuxeo-document-storage` is shared with recents/home, which do not read `isProxy`.

Made with [Cursor](https://cursor.com)

[WEBUI-1853]: https://hyland.atlassian.net/browse/WEBUI-1853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NXP-27835]: https://hyland.atlassian.net/browse/NXP-27835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SUPNXP-27219]: https://hyland.atlassian.net/browse/SUPNXP-27219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ