### PR TITLE
WEBUI-501: Apply accessible text spacing to document history filters [lts-2025]

### DIFF
--- a/test/theme-base.test.js
+++ b/test/theme-base.test.js
@@ -1,20 +1,20 @@
 /**
- @license
- ©2023 Hyland Software, Inc. and its affiliates. All rights reserved. 
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved.
 All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
- http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- */
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 // The theme is read as a static asset rather than imported: importing it would register the whole
 // application theme in the shared test page and restyle every other suite.
@@ -23,19 +23,16 @@ function readTheme() {
 }
 
 function mixin(source, name) {
-  const start = source.indexOf(`--${name}: {`);
-  if (start === -1) {
-    return null;
-  }
-  return source.slice(start, source.indexOf('}', start));
+  const match = new RegExp(`--${name}\\s*:\\s*\\{([^}]*)\\}`).exec(source);
+  return match && match[1];
 }
 
 suite('themes/base.js', () => {
   suite('--nuxeo-label', () => {
     // WCAG 2.1 AA, SC 1.4.12 (Text Spacing): widget labels apply this mixin inside their shadow
-    // roots, so an !important spacing declaration here outranks any user text-spacing stylesheet
-    // and makes the spacing impossible to adjust. See WEBUI-501.
-    test('Should not lock text spacing with !important', async () => {
+    // roots, so an !important spacing declaration here outranks the author-origin CSS that user
+    // text-spacing tools inject, making the spacing impossible to adjust. See WEBUI-501.
+    test('should not lock text spacing with !important', async () => {
       const label = mixin(await readTheme(), 'nuxeo-label');
       expect(label, 'the --nuxeo-label mixin should be defined').to.be.a('string');
       ['letter-spacing', 'word-spacing', 'line-height'].forEach((property) => {

--- a/test/theme-base.test.js
+++ b/test/theme-base.test.js
@@ -1,0 +1,47 @@
+/**
+ @license
+ ©2023 Hyland Software, Inc. and its affiliates. All rights reserved. 
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+// The theme is read as a static asset rather than imported: importing it would register the whole
+// application theme in the shared test page and restyle every other suite.
+function readTheme() {
+  return fetch(new URL('../themes/base.js', import.meta.url)).then((response) => response.text());
+}
+
+function mixin(source, name) {
+  const start = source.indexOf(`--${name}: {`);
+  if (start === -1) {
+    return null;
+  }
+  return source.slice(start, source.indexOf('}', start));
+}
+
+suite('themes/base.js', () => {
+  suite('--nuxeo-label', () => {
+    // WCAG 2.1 AA, SC 1.4.12 (Text Spacing): widget labels apply this mixin inside their shadow
+    // roots, so an !important spacing declaration here outranks any user text-spacing stylesheet
+    // and makes the spacing impossible to adjust. See WEBUI-501.
+    test('Should not lock text spacing with !important', async () => {
+      const label = mixin(await readTheme(), 'nuxeo-label');
+      expect(label, 'the --nuxeo-label mixin should be defined').to.be.a('string');
+      ['letter-spacing', 'word-spacing', 'line-height'].forEach((property) => {
+        const declaration = new RegExp(`${property}\\s*:[^;]*!important`).exec(label);
+        expect(declaration, `${property} must stay overridable by user stylesheets`).to.be.null;
+      });
+    });
+  });
+});

--- a/themes/base.js
+++ b/themes/base.js
@@ -296,8 +296,10 @@ const template = html`
         }
 
         /*
-         * letter-spacing must stay overridable so users can apply their own text spacing
-         * (WCAG 2.1 AA, SC 1.4.12): !important here would outrank a user stylesheet.
+         * Keep letter-spacing overridable (WCAG 2.1 AA, SC 1.4.12 Text Spacing). This mixin is
+         * expanded into each widget's shadow root, so !important on a label selector outranks the
+         * author-origin universal rule that text-spacing bookmarklets and browser extensions
+         * inject, leaving the spacing impossible to adjust.
          */
         --nuxeo-label: {
           display: block;

--- a/themes/base.js
+++ b/themes/base.js
@@ -295,6 +295,10 @@ const template = html`
           background-color: var(--nuxeo-box);
         }
 
+        /*
+         * letter-spacing must stay overridable so users can apply their own text spacing
+         * (WCAG 2.1 AA, SC 1.4.12): !important here would outrank a user stylesheet.
+         */
         --nuxeo-label: {
           display: block;
           opacity: 0.9;
@@ -302,7 +306,7 @@ const template = html`
           overflow: hidden;
           text-overflow: ellipsis;
           font-weight: 400 !important;
-          letter-spacing: 0.005em !important;
+          letter-spacing: 0.005em;
           font-family: var(--nuxeo-app-font);
         }
 


### PR DESCRIPTION
## Problem

Under the document **History** tab, the filter labels — **Username**, **From**, **To**, **Performed Actions**, **Event Category** (and the matching *Select event actions* / *Select event category* placeholders) — ignore a user's text-spacing stylesheet. Letter spacing stays pinned at `0.005em` no matter what the user asks for, so WCAG 2.1 AA **SC 1.4.12 (Text Spacing)** fails: "the spacing between letters, words, lines of text and/or paragraphs cannot be adjusted".

Jira: [WEBUI-501](https://hyland.atlassian.net/browse/WEBUI-501)

## Root cause

The six labels are rendered by `nuxeo-user-suggestion`, `nuxeo-date-picker` and `nuxeo-directory-suggestion` (composed in `elements/nuxeo-audit/nuxeo-audit-search.js`), which each style their label with `@apply --nuxeo-label`.

`themes/base.js` declared that mixin with `letter-spacing: 0.005em !important`. ShadyCSS's apply-shim expands `@apply` **inside each widget's shadow-root stylesheet**, producing:

```css
label {
  /* … */
  letter-spacing: var(--nuxeo-label_-_letter-spacing) !important;
}
```

That is an author `!important` declaration on a `label` selector (specificity 0,0,1). A user text-spacing stylesheet, bookmarklet or extension injects author-origin CSS such as `* { letter-spacing: 0.12em !important }` (specificity 0,0,0), which loses the cascade — so the spacing is simply not adjustable.

Measured with a shadow-DOM-aware DOM probe on the History tab, at 400/480/600/760/860/1000/1243 px viewport widths, with the WCAG override applied: `line-height` reached 1.5 and `word-spacing` 0.16em (both were already free), but `letter-spacing` stayed at **0.005em** on all six labels instead of the required **≥ 0.12em**.

## Changes

* **`themes/base.js`**: drop `!important` from `letter-spacing` in the `--nuxeo-label` mixin, with a comment recording why it must stay overridable. The declared value is unchanged, and no other rule in any widget's shadow scope sets `letter-spacing` on a `label`/`.label`, so the rendered result at default spacing is identical — only its cascade priority drops, which is what lets a user stylesheet win. `font-weight: 400 !important` is deliberately left alone: it is not a text-spacing property, and `addons/nuxeo-template-rendering/elements/nuxeo-template-param-editor.js` (`.signature label { font-weight: bold }`) currently depends on losing to it.
* **`test/theme-base.test.js`** (new): guards the invariant — the `--nuxeo-label` mixin must not declare `letter-spacing`, `word-spacing` or `line-height` with `!important`. The theme is read as a static asset instead of imported, because importing it would register the whole application theme into the shared unit-test page and restyle every other suite.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` passes — 2306 Mocha tests, 0 failures
- [x] Automated before/after DOM probe on the real History tab (webpack dev server against a Nuxeo 2025 backend), injecting `line-height: 1.5 / letter-spacing: 0.12em / word-spacing: 0.16em / p margin-bottom: 2em` into **every** shadow root:
  - before — `letter-spacing 0.005em` on all six labels → **FAIL** at every width
  - after — `letter-spacing 0.12em`, `word-spacing 0.16em`, `line-height 1.5`, no truncation (`scrollWidth == clientWidth`), no overflow and no overlapping rects → **PASS** at 400/480/600/760/860/1000/1243 px
- [x] Default spacing unchanged: labels still compute `letter-spacing: 0.005em`; screenshots at default spacing are visually identical before and after
- [x] Re-checked at a 20px root font size
- [ ] QA: open any document → **History** tab, apply a text-spacing override (bookmarklet/extension), confirm all six filter labels widen with no clipping or overlap

## Notes

- The change is in a shared theme mixin because that is the only place the `!important` can be removed: the declaration is emitted into each widget's own shadow root, and per CSS shadow-tree cascade rules an `!important` declaration in an inner tree cannot be overridden from an outer scope. A component-local override in `nuxeo-audit-search` was prototyped and rejected — apply-shim recompiles the *shared* widget templates from whichever mixin definition it processed last, so the result would be global and dependent on element-registration order.
- The mixin's `white-space: nowrap; overflow: hidden; text-overflow: ellipsis` is intentionally left as-is. It is a latent truncation risk in general, but it does **not** clip these filter labels: they are full-column-width blocks (264–1127 px) and the widest label, "Performed Actions", renders 154 px even with the spacing override; below ~440 px the filter row wraps and each label gets the full card width.
- Sibling a11y tickets [WEBUI-500](https://hyland.atlassian.net/browse/WEBUI-500) (form fields) and [WEBUI-502](https://hyland.atlassian.net/browse/WEBUI-502) (metadata layout) cover the same criterion on other screens and share this mixin; this PR keeps its edit to the single `!important` flag so it composes with theirs.
- Backport: the same commit is opened against `maintenance-3.1.x`.

Made with [Cursor](https://cursor.com)

[WEBUI-501]: https://hyland.atlassian.net/browse/WEBUI-501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBUI-500]: https://hyland.atlassian.net/browse/WEBUI-500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ