### PR TITLE
WEBUI-500: Apply accessible text spacing to form fields [lts-2025]

### DIFF
--- a/elements/document/nuxeo-document-import.js
+++ b/elements/document/nuxeo-document-import.js
@@ -82,7 +82,7 @@ Polymer({
       }
 
       .file-to-import {
-        height: 58px;
+        min-height: 58px;
         margin: 0 0.3em 0.8em;
         width: calc(50% - 3em);
         padding: 0.8em 1em;
@@ -136,7 +136,7 @@ Polymer({
         display: block;
         font-weight: normal;
         font-size: 0.75rem;
-        line-height: 10px;
+        line-height: 1.5;
         margin-top: 4px;
       }
 
@@ -149,7 +149,7 @@ Polymer({
       }
 
       #dropzone .file-error {
-        white-space: nowrap;
+        white-space: normal;
       }
 
       #sidePanel {
@@ -188,7 +188,7 @@ Polymer({
         font-weight: bold;
         text-transform: none;
         color: var(--secondary-text-color);
-        height: 88px;
+        min-height: 88px;
       }
 
       .file-overview:hover {
@@ -212,7 +212,8 @@ Polymer({
         font-weight: bold;
         -webkit-line-clamp: 2;
         -webkit-box-orient: vertical;
-        height: 40px; /* XXX: 2 * line height, consider extracting variable at the base theme leve */
+        /* min-height, not height: the two clamped lines must still fit when the user increases line spacing */
+        min-height: 40px;
         word-break: break-all;
         overflow: hidden;
       }
@@ -369,6 +370,9 @@ Polymer({
         border: none;
         cursor: pointer;
         font: inherit;
+        /* WCAG 2.1 SC 1.4.12: the UA stylesheet resets text spacing on form controls, so opt back in */
+        letter-spacing: inherit;
+        word-spacing: inherit;
       }
 
       button.link:hover {

--- a/elements/nuxeo-dropzone/nuxeo-dropzone.js
+++ b/elements/nuxeo-dropzone/nuxeo-dropzone.js
@@ -79,6 +79,9 @@ Polymer({
         border: none;
         cursor: pointer;
         font: inherit;
+        /* WCAG 2.1 SC 1.4.12: the UA stylesheet resets text spacing on form controls, so opt back in */
+        letter-spacing: inherit;
+        word-spacing: inherit;
       }
 
       button.link:hover {

--- a/test/theme-base.test.js
+++ b/test/theme-base.test.js
@@ -1,0 +1,71 @@
+/**
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { fixture, html } from '@nuxeo/testing-helpers';
+import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
+import { html as polymerHtml } from '@polymer/polymer/lib/utils/html-tag.js';
+import '../themes/base.js';
+
+// Widgets such as nuxeo-input render their label in a shadow root and style it with --nuxeo-label,
+// so this fixture stands in for any form field label in the Create / Import layouts.
+Polymer({
+  is: 'nuxeo-label-spacing-fixture',
+  _template: polymerHtml`
+    <style include="nuxeo-styles"></style>
+    <label id="label">Last Contributor</label>
+  `,
+});
+
+suite('themes/base', () => {
+  suite('WCAG 2.1 SC 1.4.12 text spacing', () => {
+    let userStyle;
+
+    teardown(() => {
+      if (userStyle) {
+        userStyle.remove();
+        userStyle = null;
+      }
+    });
+
+    test('a label styled with nuxeo-styles inherits the ambient letter spacing', async () => {
+      const host = await fixture(html`
+        <div style="letter-spacing: 3px">
+          <nuxeo-label-spacing-fixture></nuxeo-label-spacing-fixture>
+        </div>
+      `);
+      const { label } = host.querySelector('nuxeo-label-spacing-fixture').$;
+      expect(getComputedStyle(label).letterSpacing).to.equal('3px');
+    });
+
+    test('a user text-spacing stylesheet reaches labels inside shadow roots', async () => {
+      // A user stylesheet can only match elements in the main document, so labels must not pin
+      // their own spacing — otherwise SC 1.4.12 can never be satisfied.
+      userStyle = document.createElement('style');
+      userStyle.textContent = '.a11y-text-spacing { letter-spacing: 0.12em !important; }';
+      document.head.appendChild(userStyle);
+
+      const host = await fixture(html`
+        <div class="a11y-text-spacing">
+          <nuxeo-label-spacing-fixture></nuxeo-label-spacing-fixture>
+        </div>
+      `);
+      const { label } = host.querySelector('nuxeo-label-spacing-fixture').$;
+      const style = getComputedStyle(label);
+      expect(parseFloat(style.letterSpacing)).to.be.closeTo(0.12 * parseFloat(style.fontSize), 0.05);
+    });
+  });
+});

--- a/themes/base.js
+++ b/themes/base.js
@@ -302,7 +302,11 @@ const template = html`
           overflow: hidden;
           text-overflow: ellipsis;
           font-weight: 400 !important;
-          letter-spacing: 0.005em !important;
+          /*
+           * WCAG 2.1 SC 1.4.12: labels live inside widget shadow roots, so pinning letter-spacing
+           * here makes it unreachable for a user text-spacing stylesheet. Inherit it instead.
+           */
+          letter-spacing: inherit;
           font-family: var(--nuxeo-app-font);
         }
 


### PR DESCRIPTION
## Problem
With a user text-spacing override applied (`line-height: 1.5`, `letter-spacing: 0.12em`, `word-spacing: 0.16em`, paragraph spacing `2em`), the **labels of the form fields under the "Create" tab and the "Import" tab** do not change at all — their letter spacing cannot be adjusted, which fails WCAG 2.1 level AA [SC 1.4.12 Text Spacing](https://www.w3.org/TR/WCAG21/#text-spacing). Jira: [WEBUI-500](https://hyland.atlassian.net/browse/WEBUI-500)

Measured in the creation wizard at 1193px (DOM probe, computed `letter-spacing` in px, 13px root font):

| Label | Default | Override applied — before | Override applied — after | Required |
|---|---|---|---|---|
| Location, Title, Description, Content, Type, Nature, Subjects, Coverage, Expires | 0.16 | **0.065** (unchanged) | 1.56 | 1.56 (0.12em) |

19 of the 34 text nodes measured in the wizard ignored the override before this change; 0 do afterwards.

## Root cause
Every form field label in the wizard is a `<label>` rendered **inside a widget shadow root** (`nuxeo-input`, `nuxeo-textarea`, `nuxeo-select`, `nuxeo-selectivity`, `nuxeo-date-picker`, `nuxeo-dropzone`, `nuxeo-path-suggestion`) and styled with the shared `--nuxeo-label` mixin in `themes/base.js`, which pinned `letter-spacing: 0.005em !important`.

A user stylesheet, bookmarklet or extension can only match elements in the **main document** and relies on inheritance to reach shadow content. An explicit `letter-spacing` declaration inside the widget's own scope always beats an inherited value, and the `!important` additionally beats a same-specificity author-level override — so the letter spacing of these labels was unreachable by design.

Two related cases in the same dialogs:
* The dropzone affordances (*"Drag and drop, or click to select files to upload."*, *"Upload main file"*) are `<button>` elements. The UA stylesheet resets `letter-spacing`/`word-spacing` on form controls, so they do not inherit the user's spacing either (confirmed: computed `letter-spacing: 0` under a document-level override).
* The Import tab file list pins heights (`height: 58px` / `88px` / `40px`) and forces `white-space: nowrap` on the per-file error, so its text is at risk of being cut once line spacing grows.

## Changes
* **`themes/base.js`**: `--nuxeo-label` now uses `letter-spacing: inherit` instead of `letter-spacing: 0.005em !important`, so labels follow the document text spacing and a user override reaches them. **This is a shared theme mixin** — see Notes.
* **`elements/document/nuxeo-document-import.js`**: `button.link` opts back into inherited `letter-spacing`/`word-spacing`; `.file-to-import`, `.file-overview` and `.name` use `min-height` instead of `height`; `#blobList .file-error` uses a relative `line-height: 1.5` instead of `10px`; `#dropzone .file-error` wraps instead of `nowrap`.
* **`elements/nuxeo-dropzone/nuxeo-dropzone.js`**: `button.link` opts back into inherited `letter-spacing`/`word-spacing` (the "Content" field affordance on the Create tab).
* **`test/theme-base.test.js`** (new): asserts a label styled with `nuxeo-styles` inherits the ambient letter spacing and that a document-level user text-spacing stylesheet reaches labels inside shadow roots. Both tests fail against the previous mixin (0.07px vs the required 1.68px) and pass with it.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes — 2307 passed, 0 failed
- [x] Automated before/after capture against a live instance at 1193x800 (the width from the QA screenshot), injecting the SC 1.4.12 override into the document **and** every shadow root, with a DOM probe of computed spacing and `scrollWidth`/`clientWidth` + `scrollHeight`/`clientHeight` on every label: override ignored 19 → 0, no new clipping.
- [x] Control run with **no** override to separate pre-existing truncation from spacing-induced truncation: the two remaining clipped boxes (see Notes) clip identically at default spacing, so they are not 1.4.12 failures.
- [x] Default rendering (no override) visually unchanged in the Create and Import forms.
- [ ] QA: apply the text-spacing override on the Create and Import tabs and confirm the labels re-space with no truncation, overlap or loss of content.

## Notes
* **Shared/global stylesheet touched — please note for reconciliation.** `themes/base.js` is the only place the label style lives, so there is no component-local fix for the reported defect: the labels are inside third-party/`nuxeo-elements` shadow roots that the wizard's own stylesheet cannot reach, and re-declaring the `--nuxeo-label` mixin in the dialog scope would fork the theme and break the dark/light/kawaii themes. The change is deliberately one declaration. It affects every `<label>` in the app: at default spacing their letter spacing goes from `0.005em` (0.065px) to the inherited `html` value (0.16px), i.e. about 0.1px per character — visually indistinguishable, verified on the Create/Import forms. No theme overrides `--nuxeo-label` or the `html` letter spacing, so all 4 themes behave the same. Sibling a11y tickets in the same criterion (WEBUI-501 document history filters, WEBUI-502 metadata layout) also concern labels and benefit from the same mixin change — no further theme edit should be needed there.
* Out of scope, reported separately: `custom-date-picker` in `nuxeo-elements` pins `.input-wrapper { width: 156px; overflow: hidden }`, which clips the "Expires" value by 47px — but it clips by the same 47px at default spacing, so it is a pre-existing layout constraint rather than a text-spacing failure. Same for the deliberate 2-line `-webkit-line-clamp` on the Import file name. Neither is made worse by this change.
* `<input>` values inside `paper-typeahead` also do not inherit user text spacing (UA reset on form controls). That is a shared third-party widget outside the reported scope.
* Backport: the same commit is applied to `maintenance-3.1.x` in a companion PR.

Made with [Cursor](https://cursor.com)

[WEBUI-500]: https://hyland.atlassian.net/browse/WEBUI-500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ