### PR TITLE
WEBUI-502: Apply accessible text spacing to document metadata layout [maintenance-3.1.x]

### DIFF
--- a/elements/nuxeo-document-info/nuxeo-document-info.js
+++ b/elements/nuxeo-document-info/nuxeo-document-info.js
@@ -44,12 +44,21 @@ Polymer({
         line-height: 2.2rem;
       }
 
+      /*
+        The label column is sized in em so it follows the label font size, and it opts out of the
+        --nuxeo-label truncation (nowrap + hidden overflow + ellipsis) so that labels wrap instead of
+        losing characters when the user overrides text spacing (WCAG 2.1 AA, 1.4.12).
+      */
       .item label {
         @apply --nuxeo-label;
         line-height: 2.2rem;
-        width: 90px;
-        min-width: 90px;
+        width: 7.5em;
+        min-width: 7.5em;
         font-size: 12px;
+        white-space: normal;
+        overflow: visible;
+        text-overflow: clip;
+        overflow-wrap: break-word;
       }
     </style>
 

--- a/test/nuxeo-document-info.test.js
+++ b/test/nuxeo-document-info.test.js
@@ -55,6 +55,51 @@ suite('nuxeo-document-info', () => {
     });
   });
 
+  suite('text spacing (WCAG 1.4.12)', () => {
+    // Reproduces what the running app applies to these labels: the truncation carried by the theme's
+    // --nuxeo-label mixin, plus the text spacing a user is allowed to override per WCAG 2.1 AA 1.4.12.
+    const THEME_AND_SPACING_CSS = `
+      label {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      label {
+        line-height: 1.5 !important;
+        letter-spacing: 0.12em !important;
+        word-spacing: 0.16em !important;
+      }
+    `;
+
+    setup(() => {
+      const style = document.createElement('style');
+      style.textContent = THEME_AND_SPACING_CSS;
+      element.shadowRoot.appendChild(style);
+    });
+
+    test('should let labels wrap instead of truncating them', () => {
+      const labels = Array.from(element.shadowRoot.querySelectorAll('.item label'));
+      expect(labels.length).to.be.above(0);
+      labels.forEach((label) => {
+        const labelStyle = getComputedStyle(label);
+        expect(labelStyle.whiteSpace).to.equal('normal');
+        expect(labelStyle.overflow).to.equal('visible');
+        expect(labelStyle.textOverflow).to.equal('clip');
+      });
+    });
+
+    test('should not lose label content when the user overrides text spacing', () => {
+      const row = document.createElement('div');
+      row.className = 'item';
+      const label = document.createElement('label');
+      // a translated label ("Last Modified" in French) — longer than the label column, so it has to wrap
+      label.textContent = 'Dernière modification';
+      row.appendChild(label);
+      element.shadowRoot.appendChild(row);
+      expect(label.scrollWidth, 'label text is truncated').to.be.at.most(label.clientWidth + 1);
+    });
+  });
+
   suite('_documentChanged', () => {
     test('should set _showProcess to true when doc has running workflows', () => {
       element.document = {


### PR DESCRIPTION
## Problem
In the document metadata panel (the info pane of the document page), labels are truncated with an ellipsis as soon as the user overrides text spacing, e.g. "Last Modified" renders as "Last Modif…". That is a loss of content under WCAG 2.1 AA success criterion [1.4.12 Text Spacing](https://www.w3.org/TR/WCAG21/#text-spacing) (line-height 1.5, letter-spacing 0.12em, word-spacing 0.16em, paragraph spacing 2em). Jira: [WEBUI-502](https://hyland.atlassian.net/browse/WEBUI-502)

## Root cause
`elements/nuxeo-document-info/nuxeo-document-info.js` sizes the label column of each metadata row with a hard `width: 90px; min-width: 90px`, while the label inherits the theme's `--nuxeo-label` mixin (`themes/base.js`), which sets `white-space: nowrap; overflow: hidden; text-overflow: ellipsis`. The box is sized in fixed pixels to exactly fit the default text and the text cannot wrap, so any increase in letter/word spacing pushes the text past 90px and it is clipped. Measured in a browser: the "Last Modified" label goes from `scrollWidth` 90 / `clientWidth` 90 at default spacing to `scrollWidth` 98 / `clientWidth` 90 with the 1.4.12 overrides applied (truncated); every other label sits exactly at the 90px limit.

## Changes
* **`elements/nuxeo-document-info/nuxeo-document-info.js`**: label column sized in `em` instead of `px` (`7.5em` = 90px at the label's 12px font, so default rendering is unchanged) and the label opts out of the `--nuxeo-label` truncation (`white-space: normal; overflow: visible; text-overflow: clip`), with `overflow-wrap: break-word` so a long single word breaks instead of escaping the column. This follows the remediation techniques in the ticket: relative box sizing, no fixed height, content wraps instead of being clipped.
* **`test/nuxeo-document-info.test.js`**: new `text spacing (WCAG 1.4.12)` suite. It re-applies the theme truncation plus the 1.4.12 spacing inside the element's shadow root and asserts (a) the labels compute to `white-space: normal` / `overflow: visible` / `text-overflow: clip`, and (b) a long translated label ("Dernière modification") is not truncated (`scrollWidth <= clientWidth`). Both tests fail on the unpatched element and pass with the fix.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Verified in a browser on the `lts-2025` branch (same diff): with the 1.4.12 override injected into every shadow root, truncated labels go from 1 to 0 at the default pane width, at the narrow (~635px) width reported by QA, and with a 20px root font size. Default-spacing screenshots of the panel are byte-identical before and after.
- [ ] Manual re-check with a real user stylesheet / text-spacing bookmarklet on `/nuxeo/ui/#!/browse/<doc>` with the info pane open.

## Notes
- Backport of [#3390](https://github.com/nuxeo/nuxeo-web-ui/pull/3390) (`lts-2025`); cherry-picked with no conflicts.
- Scope: the per-doctype `nuxeo-<doctype>-metadata-layout.html` files were probed at several pane widths with the override applied and showed no truncation or overlap — their labels are full-width block elements that already wrap — so they are intentionally left untouched. No global theme stylesheet (`themes/*`) and no `nuxeo-elements` widget was modified, keeping this clear of the sibling 1.4.12 tickets (WEBUI-496 tags, WEBUI-497 date picker, WEBUI-500 form-field labels, WEBUI-501 history filters).
- The WEBUI-502 description body was mis-cloned from [WEBUI-501](https://hyland.atlassian.net/browse/WEBUI-501) and still lists the History tab filters; the authoritative scope for this ticket is its summary (document metadata layout). Flagged on the Jira issue.

Made with [Cursor](https://cursor.com)

[WEBUI-502]: https://hyland.atlassian.net/browse/WEBUI-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBUI-501]: https://hyland.atlassian.net/browse/WEBUI-501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ