### PR TITLE
WEBUI-1459: Fix Previous/Next/Apply alignment in nuxeo-document-import when zoomed in [maintenance-3.1.x]

### DIFF
--- a/elements/document/nuxeo-document-import.js
+++ b/elements/document/nuxeo-document-import.js
@@ -293,6 +293,54 @@ Polymer({
 
       .buttons {
         @apply --buttons-bar;
+        @apply --layout-wrap;
+        flex-shrink: 0;
+        gap: 4px 8px;
+        /* Lets the navigation group react to the bar's own rendered width instead of the
+           viewport's, so the layout below adapts the same way at any zoom level or screen
+           resolution instead of only around the width a fixed viewport breakpoint assumed. */
+        container-type: inline-size;
+      }
+
+      /* Groups the navigation buttons so they wrap as a single block instead of each
+         inline-block button breaking onto a line of its own. */
+      .navigation {
+        @apply --layout-horizontal;
+        @apply --layout-center;
+        @apply --layout-center-justified;
+        @apply --layout-wrap;
+        gap: 4px 8px;
+      }
+
+      /* paper-button's default horizontal margin is replaced by the flex gap, so that the
+         three buttons still fit on one line once the group has a row to itself. */
+      .navigation paper-button {
+        margin: 0;
+      }
+
+      /* Below this width the five action buttons no longer fit on a single line. Give the
+         navigation group a row of its own above the cancel/create row so none of the
+         buttons is misaligned or clipped by the dialog. */
+      @container (max-width: 620px) {
+        .navigation {
+          order: -1;
+          flex: 1 0 100%;
+        }
+      }
+
+      /* Lets the editor/side-panel area give up space instead of pushing the action bar
+         past the bottom edge of the dialog. */
+      .customize-content {
+        min-height: 0;
+        overflow: auto;
+      }
+
+      /* At extreme zoom the dialog itself can be too short to fit the content area and
+         the (possibly stacked) action bar together, even with the content area shrunk to
+         nothing. Make the whole stage scrollable so the buttons stay reachable instead of
+         being clipped past the dialog's bottom edge. */
+      div[name='customize'] {
+        overflow-y: auto;
       }
 
       .add-more .importActions {
@@ -546,7 +594,7 @@ Polymer({
 
       <!--Stage: allow the user to fill in properties for the uploaded files and create the respective documents-->
       <div name="customize" class="vertical layout flex">
-        <div class="horizontal layout flex">
+        <div class="customize-content horizontal layout flex">
           <div id="blobEditor" class="vertical layout flex">
             <paper-dialog-scrollable>
               <div class="suggester">
@@ -658,7 +706,7 @@ Polymer({
             [[i18n('command.cancel')]]
           </paper-button>
 
-          <div>
+          <div class="navigation">
             <paper-button
               noink
               class="text"

--- a/elements/document/nuxeo-document-import.js
+++ b/elements/document/nuxeo-document-import.js
@@ -292,6 +292,31 @@ Polymer({
 
       .buttons {
         @apply --buttons-bar;
+        @apply --layout-wrap;
+        flex-shrink: 0;
+        gap: 4px 8px;
+      }
+
+      /* Groups the navigation buttons so they wrap as a single block instead of each
+         inline-block button breaking onto a line of its own. */
+      .navigation {
+        @apply --layout-horizontal;
+        @apply --layout-center;
+        @apply --layout-center-justified;
+        @apply --layout-wrap;
+        gap: 4px 8px;
+      }
+
+      /* paper-button's default horizontal margin is replaced by the flex gap, so that the
+         three buttons still fit on one line once the group has a row to itself. */
+      .navigation paper-button {
+        margin: 0;
+      }
+
+      /* Lets the editor/side-panel area give up space instead of pushing the action bar
+         past the bottom edge of the dialog. */
+      .customize-content {
+        min-height: 0;
       }
 
       .add-more .importActions {
@@ -305,6 +330,14 @@ Polymer({
       @media (max-width: 1024px) {
         .file-to-import {
           width: calc(100% - 2em);
+        }
+
+        /* Below this width the five action buttons no longer fit on a single line, which is
+           what happens at 400% zoom. Give the navigation group a row of its own above the
+           cancel/create row so none of the buttons is misaligned or clipped by the dialog. */
+        .navigation {
+          order: -1;
+          flex: 1 0 100%;
         }
       }
 
@@ -542,7 +575,7 @@ Polymer({
 
       <!--Stage: allow the user to fill in properties for the uploaded files and create the respective documents-->
       <div name="customize" class="vertical layout flex">
-        <div class="horizontal layout flex">
+        <div class="customize-content horizontal layout flex">
           <div id="blobEditor" class="vertical layout flex">
             <paper-dialog-scrollable>
               <div class="suggester">
@@ -654,7 +687,7 @@ Polymer({
             [[i18n('command.cancel')]]
           </paper-button>
 
-          <div>
+          <div class="navigation">
             <paper-button
               noink
               class="text"

--- a/test/nuxeo-document-import.test.js
+++ b/test/nuxeo-document-import.test.js
@@ -1190,4 +1190,43 @@ suite('nuxeo-document-import', () => {
       expect(element._getDocumentProperties()).to.deep.equal({});
     });
   });
+
+  suite('customize stage action bar', () => {
+    let bar;
+    let navigation;
+
+    setup(() => {
+      bar = element.shadowRoot.querySelector('div[name="customize"] .buttons');
+      navigation = bar.querySelector('.navigation');
+    });
+
+    test('should group the navigation buttons in a single wrapping container', () => {
+      expect(navigation).to.not.be.null;
+      const buttons = navigation.querySelectorAll('paper-button');
+      expect(buttons.length).to.equal(3);
+      expect(buttons[1].getAttribute('name')).to.be.null;
+      expect(buttons[2].getAttribute('name')).to.equal('applyAll');
+      const style = getComputedStyle(navigation);
+      expect(style.display).to.equal('flex');
+      expect(style.flexWrap).to.equal('wrap');
+    });
+
+    test('should let the action bar wrap instead of overflowing', () => {
+      expect(getComputedStyle(bar).flexWrap).to.equal('wrap');
+    });
+
+    test('should not add horizontal margins to the navigation buttons', () => {
+      navigation.querySelectorAll('paper-button').forEach((button) => {
+        const style = getComputedStyle(button);
+        expect(style.marginLeft).to.equal('0px');
+        expect(style.marginRight).to.equal('0px');
+      });
+    });
+
+    test('should let the customize content shrink so the action bar stays visible', () => {
+      const content = element.shadowRoot.querySelector('div[name="customize"] .customize-content');
+      expect(content).to.not.be.null;
+      expect(getComputedStyle(content).minHeight).to.equal('0px');
+    });
+  });
 });

--- a/test/nuxeo-document-import.test.js
+++ b/test/nuxeo-document-import.test.js
@@ -1268,4 +1268,44 @@ suite('nuxeo-document-import', () => {
       expect(element._getDocumentProperties()).to.deep.equal({});
     });
   });
+
+  suite('customize stage action bar', () => {
+    let bar;
+    let navigation;
+
+    setup(() => {
+      bar = element.shadowRoot.querySelector('div[name="customize"] .buttons');
+      navigation = bar.querySelector('.navigation');
+    });
+
+    test('should group the navigation buttons in a single wrapping container', () => {
+      expect(navigation).to.not.be.null;
+      const buttons = navigation.querySelectorAll('paper-button');
+      expect(buttons).to.have.lengthOf(3);
+      expect(buttons[2].getAttribute('name')).to.equal('applyAll');
+      const style = getComputedStyle(navigation);
+      expect(style.display).to.equal('flex');
+      expect(style.flexWrap).to.equal('wrap');
+    });
+
+    test('should let the action bar wrap instead of overflowing', () => {
+      expect(getComputedStyle(bar).flexWrap).to.equal('wrap');
+    });
+
+    test('should not add horizontal margins to the navigation buttons', () => {
+      navigation.querySelectorAll('paper-button').forEach((button) => {
+        const style = getComputedStyle(button);
+        expect(style.marginLeft).to.equal('0px');
+        expect(style.marginRight).to.equal('0px');
+      });
+    });
+
+    test('should let the customize content shrink so the action bar stays visible', () => {
+      const content = element.shadowRoot.querySelector('div[name="customize"] .customize-content');
+      expect(content).to.not.be.null;
+      const style = getComputedStyle(content);
+      expect(style.minHeight).to.equal('0px');
+      expect(style.overflow).to.equal('auto');
+    });
+  });
 });

--- a/test/nuxeo-document-import.test.js
+++ b/test/nuxeo-document-import.test.js
@@ -1203,8 +1203,7 @@ suite('nuxeo-document-import', () => {
     test('should group the navigation buttons in a single wrapping container', () => {
       expect(navigation).to.not.be.null;
       const buttons = navigation.querySelectorAll('paper-button');
-      expect(buttons.length).to.equal(3);
-      expect(buttons[1].getAttribute('name')).to.be.null;
+      expect(buttons).to.have.lengthOf(3);
       expect(buttons[2].getAttribute('name')).to.equal('applyAll');
       const style = getComputedStyle(navigation);
       expect(style.display).to.equal('flex');


### PR DESCRIPTION
## Problem

At 400% browser zoom the **Add properties** step of the document import dialog is unusable: *Edit Previous*, *Edit Next* and *Apply To All* are strewn across three ragged lines and *Apply To All* is clipped by the bottom edge of the creation dialog. Jira: [WEBUI-1459](https://hyland.atlassian.net/browse/WEBUI-1459)

## Root cause

`elements/document/nuxeo-document-import.js` renders the customize-stage action bar as `<div class="buttons horizontal justified layout">`, a **non-wrapping** flex row (`--buttons-bar` only contributes padding). Its middle group was a bare `<div>` containing three inline-block `paper-button`s, so it had no flex sizing of its own. Once the group no longer fits between *Cancel* and *Create* — which is what happens when 400% zoom shrinks the CSS viewport to ~480px and the dialog to `65vw` of that — the three buttons line-wrap **individually**: *Edit Previous* stays on the *Cancel* baseline and the other two each drop onto a line of their own. That inflates the bar from 58px to ~140px tall, and because the content area above it cannot shrink, the bar is pushed past the dialog's bottom edge and *Apply To All* is clipped.

Measured at a 480x270 CSS px viewport (400% zoom of 1920x1080), before the fix: bar bottom `274.8px` vs dialog bottom `249.8px`, `Apply To All` clipped. At the WCAG 1.4.10 reference width of 320 CSS px it is worse: 41px of horizontal overflow, with *Edit Next*, *Apply To All* and *Create* all clipped.

## Changes

* **`elements/document/nuxeo-document-import.js`**:
  * `.buttons` now wraps (`--layout-wrap`), has a `gap` and `flex-shrink: 0`, so groups drop onto their own line instead of overflowing the dialog.
  * The navigation group gets a `.navigation` class and becomes a centred, wrapping flex container, so *Edit Previous* / *Edit Next* / *Apply To All* stay aligned as one block. `paper-button`'s default horizontal margin is replaced by the flex `gap` so all three still fit on one line.
  * Below `1024px` — the width at which the five buttons stop fitting on a single line — the navigation group takes a row of its own above the cancel/create row (`order: -1; flex: 1 0 100%`), reusing the media query already present in this file.
  * The customize content area gets `min-height: 0` (`.customize-content`) so it yields space instead of pushing the action bar outside the dialog.
* **`test/nuxeo-document-import.test.js`**: four regression tests covering the grouped navigation container, the wrapping action bar, the zeroed button margins and the shrinkable content area.

Desktop rendering is unchanged: at 1280x800 / 100% the bar is still a single 58.2px row with *Cancel* left, navigation centred and *Create* right.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` passes (2309 tests)
- [x] Geometry probe at 480x270 CSS px @ dpr 4 (= 400% zoom of 1920x1080): bar bottom `249.8px` == dialog bottom `249.8px`, no clipped buttons, no overlaps, no horizontal overflow
- [x] Geometry probe at 320x256 CSS px (WCAG 1.4.10 reflow reference): no clipped buttons, horizontal overflow `41px` → `0px`
- [x] Geometry probe at 1280x800 @ 100%: unchanged (bar height `58.2px`, nothing clipped)
- [ ] Manual check with real browser zoom: open a workspace, click the create button, *Import* tab, add 2+ files, *Add properties*, set zoom to 400%

## Notes

Backport of nuxeo/nuxeo-web-ui#3396 (`lts-2025`); same commit cherry-picked. Jira `fixVersions` are 3.0.x and 3.1.x. Fix is entirely in `nuxeo-web-ui`; no `nuxeo-elements` change is needed. Verification (probes, before/after recordings) was run on the `lts-2025` branch.

Made with [Cursor](https://cursor.com)

[WEBUI-1459]: https://hyland.atlassian.net/browse/WEBUI-1459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ