### PR TITLE
ELEMENTS-1611: Add a visible label to the tags input field [lts-2025]

### DIFF
--- a/elements/document/nuxeo-collapsible-document-page.js
+++ b/elements/document/nuxeo-collapsible-document-page.js
@@ -55,6 +55,21 @@ Polymer({
         max-width: 320px;
       }
 
+      /* The tags field renders its own label, which replaces the h5 that used to sit above it.
+         Scoped to this layout so other tag suggestions keep the default label styling; the
+         !important declarations are needed to win over the theme's --nuxeo-label mixin. */
+      nuxeo-tag-suggestion {
+        --nuxeo-label: {
+          display: block;
+          font-family: var(--nuxeo-app-font);
+          font-weight: 700 !important;
+          font-size: 1.08rem;
+          letter-spacing: 0.24px !important;
+          line-height: 1.54rem;
+          margin: 0 0 0.8rem;
+        };
+      }
+
       paper-icon-button {
         @apply --nuxeo-action;
       }
@@ -93,10 +108,10 @@ Polymer({
           <!-- tags -->
           <template is="dom-if" if="[[hasFacet(document, 'NXTag')]]">
             <div class="section">
-              <h5>[[i18n('documentPage.tags')]]</h5>
               <nuxeo-tag-suggestion
                 document="[[document]]"
                 allow-new-tags
+                label="[[i18n('documentPage.tags')]]"
                 placeholder="[[i18n('documentPage.tags.placeholder')]]"
                 readonly="[[!hasPermission(document, 'WriteProperties')]]"
               >

--- a/elements/document/nuxeo-document-page.js
+++ b/elements/document/nuxeo-document-page.js
@@ -178,6 +178,21 @@ Polymer({
         margin-bottom: 64px;
       }
 
+      /* The tags field renders its own label, which replaces the h5 that used to sit above it.
+         Scoped to this layout so other tag suggestions keep the default label styling; the
+         !important declarations are needed to win over the theme's --nuxeo-label mixin. */
+      nuxeo-tag-suggestion {
+        --nuxeo-label: {
+          display: block;
+          font-family: var(--nuxeo-app-font);
+          font-weight: 700 !important;
+          font-size: 1.08rem;
+          letter-spacing: 0.24px !important;
+          line-height: 1.54rem;
+          margin: 0 0 0.8rem;
+        };
+      }
+
       nuxeo-document-view {
         --nuxeo-document-content-margin-bottom: var(--nuxeo-card-margin-bottom);
       }
@@ -293,10 +308,10 @@ Polymer({
           <!-- tags -->
           <template is="dom-if" if="[[hasFacet(document, 'NXTag')]]">
             <div class="section">
-              <h5>[[i18n('documentPage.tags')]]</h5>
               <nuxeo-tag-suggestion
                 document="[[document]]"
                 allow-new-tags
+                label="[[i18n('documentPage.tags')]]"
                 placeholder="[[i18n('documentPage.tags.placeholder')]]"
                 readonly="[[!isTaggable(document)]]"
               >

--- a/test/nuxeo-collapsible-document-page.test.js
+++ b/test/nuxeo-collapsible-document-page.test.js
@@ -1,0 +1,70 @@
+/**
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { fixture, flush, html, login } from '@nuxeo/testing-helpers';
+import '../elements/document/nuxeo-collapsible-document-page.js';
+
+suite('nuxeo-collapsible-document-page', () => {
+  let server;
+  let element;
+
+  setup(async () => {
+    server = await login();
+    element = await fixture(html`<nuxeo-collapsible-document-page></nuxeo-collapsible-document-page>`);
+    sinon.stub(element, 'i18n').callsFake((key) => key);
+    sinon.stub(element, 'hasFacet').returns(false);
+    sinon.stub(element, 'hasPermission').returns(true);
+    sinon.stub(element, '_hasCollections').returns(false);
+  });
+
+  teardown(() => {
+    server.restore();
+  });
+
+  suite('tags section', () => {
+    test('is not rendered when the document is not taggable', async () => {
+      element.document = { uid: '1', type: 'File' };
+      await flush();
+
+      expect(element.shadowRoot.querySelector('nuxeo-tag-suggestion')).to.not.exist;
+    });
+
+    test('renders the tags widget with a visible label instead of a detached heading', async () => {
+      const doc = { uid: '1', type: 'File' };
+      element.hasFacet.withArgs(doc, 'NXTag').returns(true);
+      element.document = doc;
+      await flush();
+
+      const tags = element.shadowRoot.querySelector('nuxeo-tag-suggestion');
+      expect(tags).to.exist;
+      expect(tags.label).to.equal(element.i18n('documentPage.tags'));
+      expect(tags.label).to.not.be.empty;
+      // the caption is now the widget's own label, not a heading detached from the field
+      expect(tags.parentElement.querySelector('h5')).to.not.exist;
+    });
+
+    test('is read only when the user cannot write properties', async () => {
+      const doc = { uid: '1', type: 'File' };
+      element.hasFacet.withArgs(doc, 'NXTag').returns(true);
+      element.hasPermission.withArgs(doc, 'WriteProperties').returns(false);
+      element.document = doc;
+      await flush();
+
+      expect(element.shadowRoot.querySelector('nuxeo-tag-suggestion').readonly).to.be.true;
+    });
+  });
+});

--- a/test/nuxeo-document-page.test.js
+++ b/test/nuxeo-document-page.test.js
@@ -847,4 +847,20 @@ suite('nuxeo-document-page', () => {
     });
     element._openedChanged();
   });
+
+  suite('tags section', () => {
+    test('renders the tags widget with a visible label instead of a detached heading', async () => {
+      const doc = { uid: '1', type: 'File' };
+      element.hasFacet.withArgs(doc, 'NXTag').returns(true);
+      element.document = doc;
+      await flush();
+
+      const tags = element.shadowRoot.querySelector('nuxeo-tag-suggestion');
+      expect(tags).to.exist;
+      expect(tags.label).to.equal(element.i18n('documentPage.tags'));
+      expect(tags.label).to.not.be.empty;
+      // the caption is now the widget's own label, not a heading detached from the field
+      expect(tags.parentElement.querySelector('h5')).to.not.exist;
+    });
+  });
 });


### PR DESCRIPTION
## Problem

The **Tags** field in the document details sidebar has no label that is bound to it, which fails WCAG 2.0 level A criterion **3.3.2 Labels or Instructions**. Jira: [ELEMENTS-1611](https://hyland.atlassian.net/browse/ELEMENTS-1611)

A "Tags" caption is visible, but it is a decorative `<h5>` sitting next to the widget, not a label. Chrome's accessibility tree names the input `"Add tags to this document"` with `nameFrom: placeholder` — and the placeholder disappears as soon as the user types, so the field ends up with nothing naming it at all.

## Root cause

`elements/document/nuxeo-document-page.js` and `elements/document/nuxeo-collapsible-document-page.js` render `<h5>Tags</h5>` followed by a `<nuxeo-tag-suggestion>` that is given only a `placeholder`. The heading lives in the layout's shadow root while the `<input>` is two shadow roots down inside `nuxeo-selectivity`, so it cannot be referenced with `for` or `aria-labelledby`. With no `label`, `nuxeo-selectivity` falls back to naming the field after its placeholder.

## Changes

* **`elements/document/nuxeo-document-page.js`**, **`elements/document/nuxeo-collapsible-document-page.js`**: drop the decorative `<h5>` and pass the same `i18n('documentPage.tags')` text as the widget's `label`. `nuxeo-selectivity` renders that as a real `<label>` and (with nuxeo/nuxeo-elements#1556) binds it to the input via `for` + `aria-labelledby`. A scoped `--nuxeo-label` override keeps the label rendering exactly like the `<h5>` it replaces, so the sidebar is visually unchanged.

The style override is intentionally scoped to these two layouts rather than added to `nuxeo-styles`, so tag suggestions elsewhere (default search form, custom layouts) keep the standard label styling.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` passes — **2305 tests, 0 failures**
- [x] Before/after captured on a Nuxeo 2025 instance with Puppeteer; screenshots, screen recordings and an accessible-name probe are attached to the Jira issue. Chrome's accessibility tree goes from `name: "Add tags to this document", nameFrom: placeholder` to `name: "Tags", nameFrom: relatedElement`, and the rendered sidebar is pixel-comparable before and after
- [ ] QA: verify the Tags caption still looks like the other section headings in the details sidebar, in every theme (default, dark, light, kawaii) and in RTL

## Notes

Requires nuxeo/nuxeo-elements#1556 for the `label`/`for` association; without it the label still renders and stays visible, it is just named through `aria-label` instead.

**Visual/regression surface** — the "Tags" caption is now emitted by the widget rather than by an `<h5>`:
- It is no longer part of the heading outline of the details sidebar. The Info / Metadata / Collections / Activity headings are unchanged.
- Customers who overrode `nuxeo-document-page` keep their own heading and pass no `label`, so they see no change and, importantly, **no duplicated caption** — the failure mode that forced the revert of ELEMENTS-1587 in ELEMENTS-1607.

Backport to `maintenance-3.1.x`: #3400

Made with [Cursor](https://cursor.com)

[ELEMENTS-1611]: https://hyland.atlassian.net/browse/ELEMENTS-1611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
