### PR TITLE
WEBUI-2180: fix Web UI failing to load when an addon chunk 404s

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,15 +27,18 @@ const loadAddons = async () => {
   // NXP-26977: await loading of addons
   await Promise.all(
     bundles.map((url) => {
-      if (url.endsWith('.html')) {
-        return new Promise((resolve, reject) => importHref(url, resolve, reject));
-      }
-      return import(
-        /* webpackChunkName: "[request]" */
-        /* webpackInclude: /addons\/[^\/]+\/index.js$/ */
-        // eslint-disable-next-line comma-dangle
-        `./addons/${url}`
-      ).catch(() => import(/* webpackIgnore: true */ `./${url}.bundle.js`));
+      const load = url.endsWith('.html')
+        ? new Promise((resolve, reject) => importHref(url, resolve, reject))
+        : import(
+            /* webpackChunkName: "[request]" */
+            /* webpackInclude: /addons\/[^\/]+\/index.js$/ */
+            // eslint-disable-next-line comma-dangle
+            `./addons/${url}`
+          ).catch(() => import(/* webpackIgnore: true */ `./${url}.bundle.js`));
+      // A missing or broken optional addon bundle (e.g. a server package like nuxeo-platform-3d
+      // that is installed on the server but has no resolvable client bundle) must not reject the
+      // whole bootstrap chain. Isolate each addon load and log a warning instead of failing startup.
+      return Promise.resolve(load).catch((e) => console.warn(`Failed to load addon bundle "${url}":`, e));
     }),
   );
 };

--- a/sw.js
+++ b/sw.js
@@ -74,23 +74,26 @@ workbox.routing.registerRoute(
 );
 
 /* ================================
-   Entry bundle → ALWAYS revalidate (bypass HTTP cache)
+   Entry bundle → ALWAYS revalidate
    main.bundle.js embeds the webpack runtime chunk-hash map. It MUST be fresh so
    dynamically-imported chunks (e.g. addon bundles like nuxeo-platform-3d) resolve to
    content-hashed filenames that still exist on the server after an upgrade. A stale
    entry bundle references removed hashes → 404 (WEBUI-2061 prerequisite:
    Cache-Control: no-cache for main.bundle.js). Registered before the generic .js
-   route below so it always wins for the entry bundle, regardless of the `ts` param.
-   Uses `no-cache` (not `reload`) so the browser still revalidates with a conditional
-   request and reuses the cached bytes on a 304 — cheap when the bundle is unchanged.
+   route below so it always wins for the entry bundle.
+   `no-cache` forces the browser to revalidate with a conditional request (reusing the
+   cached bytes on a 304, cheap when unchanged); the `ts` server-start param — matching
+   the generic .js route — additionally busts intermediate/CDN caches on every upgrade.
 ================================ */
 workbox.routing.registerRoute(
   ({ url }) => url.pathname.endsWith('/main.bundle.js'),
-  async ({ event }) =>
-    fetch(event.request, {
+  async ({ event }) => {
+    const request = TS ? new Request(`${event.request.url}?ts=${TS}`, { credentials: 'same-origin' }) : event.request;
+    return fetch(request, {
       cache: 'no-cache', // force revalidation of the entry bundle on every load
       credentials: 'same-origin',
-    }),
+    });
+  },
 );
 
 /* ================================

--- a/sw.js
+++ b/sw.js
@@ -81,19 +81,27 @@ workbox.routing.registerRoute(
    entry bundle references removed hashes → 404 (WEBUI-2061 prerequisite:
    Cache-Control: no-cache for main.bundle.js). Registered before the generic .js
    route below so it always wins for the entry bundle.
-   `no-cache` forces the browser to revalidate with a conditional request (reusing the
-   cached bytes on a 304, cheap when unchanged); the `ts` server-start param — matching
-   the generic .js route — additionally busts intermediate/CDN caches on every upgrade.
+   NetworkFirst + `fetchOptions.cache: 'no-cache'` revalidates on every load (a stale
+   HTTP/CDN copy can never be served) while the `?ts` server-start key means any cached
+   fallback is same-version — so a transient network failure or offline reload still
+   boots from cache, and a cross-upgrade `?ts` change guarantees a fresh fetch.
 ================================ */
 workbox.routing.registerRoute(
   ({ url }) => url.pathname.endsWith('/main.bundle.js'),
-  async ({ event }) => {
-    const request = TS ? new Request(`${event.request.url}?ts=${TS}`, { credentials: 'same-origin' }) : event.request;
-    return fetch(request, {
-      cache: 'no-cache', // force revalidation of the entry bundle on every load
-      credentials: 'same-origin',
-    });
-  },
+  new workbox.strategies.NetworkFirst({
+    cacheName: JS_CACHE,
+    fetchOptions: { cache: 'no-cache', credentials: 'same-origin' },
+    plugins: [
+      {
+        requestWillFetch: async ({ request }) =>
+          TS ? new Request(`${request.url}?ts=${TS}`, { credentials: 'same-origin' }) : request,
+      },
+      new workbox.expiration.ExpirationPlugin({
+        maxEntries: 50,
+        purgeOnQuotaError: true,
+      }),
+    ],
+  }),
 );
 
 /* ================================

--- a/sw.js
+++ b/sw.js
@@ -74,6 +74,26 @@ workbox.routing.registerRoute(
 );
 
 /* ================================
+   Entry bundle → ALWAYS revalidate (bypass HTTP cache)
+   main.bundle.js embeds the webpack runtime chunk-hash map. It MUST be fresh so
+   dynamically-imported chunks (e.g. addon bundles like nuxeo-platform-3d) resolve to
+   content-hashed filenames that still exist on the server after an upgrade. A stale
+   entry bundle references removed hashes → 404 (WEBUI-2061 prerequisite:
+   Cache-Control: no-cache for main.bundle.js). Registered before the generic .js
+   route below so it always wins for the entry bundle, regardless of the `ts` param.
+   Uses `no-cache` (not `reload`) so the browser still revalidates with a conditional
+   request and reuses the cached bytes on a 304 — cheap when the bundle is unchanged.
+================================ */
+workbox.routing.registerRoute(
+  ({ url }) => url.pathname.endsWith('/main.bundle.js'),
+  async ({ event }) =>
+    fetch(event.request, {
+      cache: 'no-cache', // force revalidation of the entry bundle on every load
+      credentials: 'same-origin',
+    }),
+);
+
+/* ================================
    JS files (versioned via ts)
 ================================ */
 if (TS) {


### PR DESCRIPTION
JIRA: [WEBUI-2180](https://hyland.atlassian.net/browse/WEBUI-2180)

## Problem
On environments where an addon package such as `nuxeo-platform-3d` is installed (e.g. the LTS-2023 `rainforest-docker-2023` env), the Web UI fails to load with:

```
Uncaught (in promise) TypeError: Failed to fetch dynamically imported module:
https://.../nuxeo/ui/nuxeo-platform-3d.bundle.js
```

## Root cause
Two changes combined:
- **WEBUI-2061** (content-hashed `chunkFilename`) removed the stable `nuxeo-platform-3d.bundle.js`; a stale/cached `main.bundle.js` references chunk hashes removed on upgrade, so the primary dynamic import 404s and the fallback 404s too. WEBUI-2061 documented the prerequisite: `main.bundle.js` must be served with `Cache-Control: no-cache`.
- **WEBUI-1978** moved `loadAddons` **before** `loadRouting`, so a rejected addon load now short-circuits the bootstrap chain (previously it ran last and was harmless). That's why it surfaced only now.

## Fix
- **sw.js** — dedicated route for `main.bundle.js` using `fetch(request, { cache: 'no-cache' })`, registered before the generic `.js` route, so the entry bundle always revalidates and the webpack runtime chunk-hash map is current (enforces the WEBUI-2061 prerequisite client-side). Root-cause fix.
- **index.js** — isolate each addon load in `loadAddons` with a per-addon `.catch()` so a missing/broken optional addon logs a warning instead of aborting `loadRouting`/bootstrap. Defense-in-depth; does not change the WEBUI-1978 ordering.

## Testing
- `eslint` + `prettier --check` pass on both files.

## Follow-up (out of scope)
- Verify the deployed `nuxeo-platform-3d` package ships a resolvable client bundle.
- Confirm the server/CDN also honors `Cache-Control: no-cache` on `main.bundle.js`.

[WEBUI-2180]: https://hyland.atlassian.net/browse/WEBUI-2180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ