### PR TITLE
WEBUI-2180: fix nuxeo-platform-3d glTF loader failing to load (read-only 'load')

### DIFF
--- a/addons/nuxeo-platform-3d/loaders/gltf/glTF-parser.js
+++ b/addons/nuxeo-platform-3d/loaders/gltf/glTF-parser.js
@@ -354,6 +354,10 @@ var global = window;
 
     load: {
       enumerable: true,
+      // writable/configurable so glTFLoader can override it via prototype assignment; ESM strict
+      // mode throws on assigning to an inherited read-only property (WEBUI-2180 regression from #3094)
+      writable: true,
+      configurable: true,
       value: function (userInfo, options) {
         var self = this;
         this._buildLoader(function loaderReady(reader) {


### PR DESCRIPTION
JIRA: [WEBUI-2180](https://hyland.atlassian.net/browse/WEBUI-2180)

Follow-up to the merged bootstrap/caching hotfix (#3404): fixes the **actual root cause** of the 3D addon failing to load, reproduced locally.

## Problem
On envs with `nuxeo-platform-3d` installed, the addon's hashed chunk downloads (`200`) but the module **throws during evaluation**, so `import('./addons/nuxeo-platform-3d')` rejects, the 3D custom elements never register, and `loadAddons` falls back to a non-existent `nuxeo-platform-3d.bundle.js` (404). The real error was masked by the fallback.

Reproduced locally (backend with the rainforest WebUI build + `nuxeo-platform-3d` installed):
```
TypeError: Cannot assign to read only property 'load' of object '#<glTFLoader>'
    at addons/nuxeo-platform-3d/loaders/gltf/glTFLoader.js
```

## Root cause
The #3094 THREE.js dependency upgrade re-based the loader prototype:
```diff
-  THREE.Loader.call(this);
-glTFLoader.prototype = new THREE.Loader();
+glTFLoader.prototype = Object.create(glTFParser);
```
`glTFParser.load` is defined as a **non-writable** property (`Object.create(…, { load: { enumerable, value } })` — `writable` defaults to `false`). Since the addon is bundled as an ES module (strict mode), the subsequent `glTFLoader.prototype.load = …` throws `Cannot assign to read only property`. With the old `new THREE.Loader()` base the inherited `load` was writable, so it worked.

## Fix
Make the overridable `load` descriptor `writable`/`configurable` in `glTF-parser.js` so `glTFLoader` can override it under strict mode. Minimal, targeted; doesn't change `glTFParser`'s callable behavior.

## Verification (local)
With the 3D addon bundled and loaded: `nuxeo-3d-viewer`, `nuxeo-3d-preview`, `nuxeo-3d-render-views`, and `nuxeo-3d-transmission-formats` all register, the primary import succeeds (no fallback 404), and there are **no 3D errors** in the console.

## Notes
- `glTF-parser.js` is under the ESLint-ignored `nuxeo-platform-3d/loaders/**` (vendored THREE.js loaders); Prettier passes.
- Ports to lts-2025 in a companion PR.

[WEBUI-2180]: https://hyland.atlassian.net/browse/WEBUI-2180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ