### PR TITLE
WEBUI-2180: fix nuxeo-platform-3d glTF loader failing to load (read-only 'load')

### DIFF
--- a/addons/nuxeo-platform-3d/loaders/gltf/glTF-parser.js
+++ b/addons/nuxeo-platform-3d/loaders/gltf/glTF-parser.js
@@ -354,6 +354,10 @@ var global = window;
 
     load: {
       enumerable: true,
+      // writable/configurable so glTFLoader can override it via prototype assignment; ESM strict
+      // mode throws on assigning to an inherited read-only property (WEBUI-2180 regression from #3094)
+      writable: true,
+      configurable: true,
       value: function (userInfo, options) {
         var self = this;
         this._buildLoader(function loaderReady(reader) {


### PR DESCRIPTION
JIRA: [WEBUI-2180](https://hyland.atlassian.net/browse/WEBUI-2180)

Port of #3408 (maintenance-3.1.x) to lts-2025 for consistency.

## Root cause
The #3094 THREE.js dependency upgrade re-based `glTFLoader.prototype` from `new THREE.Loader()` onto `Object.create(glTFParser)`. `glTFParser.load` is a **non-writable** property, so `glTFLoader.prototype.load = …` throws `Cannot assign to read only property 'load'` under ES-module strict mode. The addon module rejects at evaluation → 3D elements never register → `loadAddons` falls back to a non-existent bundle (404).

## Fix
Make the overridable `load` descriptor `writable`/`configurable` in `glTF-parser.js` so `glTFLoader` can override it under strict mode.

## Verification (local)
`nuxeo-3d-viewer`/`preview`/`render-views`/`transmission-formats` all register; primary import succeeds (no fallback 404); no 3D console errors.

## Notes
- `glTF-parser.js` is under the ESLint-ignored `nuxeo-platform-3d/loaders/**`; Prettier passes.

[WEBUI-2180]: https://hyland.atlassian.net/browse/WEBUI-2180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ