### PR TITLE
WEBUI-2181: Fix postcss high GHSA-r28c-9q8g-f849 [LTS-2023]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19899,9 +19899,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -21375,9 +21375,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -21395,7 +21395,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Problem

Dependabot alert [#396](https://github.com/nuxeo/nuxeo-web-ui/security/dependabot/396) reports a **high** severity path-traversal vulnerability in `postcss` (advisory `GHSA-r28c-9q8g-f849`, no CVE assigned).

> **PostCSS: Path Traversal in Previous Source Map Auto-Loading (`sourceMappingURL`) leads to Arbitrary `.map` File Disclosure**

Vulnerable range is `<= 8.5.17`; the root `package-lock.json` resolved **8.5.15**.

## Root cause

`postcss` is a **development / build-time-only transitive dependency**. It is not declared in any `package.json` in this repo. It is reached solely through the CSS loader chain:

- `css-loader` → `postcss` (`^8.4.40`)
- `icss-utils`, `postcss-modules-extract-imports`, `postcss-modules-local-by-default`, `postcss-modules-scope`, `postcss-modules-values` → `postcss` (`^8.1.0`)

`css-loader` is wired into exactly one webpack rule:

```js
// webpack.config.js
{
  test: /\.css$/,
  use: ['style-loader', 'css-loader'],
}
```

Every declared dependent range already admits the patched version, so no `package.json` change and no `overrides` entry are required — this is a pure lockfile refresh.

## Changes

Single file: `package-lock.json` (root manifest only).

| Package | Before | After | Why |
| --- | --- | --- | --- |
| `postcss` | 8.5.15 | **8.5.25** | The CVE fix. Minimum patched version is 8.5.18; `npm update` resolves to the latest in the satisfied `^8.x` range. |
| `nanoid` | 3.3.12 | **3.3.16** | **Incidental but forced** — `postcss@8.5.25` declares `nanoid@^3.3.16`. Not itself under any alert. |

### Scope contract

Only the packages above changed. Verified mechanically against the base branch:

```
node_modules/nanoid:  3.3.12 -> 3.3.16
node_modules/postcss: 8.5.15 -> 8.5.25
total changed entries: 2
```

- `package.json` — **untouched**
- No `overrides` added
- No structural dependents needed bumping (all consumer ranges already admit 8.5.25)

### Note on the `nanoid` co-bump

This is the one change beyond the CVE package itself, so calling it out explicitly. It is *not* strictly required by the advisory: `postcss@8.5.18` (the minimum patched version) declares `nanoid@^3.3.12`, which the existing 3.3.12 already satisfies. It is pulled in by taking the latest patch in range, consistent with how previous security bumps in this epic were handled (`tmp` → 0.2.7 vs. the 0.2.6 minimum, `@babel/core` → 7.29.7 vs. 7.29.6).

`nanoid`'s only other consumer is `@web/test-runner-core`, which declares `^3.1.25` and is unaffected by 3.3.16. Both are dev-scope.

If reviewers prefer the strictly minimal diff, pinning `postcss` to exactly 8.5.18 would keep `nanoid` at 3.3.12 — but that requires a hand-pinned lockfile entry or an `overrides` block, which is a larger and more intrusive change than the one-line `nanoid` patch bump.

## Impact

- **Runtime / shipped bundle: none.** `postcss` is build-time only; it parses `.css` during the webpack build and is never emitted into a shipped bundle. No Web UI element, behavior, or public API is affected.
- **Exploitability in this project is low.** The advisory requires PostCSS to auto-load a previous source map referenced by a `sourceMappingURL` comment in *untrusted* CSS input. This build only processes first-party and vendored `node_modules` CSS. The realistic exposure is a build-machine file-disclosure vector, not a production one.
- **Semver delta:** patch-level within `8.5.x` (8.5.15 → 8.5.25). No documented breaking changes in the PostCSS 8.5 line.

## Local validation

All gates run on this branch, with `node_modules` synced to the updated lockfile.

| Gate | Result |
| --- | --- |
| `npm install` | pass |
| `npm run lint` (eslint + prettier) | pass |
| `npm test` | pass — **2305 passed, 0 failed** |
| `npm run build` (`webpack --env production`) | pass |

CVE resolution confirmed by two independent sources:

1. **semver check against the lockfile** — `postcss: 1 resolved instance: 8.5.25` → `OK — no instance in vulnerable range <= 8.5.17`
2. **`npm audit --package-lock-only`** — `postcss flagged: NO — resolved`; `nanoid flagged: NO`

Manifest coverage: alert #396 targets `package-lock.json`, which is the file changed here. `postcss` was confirmed **absent** from `packages/nuxeo-web-ui-ftest`, `packages/nuxeo-designer-catalog`, and `plugin/a11y` lockfiles, so no sibling manifest needs the same fix. No other open Dependabot alert exists for `postcss`.

## Test plan

The build itself is the primary gate, and it passes. For reviewer sanity beyond CI:

- [ ] CI lint + unit test workflows green on this PR
- [ ] Production build completes and emits CSS correctly
- [ ] Smoke-check the app renders with correct styling (any `.css` regression would surface immediately as unstyled or mis-styled UI) — browse a document, open the search form, and switch themes

No functional QA is warranted beyond styling smoke-checks, since nothing reaches the runtime bundle.

## Notes

> **Alert closure expectation:** this PR targets the `security-fixes-lts-2023` integration branch, not `maintenance-3.1.x` directly. Dependabot alert #396 will stay **open** until the integration branch is merged into the LTS branch. That is expected and not a sign the fix failed.

Companion PR for the LTS-2025 line: #3410. Same lockfile change; both lines resolved `postcss` at 8.5.15 with identical dependent ranges and `lockfileVersion` 3, so the fix is byte-equivalent in effect.

## Resolves Dependabot Security Alerts

- Alert [#396](https://github.com/nuxeo/nuxeo-web-ui/security/dependabot/396) — `postcss` — `GHSA-r28c-9q8g-f849` — high

Jira: [WEBUI-2181](https://hyland.atlassian.net/browse/WEBUI-2181)


[WEBUI-2181]: https://hyland.atlassian.net/browse/WEBUI-2181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ