### PR TITLE
fix: the application constructs n1ql queries using t... in...

### DIFF
--- a/elements/nuxeo-publication/nuxeo-document-publications.js
+++ b/elements/nuxeo-publication/nuxeo-document-publications.js
@@ -200,6 +200,9 @@ Polymer({
   _computeParams() {
     if (this._src) {
       const { uid } = this._src;
+      if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(uid)) {
+        return;
+      }
       return {
         queryParams: `${'SELECT * FROM Document WHERE ecm:isProxy = 1 AND ecm:isTrashed = 0 AND (rend:sourceVersionableId = "'}${uid}" OR ecm:proxyVersionableId = "${uid}")`,
       };


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `elements/nuxeo-publication/nuxeo-document-publications.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `elements/nuxeo-publication/nuxeo-document-publications.js:204` |
| **Assessment** | Likely exploitable |

**Description**: The application constructs N1QL queries using template literals with direct string interpolation of the uid variable. An attacker who can control the uid value can inject arbitrary N1QL syntax to modify query logic, bypass access controls, or exfiltrate data.

## Evidence

**Exploitation scenario**: An attacker manipulates the document object or injects JavaScript (via XSS) to set this._src.uid to a malicious value like: `foo" OR 1=1) UNION SELECT * FROM Document WHERE ecm:isTrashed = 0 AND.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `elements/nuxeo-publication/nuxeo-document-publications.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
