### PR TITLE
chore: add Cursor Cloud Agent environment configuration

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,6 +1,6 @@
 {
   "name": "Nuxeo Web UI",
-  "install": "cp -n .env.sample .env || true; npm install && npm run pretest",
+  "install": "[ -f .env ] || cp .env.sample .env; npm install && npm run pretest",
   "terminals": [
     {
       "name": "dev-server",

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "Nuxeo Web UI",
+  "install": "cp -n .env.sample .env || true; npm install && npm run pretest",
+  "terminals": [
+    {
+      "name": "dev-server",
+      "command": "npm start",
+      "description": "Webpack dev server for Nuxeo Web UI on http://localhost:5000. Proxies /nuxeo to NUXEO_HOST (default localhost:8080); backend API calls fail with 504 until a Nuxeo server is available, but the SPA builds and serves."
+    }
+  ],
+  "ports": [
+    {
+      "name": "web-ui-dev-server",
+      "port": 5000
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem

There was no Cursor Cloud Agent environment defined for `nuxeo-web-ui`, so a fresh Cloud Agent booted without dependencies, dev config, or a running dev server.

### Changes

Adds `.cursor/environment.json` describing a reproducible dev environment for the Web UI:

- **`install`**: `[ -f .env ] || cp .env.sample .env; npm install && npm run pretest`
  - `npm install` runs the repo's `preinstall` (sub-package `npm ci` for `nuxeo-web-ui-ftest`, `nuxeo-designer-catalog`, `plugin/a11y`) and `postinstall` (`check-engine`).
  - `[ -f .env ] || cp .env.sample .env` seeds the documented dev config (`.env` is gitignored; never overwritten).
  - `npm run pretest` provisions the Puppeteer-bundled Chrome so `npm test` is ready immediately.
  - Idempotent: verified by running it twice with no lockfile churn.
- **`terminals`**: a `dev-server` terminal running `npm start` (webpack dev server on `http://localhost:5000`).
- **`ports`**: exposes port `5000`.

Uses Cursor's default base image (Node 22, Chrome preinstalled) — no custom Dockerfile needed. `@nuxeo/*` packages resolve from `packages.nuxeo.com` via the committed `.npmrc`, so the setup is self-contained (no sibling `nuxeo-elements` checkout required).

### Test plan

Validated on the Cloud Agent VM:

- `npm install` — succeeds; second run is idempotent (no lockfile changes).
- `npm run lint` — passes (eslint + prettier).
- `npm test` — **2393 passed, 0 failed** (Web Test Runner, headless Chrome).
- `npm start` — webpack compiles successfully; the SPA boots and renders the Dashboard at `http://localhost:5000` (verified in headless Chrome). Backend API calls return `504` as expected when no Nuxeo server is running on `:8080`.

Validated on a **fresh Cloud Agent booted from the prebuilt environment build**:

- Correct build booted; Node `v22.14.0` / npm `10.9.7`.
- `node_modules` + `@nuxeo/*` packages present; Puppeteer Chrome cache present; `.env` seeded.
- `npm run lint` — exit 0.
- `npm start` — `compiled successfully`, `curl http://localhost:5000/` → HTTP 200.

### Notes

- The dev server proxies `/nuxeo` to `NUXEO_HOST` (default `localhost:8080`); a running Nuxeo server is still required for authenticated, data-backed flows.
- No application code changed — this only adds environment configuration.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05607794-eb7e-4f62-9ea8-19b4fbc2b9c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05607794-eb7e-4f62-9ea8-19b4fbc2b9c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

