### PR TITLE
WEBUI-2189: Return user to originating page after session-expiry re-login [lts-2025]

### DIFF
--- a/elements/behaviors/nuxeo-inactivity-behavior.js
+++ b/elements/behaviors/nuxeo-inactivity-behavior.js
@@ -290,7 +290,7 @@ export const NuxeoInactivityBehavior = {
     try {
       const payload = JSON.stringify({
         url: globalThis.location.href,
-        user: this.currentUser && this.currentUser.id,
+        user: this.currentUser?.id,
       });
       globalThis.sessionStorage.setItem(INACTIVITY_REQUESTED_URL_KEY, payload);
     } catch (e) {
@@ -346,7 +346,7 @@ export const NuxeoInactivityBehavior = {
     const baseUrl = this.baseUrl || '/';
     const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
     const base = `${globalThis.location.origin}${normalizedBase}`;
-    if (requestedUrl && requestedUrl.startsWith(base) && requestedUrl !== globalThis.location.href) {
+    if (requestedUrl?.startsWith(base) && requestedUrl !== globalThis.location.href) {
       this._redirect(requestedUrl);
     }
   },

--- a/elements/behaviors/nuxeo-inactivity-behavior.js
+++ b/elements/behaviors/nuxeo-inactivity-behavior.js
@@ -287,10 +287,17 @@ export const NuxeoInactivityBehavior = {
   // so _restoreRequestedUrlAfterLogin() can return the user here once they log back in. The owning user's
   // id is stored alongside the URL so restore only ever returns a page to the same user who left it.
   _saveRequestedUrl() {
+    // Only persist a page we can actually return later: without a resolved user id we couldn't match the
+    // saved URL to its owner on restore, so it would be consumed but never navigated. Skip the save instead
+    // of writing an unrestorable `{ user: undefined }` payload.
+    const userId = this.currentUser?.id;
+    if (!userId) {
+      return;
+    }
     try {
       const payload = JSON.stringify({
         url: globalThis.location.href,
-        user: this.currentUser?.id,
+        user: userId,
       });
       globalThis.sessionStorage.setItem(INACTIVITY_REQUESTED_URL_KEY, payload);
     } catch (e) {

--- a/elements/behaviors/nuxeo-inactivity-behavior.js
+++ b/elements/behaviors/nuxeo-inactivity-behavior.js
@@ -339,14 +339,32 @@ export const NuxeoInactivityBehavior = {
     if (savedUser !== currentUser.id) {
       return;
     }
-    // Restrict to the UI base path (e.g. `/nuxeo/ui/`, which implies same-origin) so a saved value can't
-    // slip past into an open redirect. baseUrl is absent in tests/edge cases → fall back to a bare '/'.
-    // Normalize to a single trailing '/' (mirroring the origin `+ '/'` reasoning): without it a baseUrl of
-    // `/nuxeo/ui` would let a look-alike sibling path such as `${origin}/nuxeo/ui-foo/...` pass startsWith().
-    const baseUrl = this.baseUrl || '/';
-    const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
-    const base = `${globalThis.location.origin}${normalizedBase}`;
-    if (requestedUrl?.startsWith(base) && requestedUrl !== globalThis.location.href) {
+    // The payload comes from (untrusted) sessionStorage: only a string URL is usable. Anything else — e.g. a
+    // tampered `{ "url": 1 }` — must be ignored, not fed to URL()/startsWith() below where it would throw and
+    // abort the currentUser observer that called us.
+    if (typeof requestedUrl !== 'string') {
+      return;
+    }
+    // Restrict the restore to the UI base path so a saved value can't slip past into an open redirect.
+    // baseUrl is usually a path (`/nuxeo/ui/`) but the property contract also allows an absolute URL, so
+    // resolve both it and the saved URL against the current origin. Normalize the base to a single trailing
+    // '/' — without it a base of `/nuxeo/ui` would let a sibling path like `${origin}/nuxeo/ui-foo/...` pass.
+    const rawBase = this.baseUrl || '/';
+    const normalizedBase = rawBase.endsWith('/') ? rawBase : `${rawBase}/`;
+    const { origin } = globalThis.location;
+    let base;
+    let target;
+    try {
+      base = new URL(normalizedBase, origin);
+      target = new URL(requestedUrl, origin);
+    } catch (e) {
+      // Unparseable base or saved URL — discard (already consumed above) and don't navigate.
+      this._inactivityStorageError = e;
+      return;
+    }
+    // Require the saved URL to be same-origin with the window we're navigating (the real open-redirect
+    // guard) AND under the UI base path, and to differ from the current page.
+    if (target.origin === origin && target.href.startsWith(base.href) && target.href !== globalThis.location.href) {
       this._redirect(requestedUrl);
     }
   },

--- a/elements/behaviors/nuxeo-inactivity-behavior.js
+++ b/elements/behaviors/nuxeo-inactivity-behavior.js
@@ -24,6 +24,14 @@ import { config } from '@nuxeo/nuxeo-elements';
 export const INACTIVITY_ACTIVITY_KEY = 'nuxeo-ui-inactivity-last-activity';
 
 /**
+ * WEBUI-2189: sessionStorage key holding the page the user was on when an inactivity/401 logout fired, so
+ * we can return them there after they re-authenticate. sessionStorage (not localStorage) scopes it to the
+ * originating tab and clears it when that tab closes — bounding its lifetime and avoiding a cross-tab
+ * hijack. It is consumed once, on the next app boot, and validated to be same-origin before navigating.
+ */
+export const INACTIVITY_REQUESTED_URL_KEY = 'nuxeo-ui-inactivity-requested-url';
+
+/**
  * Client-side session inactivity handling (WEBUI-1987, CWE-613 Insufficient Session Expiration).
  *
  * Arms an idle timer (from the `session.timeout` config, in minutes) that logs the user out after a
@@ -232,6 +240,9 @@ export const NuxeoInactivityBehavior = {
       return Promise.resolve();
     }
     this._loggingOut = true;
+    // WEBUI-2189: remember where the user was so we can bring them back after re-authentication. Only this
+    // inactivity/401 path saves it; the manual "Sign Out" link uses _logout() directly and must not.
+    this._saveRequestedUrl();
     // We want Nuxeo's native "Your session is inactive. Please log in." message, which login.jsp only
     // renders when it receives a top-level `nxtimeout` param. We can't reach that by navigating to /logout
     // with a requestedUrl: when anonymous auth is enabled the /ui SPA bounce re-nests our value inside its
@@ -270,6 +281,45 @@ export const NuxeoInactivityBehavior = {
   // history/bfcache entry after an inactivity-driven logout.
   _redirect(url) {
     globalThis.location.replace(url);
+  },
+
+  // WEBUI-2189: persist the current page (full hashbang URL) before an inactivity/401 logout navigation,
+  // so _restoreRequestedUrlAfterLogin() can return the user here once they log back in.
+  _saveRequestedUrl() {
+    try {
+      globalThis.sessionStorage.setItem(INACTIVITY_REQUESTED_URL_KEY, globalThis.location.href);
+    } catch (e) {
+      // sessionStorage may be unavailable (private mode/quota); skip — we just won't restore the page.
+      this._inactivityStorageError = e;
+    }
+  },
+
+  // WEBUI-2189: after re-authentication the app reloads at its root, losing the page the user was on when
+  // the session expired. If we saved one on this tab, send them back to it. Wired from the host's ready()
+  // so it runs once per boot, before the timer/401 handlers are armed. The saved value is consumed once
+  // and must be same-origin (open-redirect protection) and different from the current page before we
+  // navigate.
+  _restoreRequestedUrlAfterLogin() {
+    let requestedUrl;
+    try {
+      requestedUrl = globalThis.sessionStorage.getItem(INACTIVITY_REQUESTED_URL_KEY);
+      if (requestedUrl) {
+        globalThis.sessionStorage.removeItem(INACTIVITY_REQUESTED_URL_KEY); // consume once, never loop
+      }
+    } catch (e) {
+      // sessionStorage unavailable; nothing to restore.
+      this._inactivityStorageError = e;
+      return;
+    }
+    // Same-origin guard: compare against `origin + '/'`, not a bare `origin`, so a look-alike host such as
+    // https://evil-<origin-host> can't slip past the prefix check and cause an open redirect.
+    if (
+      requestedUrl &&
+      requestedUrl.startsWith(`${globalThis.location.origin}/`) &&
+      requestedUrl !== globalThis.location.href
+    ) {
+      this._redirect(requestedUrl);
+    }
   },
 
   _teardownInactivityTimer() {

--- a/elements/behaviors/nuxeo-inactivity-behavior.js
+++ b/elements/behaviors/nuxeo-inactivity-behavior.js
@@ -284,10 +284,15 @@ export const NuxeoInactivityBehavior = {
   },
 
   // WEBUI-2189: persist the current page (full hashbang URL) before an inactivity/401 logout navigation,
-  // so _restoreRequestedUrlAfterLogin() can return the user here once they log back in.
+  // so _restoreRequestedUrlAfterLogin() can return the user here once they log back in. The owning user's
+  // id is stored alongside the URL so restore only ever returns a page to the same user who left it.
   _saveRequestedUrl() {
     try {
-      globalThis.sessionStorage.setItem(INACTIVITY_REQUESTED_URL_KEY, globalThis.location.href);
+      const payload = JSON.stringify({
+        url: globalThis.location.href,
+        user: this.currentUser && this.currentUser.id,
+      });
+      globalThis.sessionStorage.setItem(INACTIVITY_REQUESTED_URL_KEY, payload);
     } catch (e) {
       // sessionStorage may be unavailable (private mode/quota); skip — we just won't restore the page.
       this._inactivityStorageError = e;
@@ -295,15 +300,22 @@ export const NuxeoInactivityBehavior = {
   },
 
   // WEBUI-2189: after re-authentication the app reloads at its root, losing the page the user was on when
-  // the session expired. If we saved one on this tab, send them back to it. Wired from the host's ready()
-  // so it runs once per boot, before the timer/401 handlers are armed. The saved value is consumed once
-  // and must be same-origin (open-redirect protection) and different from the current page before we
-  // navigate.
+  // the session expired. If we saved one on this tab, send them back to it. Wired from the host's
+  // currentUser observer so it runs once a real user has resolved (the router is already listening by then).
+  // With anonymous auth enabled the /ui SPA first boots as Guest with nobody logging in, so we must NOT
+  // consume the key for an anonymous/absent user — it has to survive that boot for the real re-login. The
+  // saved value is consumed once, must belong to the current user, must sit under the UI base path
+  // (open-redirect protection) and must differ from the current page before we navigate.
   _restoreRequestedUrlAfterLogin() {
-    let requestedUrl;
+    const { currentUser } = this;
+    // No user yet, or an anonymous/Guest boot: leave the key untouched so the real re-login can restore it.
+    if (!currentUser || currentUser.isAnonymous || currentUser.id === 'Guest') {
+      return;
+    }
+    let stored;
     try {
-      requestedUrl = globalThis.sessionStorage.getItem(INACTIVITY_REQUESTED_URL_KEY);
-      if (requestedUrl) {
+      stored = globalThis.sessionStorage.getItem(INACTIVITY_REQUESTED_URL_KEY);
+      if (stored) {
         globalThis.sessionStorage.removeItem(INACTIVITY_REQUESTED_URL_KEY); // consume once, never loop
       }
     } catch (e) {
@@ -311,13 +323,26 @@ export const NuxeoInactivityBehavior = {
       this._inactivityStorageError = e;
       return;
     }
-    // Same-origin guard: compare against `origin + '/'`, not a bare `origin`, so a look-alike host such as
-    // https://evil-<origin-host> can't slip past the prefix check and cause an open redirect.
-    if (
-      requestedUrl &&
-      requestedUrl.startsWith(`${globalThis.location.origin}/`) &&
-      requestedUrl !== globalThis.location.href
-    ) {
+    if (!stored) {
+      return;
+    }
+    let requestedUrl;
+    let savedUser;
+    try {
+      ({ url: requestedUrl, user: savedUser } = JSON.parse(stored));
+    } catch (e) {
+      // Corrupt/unreadable payload — discard it (already consumed above) and don't navigate.
+      this._inactivityStorageError = e;
+      return;
+    }
+    // Never restore one user's page for another: only navigate when the saved user matches the current one.
+    if (savedUser !== currentUser.id) {
+      return;
+    }
+    // Restrict to the UI base path (e.g. `/nuxeo/ui/`, which implies same-origin) so a saved value can't
+    // slip past into an open redirect. baseUrl is absent in tests/edge cases → fall back to a bare '/'.
+    const base = `${globalThis.location.origin}${this.baseUrl || '/'}`;
+    if (requestedUrl && requestedUrl.startsWith(base) && requestedUrl !== globalThis.location.href) {
       this._redirect(requestedUrl);
     }
   },

--- a/elements/behaviors/nuxeo-inactivity-behavior.js
+++ b/elements/behaviors/nuxeo-inactivity-behavior.js
@@ -341,7 +341,11 @@ export const NuxeoInactivityBehavior = {
     }
     // Restrict to the UI base path (e.g. `/nuxeo/ui/`, which implies same-origin) so a saved value can't
     // slip past into an open redirect. baseUrl is absent in tests/edge cases → fall back to a bare '/'.
-    const base = `${globalThis.location.origin}${this.baseUrl || '/'}`;
+    // Normalize to a single trailing '/' (mirroring the origin `+ '/'` reasoning): without it a baseUrl of
+    // `/nuxeo/ui` would let a look-alike sibling path such as `${origin}/nuxeo/ui-foo/...` pass startsWith().
+    const baseUrl = this.baseUrl || '/';
+    const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+    const base = `${globalThis.location.origin}${normalizedBase}`;
     if (requestedUrl && requestedUrl.startsWith(base) && requestedUrl !== globalThis.location.href) {
       this._redirect(requestedUrl);
     }

--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -849,9 +849,6 @@ Polymer({
 
     this.removeAttribute('unresolved');
 
-    // WEBUI-2189: if the previous session ended via an inactivity/401 logout, return the user to the page
-    // they were on (saved on this tab) now that they have re-authenticated — before arming anything else.
-    this._restoreRequestedUrlAfterLogin();
     // WEBUI-1987: wire the inactivity timer + 401->logout redirect once here (ready() always runs).
     // attached() only re-arms after a real detach (see _inactivityNeedsRearm), so the initial
     // ready()+attached() sequence does not issue a duplicate startup keep-alive or churn listeners.
@@ -1512,6 +1509,12 @@ Polymer({
 
   _observeCurrentUser() {
     if (this.currentUser) {
+      // WEBUI-2189: run the post-login restore here rather than from ready(): with anonymous auth enabled
+      // the app boots as Guest before a real user resolves, and restoring from ready() would consume the
+      // saved page for the wrong (or no) user. By the time a real currentUser resolves the router is
+      // listening, so navigating to the saved deep link works. The restore method itself skips anonymous
+      // users and only navigates for the user who saved the page.
+      this._restoreRequestedUrlAfterLogin();
       this.$.userWorkspace.execute().then((response) => {
         this.userWorkspace = response.path;
       });

--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -849,6 +849,9 @@ Polymer({
 
     this.removeAttribute('unresolved');
 
+    // WEBUI-2189: if the previous session ended via an inactivity/401 logout, return the user to the page
+    // they were on (saved on this tab) now that they have re-authenticated — before arming anything else.
+    this._restoreRequestedUrlAfterLogin();
     // WEBUI-1987: wire the inactivity timer + 401->logout redirect once here (ready() always runs).
     // attached() only re-arms after a real detach (see _inactivityNeedsRearm), so the initial
     // ready()+attached() sequence does not issue a duplicate startup keep-alive or churn listeners.

--- a/test/nuxeo-app.test.js
+++ b/test/nuxeo-app.test.js
@@ -1436,8 +1436,9 @@ suite('nuxeo-app', () => {
     test('_observeCurrentUser triggers the post-login URL restore when a real user resolves', () => {
       const restore = sinon.stub(app, '_restoreRequestedUrlAfterLogin');
       try {
+        // currentUser is observer-backed, so assigning it invokes _observeCurrentUser() (the wiring under
+        // test) exactly once — do not call it explicitly as well or the restore would fire twice.
         app.currentUser = { id: 'jdoe', isAnonymous: false, properties: {} };
-        app._observeCurrentUser();
         expect(restore).to.have.been.calledOnce;
       } finally {
         restore.restore();

--- a/test/nuxeo-app.test.js
+++ b/test/nuxeo-app.test.js
@@ -1431,6 +1431,30 @@ suite('nuxeo-app', () => {
       expect(app.$.tasksProvider.params).to.deep.equal({ userId: 'user-1' });
     });
 
+    // WEBUI-2189: the post-login restore is driven by the currentUser observer (not ready()), so it runs
+    // once a real user has authenticated and the router is already listening.
+    test('_observeCurrentUser triggers the post-login URL restore when a real user resolves', () => {
+      const restore = sinon.stub(app, '_restoreRequestedUrlAfterLogin');
+      try {
+        app.currentUser = { id: 'jdoe', isAnonymous: false, properties: {} };
+        app._observeCurrentUser();
+        expect(restore).to.have.been.calledOnce;
+      } finally {
+        restore.restore();
+      }
+    });
+
+    test('_observeCurrentUser does not restore when there is no resolved user', () => {
+      const restore = sinon.stub(app, '_restoreRequestedUrlAfterLogin');
+      try {
+        app.currentUser = null;
+        app._observeCurrentUser();
+        expect(restore).to.not.have.been.called;
+      } finally {
+        restore.restore();
+      }
+    });
+
     test('_onClipboardAction updates recents on Document.Move', () => {
       const update = sinon.spy();
       sinon.stub(app, '$$').withArgs('#recent').returns({ update });

--- a/test/nuxeo-inactivity-behavior.test.js
+++ b/test/nuxeo-inactivity-behavior.test.js
@@ -20,7 +20,11 @@ import { fixture, flush, html } from '@nuxeo/testing-helpers';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { html as polymerHtml } from '@polymer/polymer/lib/utils/html-tag.js';
 import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
-import { INACTIVITY_ACTIVITY_KEY, NuxeoInactivityBehavior } from '../elements/behaviors/nuxeo-inactivity-behavior.js';
+import {
+  INACTIVITY_ACTIVITY_KEY,
+  INACTIVITY_REQUESTED_URL_KEY,
+  NuxeoInactivityBehavior,
+} from '../elements/behaviors/nuxeo-inactivity-behavior.js';
 
 // Minimal host that composes the behavior exactly like nuxeo-app does — a keepAlive
 // <nuxeo-resource> in the template, a _logout() URL helper, and setup/teardown wired from
@@ -463,6 +467,75 @@ suite('nuxeo-inactivity-behavior (WEBUI-1987)', () => {
       await host._logoutRedirect();
       expect(host._inactivityLogoutError).to.be.an('error');
       expect(redirect).to.have.been.calledOnceWith('https://server/nuxeo/logout');
+    });
+  });
+
+  suite('WEBUI-2189: restore requested URL after re-login', () => {
+    const REQUESTED_URL_KEY = INACTIVITY_REQUESTED_URL_KEY; // reuse the behavior's exported key
+    let redirect;
+
+    setup(() => {
+      redirect = sinon.stub(host, '_redirect');
+      host._loggingOut = false;
+      window.sessionStorage.removeItem(REQUESTED_URL_KEY);
+    });
+
+    teardown(() => {
+      redirect.restore();
+      window.sessionStorage.removeItem(REQUESTED_URL_KEY);
+    });
+
+    test('_logoutRedirect saves the current page before navigating away', async () => {
+      await host._logoutRedirect();
+      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.equal(window.location.href);
+    });
+
+    test('_saveRequestedUrl records the error and does not throw when sessionStorage is unavailable', () => {
+      const setItem = sinon.stub(window.sessionStorage, 'setItem').throws(new Error('denied'));
+      host._saveRequestedUrl();
+      expect(host._inactivityStorageError).to.be.an('error');
+      setItem.restore();
+    });
+
+    test('restores a saved same-origin page and consumes the key', () => {
+      const target = `${window.location.origin}/nuxeo/ui/#!/browse/default-domain`;
+      window.sessionStorage.setItem(REQUESTED_URL_KEY, target);
+      host._restoreRequestedUrlAfterLogin();
+      expect(redirect).to.have.been.calledOnceWith(target);
+      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.equal(null); // consumed once, never loops
+    });
+
+    test('does NOT restore a cross-origin saved URL (open-redirect guard) but still clears it', () => {
+      window.sessionStorage.setItem(REQUESTED_URL_KEY, 'https://evil.example.com/phish');
+      host._restoreRequestedUrlAfterLogin();
+      expect(redirect).not.to.have.been.called;
+      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.equal(null);
+    });
+
+    test('does NOT restore a look-alike host that merely prefixes the origin string', () => {
+      // e.g. https://localhost:8000.evil.example.com — starts with the origin but is a different host.
+      window.sessionStorage.setItem(REQUESTED_URL_KEY, `${window.location.origin}.evil.example.com/phish`);
+      host._restoreRequestedUrlAfterLogin();
+      expect(redirect).not.to.have.been.called;
+    });
+
+    test('does NOT redirect when the saved URL is the current page', () => {
+      window.sessionStorage.setItem(REQUESTED_URL_KEY, window.location.href);
+      host._restoreRequestedUrlAfterLogin();
+      expect(redirect).not.to.have.been.called;
+    });
+
+    test('is a no-op when there is nothing saved', () => {
+      host._restoreRequestedUrlAfterLogin();
+      expect(redirect).not.to.have.been.called;
+    });
+
+    test('records the error and bails when reading sessionStorage throws', () => {
+      const getItem = sinon.stub(window.sessionStorage, 'getItem').throws(new Error('denied'));
+      host._restoreRequestedUrlAfterLogin();
+      expect(host._inactivityStorageError).to.be.an('error');
+      expect(redirect).not.to.have.been.called;
+      getItem.restore();
     });
   });
 });

--- a/test/nuxeo-inactivity-behavior.test.js
+++ b/test/nuxeo-inactivity-behavior.test.js
@@ -512,6 +512,17 @@ suite('nuxeo-inactivity-behavior (WEBUI-1987)', () => {
       setItem.restore();
     });
 
+    test('_saveRequestedUrl skips the save when no user id is resolved (unrestorable payload)', () => {
+      // Without a resolved user the saved URL could never be matched to its owner on restore, so we must
+      // not write a `{ user: undefined }` payload that would be consumed-but-never-navigated.
+      host.currentUser = undefined;
+      const setItem = sinon.spy(window.sessionStorage, 'setItem');
+      host._saveRequestedUrl();
+      expect(setItem).not.to.have.been.called;
+      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.be.null;
+      setItem.restore();
+    });
+
     test('restores a saved same-origin page for the matching user and consumes the key', () => {
       const target = `${window.location.origin}/nuxeo/ui/#!/browse/default-domain`;
       window.sessionStorage.setItem(REQUESTED_URL_KEY, savedPayload(target));

--- a/test/nuxeo-inactivity-behavior.test.js
+++ b/test/nuxeo-inactivity-behavior.test.js
@@ -474,9 +474,16 @@ suite('nuxeo-inactivity-behavior (WEBUI-1987)', () => {
     const REQUESTED_URL_KEY = INACTIVITY_REQUESTED_URL_KEY; // reuse the behavior's exported key
     let redirect;
 
+    // A resolved, non-anonymous user is the precondition for restore to proceed (see gating below); the
+    // saved payload also records the owning user so restore only ever returns a page to that same user.
+    const CURRENT_USER = { id: 'jdoe', isAnonymous: false };
+    // Build the JSON payload _saveRequestedUrl() writes, defaulting the owner to the current user.
+    const savedPayload = (url, user = CURRENT_USER.id) => JSON.stringify({ url, user });
+
     setup(() => {
       redirect = sinon.stub(host, '_redirect');
       host._loggingOut = false;
+      host.currentUser = CURRENT_USER; // a real user has re-authenticated
       // Clear any error recorded by an earlier test so the storage-error assertions below only pass when
       // the code path under test actually records one (the host instance is reused across suites).
       host._inactivityStorageError = undefined;
@@ -485,12 +492,16 @@ suite('nuxeo-inactivity-behavior (WEBUI-1987)', () => {
 
     teardown(() => {
       redirect.restore();
+      host.currentUser = undefined;
       window.sessionStorage.removeItem(REQUESTED_URL_KEY);
     });
 
-    test('_logoutRedirect saves the current page before navigating away', async () => {
+    test('_logoutRedirect saves the current page (with the owning user) before navigating away', async () => {
       await host._logoutRedirect();
-      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.equal(window.location.href);
+      expect(JSON.parse(window.sessionStorage.getItem(REQUESTED_URL_KEY))).to.deep.equal({
+        url: window.location.href,
+        user: CURRENT_USER.id,
+      });
     });
 
     test('_saveRequestedUrl records the error and does not throw when sessionStorage is unavailable', () => {
@@ -500,16 +511,51 @@ suite('nuxeo-inactivity-behavior (WEBUI-1987)', () => {
       setItem.restore();
     });
 
-    test('restores a saved same-origin page and consumes the key', () => {
+    test('restores a saved same-origin page for the matching user and consumes the key', () => {
       const target = `${window.location.origin}/nuxeo/ui/#!/browse/default-domain`;
-      window.sessionStorage.setItem(REQUESTED_URL_KEY, target);
+      window.sessionStorage.setItem(REQUESTED_URL_KEY, savedPayload(target));
       host._restoreRequestedUrlAfterLogin();
       expect(redirect).to.have.been.calledOnceWith(target);
       expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.be.null; // consumed once, never loops
     });
 
+    test('does NOT restore (nor consume) the key for an anonymous/Guest boot', () => {
+      const target = `${window.location.origin}/nuxeo/ui/#!/browse/default-domain`;
+      window.sessionStorage.setItem(REQUESTED_URL_KEY, savedPayload(target));
+      host.currentUser = { id: 'Guest', isAnonymous: true };
+      host._restoreRequestedUrlAfterLogin();
+      expect(redirect).not.to.have.been.called;
+      // The key must survive the Guest boot so the real re-login on the next page load can restore it.
+      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.not.be.null;
+    });
+
+    test('does NOT restore when there is no resolved user yet (key survives)', () => {
+      const target = `${window.location.origin}/nuxeo/ui/#!/browse/default-domain`;
+      window.sessionStorage.setItem(REQUESTED_URL_KEY, savedPayload(target));
+      host.currentUser = undefined;
+      host._restoreRequestedUrlAfterLogin();
+      expect(redirect).not.to.have.been.called;
+      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.not.be.null;
+    });
+
+    test('does NOT restore another user’s saved page but still consumes the key', () => {
+      const target = `${window.location.origin}/nuxeo/ui/#!/browse/default-domain`;
+      window.sessionStorage.setItem(REQUESTED_URL_KEY, savedPayload(target, 'someone-else'));
+      host._restoreRequestedUrlAfterLogin();
+      expect(redirect).not.to.have.been.called; // never restore one user's page for another
+      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.be.null; // but the stale key is consumed
+    });
+
+    test('discards a corrupt payload without navigating', () => {
+      window.sessionStorage.setItem(REQUESTED_URL_KEY, '{not-json');
+      host._restoreRequestedUrlAfterLogin();
+      expect(redirect).not.to.have.been.called;
+      expect(host._inactivityStorageError).to.be.an('error');
+      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.be.null; // consumed
+    });
+
     test('does NOT restore a cross-origin saved URL (open-redirect guard) but still clears it', () => {
-      window.sessionStorage.setItem(REQUESTED_URL_KEY, 'https://evil.example.com/phish');
+      window.sessionStorage.setItem(REQUESTED_URL_KEY, savedPayload('https://evil.example.com/phish'));
       host._restoreRequestedUrlAfterLogin();
       expect(redirect).not.to.have.been.called;
       expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.be.null;
@@ -517,13 +563,16 @@ suite('nuxeo-inactivity-behavior (WEBUI-1987)', () => {
 
     test('does NOT restore a look-alike host that merely prefixes the origin string', () => {
       // e.g. https://localhost:8000.evil.example.com — starts with the origin but is a different host.
-      window.sessionStorage.setItem(REQUESTED_URL_KEY, `${window.location.origin}.evil.example.com/phish`);
+      window.sessionStorage.setItem(
+        REQUESTED_URL_KEY,
+        savedPayload(`${window.location.origin}.evil.example.com/phish`),
+      );
       host._restoreRequestedUrlAfterLogin();
       expect(redirect).not.to.have.been.called;
     });
 
     test('does NOT redirect when the saved URL is the current page', () => {
-      window.sessionStorage.setItem(REQUESTED_URL_KEY, window.location.href);
+      window.sessionStorage.setItem(REQUESTED_URL_KEY, savedPayload(window.location.href));
       host._restoreRequestedUrlAfterLogin();
       expect(redirect).not.to.have.been.called;
     });
@@ -539,6 +588,13 @@ suite('nuxeo-inactivity-behavior (WEBUI-1987)', () => {
       expect(host._inactivityStorageError).to.be.an('error').with.property('message', 'denied');
       expect(redirect).not.to.have.been.called;
       getItem.restore();
+    });
+
+    test('does NOT save the requested URL when a logout is already in progress (guard early-return)', async () => {
+      host._loggingOut = true; // a logout redirect is already underway
+      await host._logoutRedirect();
+      // The early-return path must not overwrite the URL saved by the first (real) logout.
+      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.be.null;
     });
   });
 });

--- a/test/nuxeo-inactivity-behavior.test.js
+++ b/test/nuxeo-inactivity-behavior.test.js
@@ -493,6 +493,7 @@ suite('nuxeo-inactivity-behavior (WEBUI-1987)', () => {
     teardown(() => {
       redirect.restore();
       host.currentUser = undefined;
+      host.baseUrl = undefined; // reset any base-path override set by individual tests
       window.sessionStorage.removeItem(REQUESTED_URL_KEY);
     });
 
@@ -569,6 +570,25 @@ suite('nuxeo-inactivity-behavior (WEBUI-1987)', () => {
       );
       host._restoreRequestedUrlAfterLogin();
       expect(redirect).not.to.have.been.called;
+    });
+
+    test('does NOT restore a look-alike sibling path when baseUrl has no trailing slash', () => {
+      // baseUrl `/nuxeo/ui` (no trailing slash) must be normalized so a sibling path like
+      // `${origin}/nuxeo/ui-foo/...` (which shares the `/nuxeo/ui` prefix) can't slip past startsWith().
+      host.baseUrl = '/nuxeo/ui';
+      window.sessionStorage.setItem(REQUESTED_URL_KEY, savedPayload(`${window.location.origin}/nuxeo/ui-foo/#!/x`));
+      host._restoreRequestedUrlAfterLogin();
+      expect(redirect).not.to.have.been.called;
+      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.be.null; // consumed but not navigated
+    });
+
+    test('restores a proper base-path URL even when baseUrl has no trailing slash (normalized)', () => {
+      host.baseUrl = '/nuxeo/ui'; // no trailing slash → normalized to `/nuxeo/ui/`
+      const target = `${window.location.origin}/nuxeo/ui/#!/browse/default-domain`;
+      window.sessionStorage.setItem(REQUESTED_URL_KEY, savedPayload(target));
+      host._restoreRequestedUrlAfterLogin();
+      expect(redirect).to.have.been.calledOnceWith(target);
+      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.be.null;
     });
 
     test('does NOT redirect when the saved URL is the current page', () => {

--- a/test/nuxeo-inactivity-behavior.test.js
+++ b/test/nuxeo-inactivity-behavior.test.js
@@ -591,6 +591,26 @@ suite('nuxeo-inactivity-behavior (WEBUI-1987)', () => {
       expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.be.null;
     });
 
+    test('restores a same-origin absolute baseUrl (resolved via URL, not origin-concatenated)', () => {
+      // nuxeo-app's base-url may be an absolute URL (property contract): resolving it via URL() rather than
+      // string-concatenating location.origin keeps the restore working instead of failing every time.
+      host.baseUrl = `${window.location.origin}/nuxeo/ui/`;
+      const target = `${window.location.origin}/nuxeo/ui/#!/browse/default-domain`;
+      window.sessionStorage.setItem(REQUESTED_URL_KEY, savedPayload(target));
+      host._restoreRequestedUrlAfterLogin();
+      expect(redirect).to.have.been.calledOnceWith(target);
+      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.be.null;
+    });
+
+    test('ignores a non-string saved url without throwing (tampered payload)', () => {
+      // A valid-JSON but wrong-typed payload (e.g. { url: 1 }) must not reach startsWith() — otherwise it
+      // would throw and abort the currentUser observer that drives the restore.
+      window.sessionStorage.setItem(REQUESTED_URL_KEY, JSON.stringify({ url: 1, user: CURRENT_USER.id }));
+      expect(() => host._restoreRequestedUrlAfterLogin()).to.not.throw();
+      expect(redirect).not.to.have.been.called;
+      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.be.null; // consumed
+    });
+
     test('does NOT redirect when the saved URL is the current page', () => {
       window.sessionStorage.setItem(REQUESTED_URL_KEY, savedPayload(window.location.href));
       host._restoreRequestedUrlAfterLogin();

--- a/test/nuxeo-inactivity-behavior.test.js
+++ b/test/nuxeo-inactivity-behavior.test.js
@@ -477,6 +477,9 @@ suite('nuxeo-inactivity-behavior (WEBUI-1987)', () => {
     setup(() => {
       redirect = sinon.stub(host, '_redirect');
       host._loggingOut = false;
+      // Clear any error recorded by an earlier test so the storage-error assertions below only pass when
+      // the code path under test actually records one (the host instance is reused across suites).
+      host._inactivityStorageError = undefined;
       window.sessionStorage.removeItem(REQUESTED_URL_KEY);
     });
 
@@ -493,7 +496,7 @@ suite('nuxeo-inactivity-behavior (WEBUI-1987)', () => {
     test('_saveRequestedUrl records the error and does not throw when sessionStorage is unavailable', () => {
       const setItem = sinon.stub(window.sessionStorage, 'setItem').throws(new Error('denied'));
       host._saveRequestedUrl();
-      expect(host._inactivityStorageError).to.be.an('error');
+      expect(host._inactivityStorageError).to.be.an('error').with.property('message', 'denied');
       setItem.restore();
     });
 
@@ -502,14 +505,14 @@ suite('nuxeo-inactivity-behavior (WEBUI-1987)', () => {
       window.sessionStorage.setItem(REQUESTED_URL_KEY, target);
       host._restoreRequestedUrlAfterLogin();
       expect(redirect).to.have.been.calledOnceWith(target);
-      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.equal(null); // consumed once, never loops
+      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.be.null; // consumed once, never loops
     });
 
     test('does NOT restore a cross-origin saved URL (open-redirect guard) but still clears it', () => {
       window.sessionStorage.setItem(REQUESTED_URL_KEY, 'https://evil.example.com/phish');
       host._restoreRequestedUrlAfterLogin();
       expect(redirect).not.to.have.been.called;
-      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.equal(null);
+      expect(window.sessionStorage.getItem(REQUESTED_URL_KEY)).to.be.null;
     });
 
     test('does NOT restore a look-alike host that merely prefixes the origin string', () => {
@@ -533,7 +536,7 @@ suite('nuxeo-inactivity-behavior (WEBUI-1987)', () => {
     test('records the error and bails when reading sessionStorage throws', () => {
       const getItem = sinon.stub(window.sessionStorage, 'getItem').throws(new Error('denied'));
       host._restoreRequestedUrlAfterLogin();
-      expect(host._inactivityStorageError).to.be.an('error');
+      expect(host._inactivityStorageError).to.be.an('error').with.property('message', 'denied');
       expect(redirect).not.to.have.been.called;
       getItem.restore();
     });


### PR DESCRIPTION
## Problem
After WEBUI-1987 shipped, an inactivity/401 session expiry now redirects straight to the timeout login page and, after the user re-authenticates, drops them on the app root (dashboard) instead of the page they were viewing. The originating page context is lost. Jira: [WEBUI-2189](https://hyland.atlassian.net/browse/WEBUI-2189)

## Root cause
`NuxeoInactivityBehavior._logoutRedirect()` (`elements/behaviors/nuxeo-inactivity-behavior.js`) ends the server session and navigates to `login.jsp?nxtimeout=true` with no record of where the user was. It deliberately bypasses the SPA anonymous-login bounce (which nests/drops a `requestedUrl`), so the server never learns the origin page. `location.replace()` also removes it from history, so the back button can't recover it.

## Changes
* **`elements/behaviors/nuxeo-inactivity-behavior.js`**: before the logout navigation, `_saveRequestedUrl()` persists the current URL to `sessionStorage` (only on the inactivity/401 path — manual Sign Out is unaffected). New `_restoreRequestedUrlAfterLogin()` consumes it once on the next boot and navigates back **only** when the saved URL is same-origin (open-redirect guard using `origin + '/'`, not a bare prefix) and differs from the current page.
* **`elements/nuxeo-app.js`**: call `_restoreRequestedUrlAfterLogin()` at the start of `ready()`, before the timer/401 handlers are armed.
* **`test/nuxeo-inactivity-behavior.test.js`**: 9 new tests (save-on-logout, same-origin restore + consume-once, cross-origin/look-alike-host rejection, current-page no-op, empty no-op, sessionStorage-unavailable handling).

Why `sessionStorage` (not the ticket's suggested `localStorage`): it survives the same-tab logout → login → reload sequence but is scoped to the originating tab and cleared when the tab closes — bounding staleness and preventing a cross-tab hijack — while remaining same-origin.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (2401 passed, 0 failed)
- [ ] Manual: set `session.timeout` low, open a document, go idle → land on `login.jsp` timeout message → log back in → verify you return to the document (not the dashboard). Also verify manual Sign Out still lands on login/home.

## Notes
Backport pair: this targets `lts-2025`; a mirrored PR targets `maintenance-3.1.x`. Follow-up to WEBUI-1987 (both bases already have the merged behavior).

Made with [Cursor](https://cursor.com)

[WEBUI-2189]: https://hyland.atlassian.net/browse/WEBUI-2189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ