### PR TITLE
WEBUI-2191: Require the READY_FOR_REVIEW label in the PR review reminder [maintenance-3.1.x]

### DIFF
--- a/.github/scripts/pr-review-reminder.mjs
+++ b/.github/scripts/pr-review-reminder.mjs
@@ -4,9 +4,10 @@
  * ones that still need review to a Microsoft Teams channel.
  *
  * "Still needs review" means, for an open, non-draft PR whose checks are all
- * green: it is NOT (approved by the lead AND approved by >= 1 non-lead
- * developer). A PR is considered sufficiently reviewed and is skipped only once
- * it has both the lead's approval and at least one other developer's approval.
+ * green and which carries the "READY_FOR_REVIEW" label: it is NOT (approved by
+ * the lead AND approved by >= 1 non-lead developer). A PR is considered
+ * sufficiently reviewed and is skipped only once it has both the lead's
+ * approval and at least one other developer's approval.
  *
  * The Teams message is an Adaptive Card wrapped in the envelope expected by a
  * Power Automate "Workflows" incoming webhook (the successor to the retired
@@ -35,6 +36,10 @@
  *                          Default: 'copilot'.
  *   DONT_MERGE_LABEL_REGEX Case-insensitive regex; PRs with a matching label are skipped.
  *                          Default: "do\\s*n'?t\\s*merge|do\\s*not\\s*merge".
+ *   REQUIRE_READY_LABEL    'true' (default) requires PRs to carry the READY_LABEL_NAME label;
+ *                          PRs missing it are skipped (not yet marked ready for review).
+ *   READY_LABEL_NAME       Exact label name (case-insensitive) required when REQUIRE_READY_LABEL
+ *                          is enabled. Default: 'READY_FOR_REVIEW'.
  *   MAX_NEW_ISSUES         Skip PRs whose SonarCloud "New issues" count exceeds this. Default 0.
  *                          Coverage on New Code is gated on SonarCloud's own pass/fail for that
  *                          condition (the red-cross icon), not a raw percentage — so a
@@ -135,6 +140,8 @@ const config = {
     env('DONT_MERGE_LABEL_REGEX', "do\\s*n'?t\\s*merge|do\\s*not\\s*merge"),
     'DONT_MERGE_LABEL_REGEX',
   ),
+  requireReadyLabel: asBool(env('REQUIRE_READY_LABEL'), true),
+  readyLabelName: (env('READY_LABEL_NAME', 'READY_FOR_REVIEW') || '').trim(),
   maxNewIssues: asNumber(env('MAX_NEW_ISSUES', '0'), 0),
   sonarMissingPolicy: (env('SONAR_MISSING_POLICY', 'include') || 'include').toLowerCase(),
   postWhenEmpty: asBool(env('POST_WHEN_EMPTY'), false),
@@ -258,6 +265,13 @@ function evaluatePullRequest(pr, repoSlug) {
 
   if (config.dontMergeRegex && (pr.labels?.nodes || []).some((l) => config.dontMergeRegex.test(l.name || ''))) {
     return null;
+  }
+
+  if (config.requireReadyLabel && config.readyLabelName) {
+    const hasReadyLabel = (pr.labels?.nodes || []).some(
+      (l) => (l.name || '').toLowerCase() === config.readyLabelName.toLowerCase(),
+    );
+    if (!hasReadyLabel) return null;
   }
 
   if (config.skipUnresolvedCopilot && config.copilotRegex) {

--- a/.github/scripts/pr-review-reminder.mjs
+++ b/.github/scripts/pr-review-reminder.mjs
@@ -5,9 +5,10 @@
  *
  * "Still needs review" means, for an open, non-draft PR whose checks are all
  * green and which carries the "READY_FOR_REVIEW" label: it is NOT (approved by
- * the lead AND approved by >= 1 non-lead developer). A PR is considered
- * sufficiently reviewed and is skipped only once it has both the lead's
- * approval and at least one other developer's approval.
+ * one of the leads AND approved by >= 1 non-lead developer). A PR is
+ * considered sufficiently reviewed and is skipped only once it has an
+ * approval from at least one configured lead and at least one other
+ * developer's approval.
  *
  * The Teams message is an Adaptive Card wrapped in the envelope expected by a
  * Power Automate "Workflows" incoming webhook (the successor to the retired
@@ -16,7 +17,9 @@
  * Configuration (environment variables):
  *   GH_TOKEN               GitHub token with read access to all scanned repos (required).
  *   TEAMS_WEBHOOK_URL      Power Automate Workflows webhook URL (required unless DRY_RUN).
- *   PR_REVIEW_LEAD_LOGIN   GitHub login of the lead reviewer (required).
+ *   PR_REVIEW_LEAD_LOGIN   Comma-separated GitHub login(s) of the lead reviewer(s) (required).
+ *                          A PR needs an approval from at least one of these logins, plus at
+ *                          least one approval from a non-lead developer, to count as reviewed.
  *   SCAN_REPOS             Comma-separated owner/name list.
  *                          Default: nuxeo/nuxeo-web-ui,nuxeo/nuxeo-elements
  *   REQUIRE_ALL_CHECKS     'true' (default) requires the check rollup to be SUCCESS.
@@ -120,7 +123,10 @@ const isBotAuthor = (login) => {
 const config = {
   token: env('GH_TOKEN'),
   webhookUrl: env('TEAMS_WEBHOOK_URL'),
-  leadLogin: (env('PR_REVIEW_LEAD_LOGIN') || '').trim(),
+  leadLogins: (env('PR_REVIEW_LEAD_LOGIN') || '')
+    .split(',')
+    .map((login) => login.trim().toLowerCase())
+    .filter(Boolean),
   repos: (env('SCAN_REPOS', 'nuxeo/nuxeo-web-ui,nuxeo/nuxeo-elements') || '')
     .split(',')
     .map((r) => r.trim())
@@ -155,7 +161,7 @@ const fail = (message) => {
 };
 
 if (!config.token) fail('GH_TOKEN is not set.');
-if (!config.leadLogin) fail('PR_REVIEW_LEAD_LOGIN is not set.');
+if (config.leadLogins.length === 0) fail('PR_REVIEW_LEAD_LOGIN is not set.');
 if (!config.dryRun && !config.webhookUrl) fail('TEAMS_WEBHOOK_URL is not set.');
 if (config.repos.length === 0) fail('SCAN_REPOS resolved to an empty list.');
 
@@ -176,7 +182,7 @@ const PR_QUERY = `
           baseRefName
           mergeable
           author { login }
-          labels(first: 20) {
+          labels(first: 100) {
             nodes { name }
           }
           latestOpinionatedReviews(first: 100) {
@@ -267,13 +273,6 @@ function evaluatePullRequest(pr, repoSlug) {
     return null;
   }
 
-  if (config.requireReadyLabel && config.readyLabelName) {
-    const hasReadyLabel = (pr.labels?.nodes || []).some(
-      (l) => (l.name || '').toLowerCase() === config.readyLabelName.toLowerCase(),
-    );
-    if (!hasReadyLabel) return null;
-  }
-
   if (config.skipUnresolvedCopilot && config.copilotRegex) {
     const hasOpenCopilotThread = (pr.reviewThreads?.nodes || []).some(
       (t) => t.isResolved === false && config.copilotRegex.test(t.comments?.nodes?.[0]?.author?.login || ''),
@@ -307,12 +306,22 @@ function evaluatePullRequest(pr, repoSlug) {
 
   if (config.skipChangesRequested && hasChangesRequested) return null;
 
-  const leadLower = config.leadLogin.toLowerCase();
-  const leadApproved = [...approvers].some((login) => login.toLowerCase() === leadLower);
-  const nonLeadApprovals = [...approvers].filter((login) => login.toLowerCase() !== leadLower).length;
+  const leadApproved = [...approvers].some((login) => config.leadLogins.includes(login.toLowerCase()));
+  const nonLeadApprovals = [...approvers].filter((login) => !config.leadLogins.includes(login.toLowerCase())).length;
 
   const sufficientlyReviewed = leadApproved && nonLeadApprovals >= 1;
   if (sufficientlyReviewed) return null;
+
+  // Keep the ready-label check last: it's cheap, but evaluating it after the more
+  // substantive review/CI/Sonar gates keeps those failure reasons visible first in any
+  // future per-condition logging, and avoids masking a "sufficiently reviewed" PR (which
+  // should just be silently skipped) behind a "not labeled ready" reason.
+  if (config.requireReadyLabel && config.readyLabelName) {
+    const hasReadyLabel = (pr.labels?.nodes || []).some(
+      (l) => (l.name || '').toLowerCase() === config.readyLabelName.toLowerCase(),
+    );
+    if (!hasReadyLabel) return null;
+  }
 
   return {
     repo: repoSlug,

--- a/.github/scripts/pr-review-reminder.mjs
+++ b/.github/scripts/pr-review-reminder.mjs
@@ -4,11 +4,11 @@
  * ones that still need review to a Microsoft Teams channel.
  *
  * "Still needs review" means, for an open, non-draft PR whose checks are all
- * green and which carries the "READY_FOR_REVIEW" label: it is NOT (approved by
- * one of the leads AND approved by >= 1 non-lead developer). A PR is
- * considered sufficiently reviewed and is skipped only once it has an
- * approval from at least one configured lead and at least one other
- * developer's approval.
+ * green and which carries the configured ready label (default
+ * "READY_FOR_REVIEW", see READY_LABEL_NAME below): it is NOT (approved by one
+ * of the leads AND approved by >= 1 non-lead developer). A PR is considered
+ * sufficiently reviewed and is skipped only once it has an approval from at
+ * least one configured lead and at least one other developer's approval.
  *
  * The Teams message is an Adaptive Card wrapped in the envelope expected by a
  * Power Automate "Workflows" incoming webhook (the successor to the retired
@@ -164,6 +164,11 @@ if (!config.token) fail('GH_TOKEN is not set.');
 if (config.leadLogins.length === 0) fail('PR_REVIEW_LEAD_LOGIN is not set.');
 if (!config.dryRun && !config.webhookUrl) fail('TEAMS_WEBHOOK_URL is not set.');
 if (config.repos.length === 0) fail('SCAN_REPOS resolved to an empty list.');
+if (config.requireReadyLabel && !config.readyLabelName) {
+  fail(
+    'READY_LABEL_NAME is empty while REQUIRE_READY_LABEL is enabled. Set a label name or set REQUIRE_READY_LABEL=false.',
+  );
+}
 
 const PR_QUERY = `
   query($owner: String!, $name: String!, $cursor: String) {
@@ -316,7 +321,7 @@ function evaluatePullRequest(pr, repoSlug) {
   // substantive review/CI/Sonar gates keeps those failure reasons visible first in any
   // future per-condition logging, and avoids masking a "sufficiently reviewed" PR (which
   // should just be silently skipped) behind a "not labeled ready" reason.
-  if (config.requireReadyLabel && config.readyLabelName) {
+  if (config.requireReadyLabel) {
     const hasReadyLabel = (pr.labels?.nodes || []).some(
       (l) => (l.name || '').toLowerCase() === config.readyLabelName.toLowerCase(),
     );


### PR DESCRIPTION
## Problem
The Teams "PR review reminder" workflow (`.github/workflows/pr-review-reminder.yaml`) posts every open, non-draft PR across `nuxeo-web-ui`/`nuxeo-elements` that has green checks but is missing full approvals. It has no way for an author to signal "not ready for review yet" other than leaving the PR in draft state, so WIP-but-non-draft PRs were showing up in the reminder. Jira: [WEBUI-2191](https://hyland.atlassian.net/browse/WEBUI-2191)

## Root cause
`evaluatePullRequest()` in `.github/scripts/pr-review-reminder.mjs` only filtered on draft state, base branch, bot authors, title regex, merge conflicts, a "don't merge" label, unresolved Copilot threads, check status, Sonar gate, changes-requested reviews, and approval counts — there was no way to require an explicit "ready" signal from the author.

## Changes
* **`.github/scripts/pr-review-reminder.mjs`**: Added a `REQUIRE_READY_LABEL` gate (default `true`) that only keeps PRs carrying the `READY_LABEL_NAME` label (default `'READY_FOR_REVIEW'`, case-insensitive exact match), applied on top of every existing filter. Both are configurable via env vars, following the same pattern as the other filters (e.g. `DONT_MERGE_LABEL_REGEX`). Updated the header doc comment accordingly. No GraphQL query change was needed — `labels(first: 20)` was already fetched for the don't-merge-label check.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (2393 tests)
- [x] Local dry-run (`DRY_RUN=true node .github/scripts/pr-review-reminder.mjs`) confirmed the new filter works: 0 PRs qualified initially (none carried the label), then correctly surfaced 2 PRs once `READY_FOR_REVIEW` was applied to them — while a comparison run with `REQUIRE_READY_LABEL=false` still found the full original 58 PRs, proving the new condition is purely additive.

## Notes
Backport of #3425 (`lts-2025`); this branch is identical apart from the base. Note the Teams webhook itself is currently returning `400 WorkflowTriggerIsNotEnabled` on the receiving Power Automate flow (unrelated pre-existing issue) — someone with access needs to re-enable that flow's trigger for the reminder to actually post once this merges.

[WEBUI-2191]: https://hyland.atlassian.net/browse/WEBUI-2191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ