### PR TITLE
WEBUI-1876: Show root label instead of uid in the page title [maintenance-3.1.x]

### DIFF
--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -1240,7 +1240,11 @@ Polymer({
     switch (this.page) {
       case 'browse':
         if (this.currentDocument && this.currentDocument.title) {
-          title.push(this.currentDocument.title);
+          // The repository root has no dc:title, so the server returns its uid as the title.
+          // Mirror the breadcrumb/clipboard behavior and show the localized root label instead
+          // of a raw UUID, so the browser tab title stays meaningful and consistent for
+          // screen-reader users navigating between tabs (WEBUI-1876).
+          title.push(this.currentDocument.type === 'Root' ? this.i18n('browse.root') : this.currentDocument.title);
           if (this.currentDocument.type === 'Collections') {
             title.push(this.i18n('app.title.collections'));
           } else if (this.hasFacet(this.currentDocument, 'Collection')) {

--- a/test/nuxeo-app.test.js
+++ b/test/nuxeo-app.test.js
@@ -705,6 +705,22 @@ suite('nuxeo-app', () => {
       app.hasFacet.restore();
     });
 
+    test('uses the localized root label instead of the uid for the Root document (WEBUI-1876)', () => {
+      sinon.stub(app, 'hasFacet').returns(false);
+      app.page = 'browse';
+      // The repository root has no dc:title; the server returns its uid as the title.
+      app.currentDocument = {
+        title: '0c5bf33e-86b4-486e-b6a5-f8fa2a85dbec',
+        uid: '0c5bf33e-86b4-486e-b6a5-f8fa2a85dbec',
+        type: 'Root',
+      };
+      app.productName = 'Nuxeo';
+      app._updateTitle();
+      expect(document.title).to.include('browse.root');
+      expect(document.title).to.not.include('0c5bf33e-86b4-486e-b6a5-f8fa2a85dbec');
+      app.hasFacet.restore();
+    });
+
     test('sets title for admin page', () => {
       app.page = 'admin';
       app.selectedAdminTab = 'users';


### PR DESCRIPTION
## Problem
On the browse repository **root**, the browser tab title was a raw document UUID (e.g. `0c5bf33e-86b4-486e-b6a5-f8fa2a85dbec - Nuxeo Platform`) instead of a human-readable label. Screen-reader / low-vision users rely on the tab title to identify and return to the Nuxeo tab when several tabs are open, so an opaque UUID is an accessibility defect (WCAG 2.4.2 Page Titled). Jira: [WEBUI-1876](https://hyland.atlassian.net/browse/WEBUI-1876)

## Root cause
The repository root document has no `dc:title`, so the server returns its `uid` as the document title. `nuxeo-app._updateTitle()` pushed `currentDocument.title` verbatim for the `browse` page, so for the Root document the tab title became the UUID. The breadcrumb, clipboard and recent-documents elements already special-case `type === 'Root'` to show the localized `browse.root` label, but `_updateTitle` did not, leaving the tab title inconsistent with the on-screen breadcrumb heading ("Root").

## Changes
* **`elements/nuxeo-app.js`**: in `_updateTitle`, use `this.i18n('browse.root')` for `Root` documents instead of the raw `currentDocument.title` (uid), mirroring the existing breadcrumb/clipboard/recent-documents behavior. Non-root documents are unchanged.
* **`test/nuxeo-app.test.js`**: add a unit test asserting the Root document title resolves to the `browse.root` label and never contains the uid.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (2413 tests)
- [x] Verified in a real browser (`/#!/browse`): tab title before = `<uid> - Nuxeo`, after = `Root - Nuxeo`; `/#!/home` unchanged (`Home - Nuxeo`).

## Notes
Backport pair of the `lts-2025` PR (same commit, cherry-picked). Only the repository Root document was mis-titled; all other pages (home, search, tasks, admin, profile, diff, regular documents, collections/favorites) already produced correct titles and are unaffected.

Made with [Cursor](https://cursor.com)

[WEBUI-1876]: https://hyland.atlassian.net/browse/WEBUI-1876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ