### PR TITLE
WEBUI-1875: add accessible captions to remaining data tables [lts-2025]

### DIFF
--- a/addons/nuxeo-template-rendering/document/templatesource/nuxeo-templatesource-view-layout.html
+++ b/addons/nuxeo-template-rendering/document/templatesource/nuxeo-templatesource-view-layout.html
@@ -62,6 +62,7 @@ limitations under the License.
           empty-label="[[i18n('templateSourceViewLayout.templateBasedDocuments.noDocument')]]"
           empty-label-when-filtered="[[i18n('templateSourceViewLayout.templateBasedDocuments.noDocumentWhenFiltered')]]"
           on-row-clicked="_navigate"
+          caption-text="[[i18n('templateSourceViewLayout.templateBasedDocuments.heading')]]"
         >
           <nuxeo-data-table-column name="[[i18n('documentContentView.datatable.header.title')]]" flex="100">
             <template>

--- a/addons/nuxeo-template-rendering/document/webtemplatesource/nuxeo-webtemplatesource-view-layout.html
+++ b/addons/nuxeo-template-rendering/document/webtemplatesource/nuxeo-webtemplatesource-view-layout.html
@@ -55,6 +55,7 @@ limitations under the License.
           empty-label="[[i18n('templateSourceViewLayout.templateBasedDocuments.noDocument')]]"
           empty-label-when-filtered="[[i18n('templateSourceViewLayout.templateBasedDocuments.noDocumentWhenFiltered')]]"
           on-row-clicked="_navigate"
+          caption-text="[[i18n('templateSourceViewLayout.templateBasedDocuments.heading')]]"
         >
           <nuxeo-data-table-column name="[[i18n('documentContentView.datatable.header.title')]]" flex="100">
             <template>

--- a/elements/document/picturebook/nuxeo-picturebook-view-layout.html
+++ b/elements/document/picturebook/nuxeo-picturebook-view-layout.html
@@ -116,6 +116,7 @@ limitations under the License.
         on-row-clicked="_navigate"
         draggable$="[[_hasWritePermission(document)]]"
         drop-target-filter="[[_dropTargetFilter]]"
+        caption-text="[[i18n('documentContentView.datatable.picturebook.heading')]]"
       >
         <nuxeo-data-table-column
           name="[[i18n('documentContentView.datatable.header.title')]]"

--- a/elements/nuxeo-results/nuxeo-default-results.js
+++ b/elements/nuxeo-results/nuxeo-default-results.js
@@ -109,7 +109,7 @@ Polymer({
         column-resize-enabled
         column-reorder-enabled
         on-row-clicked="_navigate"
-        caption-text="[[i18n('documentContentView.datatable.heading')]]"
+        caption-text="[[i18n('documentContentView.datatable.defaultResults.heading')]]"
       >
         <nuxeo-data-table-column
           name="[[i18n('documentContentView.datatable.header.title')]]"

--- a/i18n/messages.json
+++ b/i18n/messages.json
@@ -398,6 +398,7 @@
   "documentContentView.datatable.header.title": "Title",
   "documentContentView.datatable.header.type": "Type",
   "documentContentView.datatable.header.version": "Version",
+  "documentContentView.datatable.picturebook.heading": "Picture Book Content",
   "documentContentView.drag.import": "Drop to import",
   "documentCreateButton.tooltip": "Add Content",
   "documentCreatePopup.create": "Create",


### PR DESCRIPTION
## Problem

Screen readers announce a table but have no meaningful accessible name for
several `nuxeo-data-table` instances, so users of assistive technology cannot
tell what each table contains. This is part of the Web UI accessibility audit
[WEBUI-1875](https://hyland.atlassian.net/browse/WEBUI-1875). The ticket's
screenshot shows the main document-listing table being announced as the raw
i18n key `documentContentView.datatable.heading`.

## Root cause

The base `iron-data-table` element already sets `role="table"` and exposes a
`captionText` property that it reflects to the table's `aria-label`. Most
tables across the platform were given a `caption-text` in prior a11y work, but
some instances were still broken in two ways:

**A. Missing `caption-text` entirely** (empty `aria-label`):

- `elements/document/picturebook/nuxeo-picturebook-view-layout.html`
- `addons/nuxeo-template-rendering/document/templatesource/nuxeo-templatesource-view-layout.html`
- `addons/nuxeo-template-rendering/document/webtemplatesource/nuxeo-webtemplatesource-view-layout.html`

**B. Referencing a non-existent i18n key**, so the `aria-label` rendered the raw
key string (this is the table in the ticket screenshot):

- `elements/nuxeo-results/nuxeo-default-results.js` referenced
  `documentContentView.datatable.heading`, which is not defined in any
  `messages.json`. This is the **default document listing** used on Collection,
  Favorites and browse pages — the most visible occurrence of the bug.

## Changes

- Add `caption-text` to the three tables in (A) so each exposes a meaningful
  accessible name.
- The two template-rendering tables reuse the existing card heading key
  `templateSourceViewLayout.templateBasedDocuments.heading`.
- The picturebook table uses a new message
  `documentContentView.datatable.picturebook.heading` = "Picture Book Content"
  (English only; other locales handled by Crowdin), following the existing
  `documentContentView.datatable.<context>.heading` convention.
- Repoint the default results table (B) to the existing, already-translated key
  `documentContentView.datatable.defaultResults.heading` ("Default Results"),
  matching its sibling results elements (`documentContent.heading`,
  `documentTrashContent.heading`, `picturebook.heading`). No new key needed.

## Test plan

- Verified with Chromium's computed accessibility tree
  (`page.accessibility.snapshot()`): the default results table's accessible name
  was the raw key `documentContentView.datatable.heading` before the fix and
  resolves to a human-readable caption after the repoint.
- `npm run lint` (eslint + prettier) — passes.
- Unit suite unaffected (no test asserts these caption keys); the earlier
  caption additions kept 2412/2412 passing.
- Manual/AT: on a Collection/Favorites page and on a Picture Book / Template
  Source document, switch the results view to the table (list) display and
  confirm the screen reader announces the caption above (rendered DOM shows a
  non-empty, human-readable `aria-label` on `nuxeo-data-table[role="table"]`).
  In VoiceOver, the table name is announced via the rotor
  (Ctrl+Option+U → Tables).

## Notes

- Pure a11y enhancement; no visual or behavioral change, no API change.
- The base `iron-data-table` caption/`aria-label` mechanism is unchanged.


[NXENG-37]: https://hyland.atlassian.net/browse/NXENG-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBUI-1875]: https://hyland.atlassian.net/browse/WEBUI-1875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
