### PR TITLE
Test PR: document npm run test:watch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ nuxeo.cors.urls=*
 | Lint | `npm run lint` | |
 | Format | `npm run format` | |
 | Unit tests | `npm test` | Web Test Runner; one runner file, ~1000+ Mocha tests |
+| Unit tests (watch) | `npm run test:watch` | Re-runs on file changes |
 | Functional tests | `npm run ftest` | |
 | Production build | `npm run build` | |
 | Bundle analysis | `npm run build:analyze` | |


### PR DESCRIPTION
## Summary

Test PR to validate the PR + CI flow on `maintenance-3.1.x`.

- Adds a `npm run test:watch` row to the README commands table (the script already exists in `package.json` but was undocumented).

Docs-only change; no runtime or build impact.

## Test plan

- [ ] Lint workflow passes
- [ ] Test (unit) workflow passes
- [ ] Remaining PR checks report as expected

This PR is for verifying the CI pipeline and can be closed without merging.
