### PR TITLE
WEBUI-1879: give the replace-blob button a descriptive accessible name [LTS-2025]

### DIFF
--- a/elements/nuxeo-document-actions/nuxeo-replace-blob-button.js
+++ b/elements/nuxeo-document-actions/nuxeo-replace-blob-button.js
@@ -47,7 +47,12 @@ Polymer({
     <dom-if if="[[_isAvailable(document)]]">
       <template>
         <div class="action" on-tap="_toggleDialog">
-          <paper-icon-button id="replaceBtn" icon="[[icon]]" noink aria-labelledby="label"></paper-icon-button>
+          <paper-icon-button
+            id="replaceBtn"
+            icon="[[icon]]"
+            noink
+            aria-label$="[[_computeAriaLabel(i18n)]]"
+          ></paper-icon-button>
           <span class="label" hidden$="[[!showLabel]]" id="label">[[_label]]</span>
           <nuxeo-tooltip>[[_label]]</nuxeo-tooltip>
         </div>
@@ -175,6 +180,10 @@ Polymer({
 
   _computeLabel() {
     return this.i18n('replaceBlobButton.tooltip');
+  },
+
+  _computeAriaLabel() {
+    return this.i18n('replaceBlobButton.ariaLabel');
   },
 
   _isAvailable(doc) {

--- a/i18n/messages.json
+++ b/i18n/messages.json
@@ -1274,6 +1274,7 @@
   "renderTemplateButton.toast.rendered": "Document rendered with '{0}' template.",
   "renderTemplateButton.toast.rendering": "Rendering document...",
   "renderTemplateButton.tooltip": "Render with Template",
+  "replaceBlobButton.ariaLabel": "Replace the document",
   "replaceBlobButton.dialog.heading": "Replace File",
   "replaceBlobButton.dialog.cancel": "Cancel",
   "replaceBlobButton.dialog.replace": "Replace",

--- a/i18n/messages.json
+++ b/i18n/messages.json
@@ -1274,7 +1274,7 @@
   "renderTemplateButton.toast.rendered": "Document rendered with '{0}' template.",
   "renderTemplateButton.toast.rendering": "Rendering document...",
   "renderTemplateButton.tooltip": "Render with Template",
-  "replaceBlobButton.ariaLabel": "Replace the document",
+  "replaceBlobButton.ariaLabel": "Replace the file",
   "replaceBlobButton.dialog.heading": "Replace File",
   "replaceBlobButton.dialog.cancel": "Cancel",
   "replaceBlobButton.dialog.replace": "Replace",

--- a/test/nuxeo-replace-blob-button.test.js
+++ b/test/nuxeo-replace-blob-button.test.js
@@ -15,7 +15,7 @@ All Hyland product names are registered or unregistered trademarks of Hyland Sof
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-import { fixture, html } from '@nuxeo/testing-helpers';
+import { fixture, flush, html } from '@nuxeo/testing-helpers';
 import '../elements/nuxeo-document-actions/nuxeo-replace-blob-button.js';
 
 suite('nuxeo-replace-blob-button', () => {
@@ -91,6 +91,22 @@ suite('nuxeo-replace-blob-button', () => {
       const properties = { 'file:content': { name: 'report.pdf' } };
       const root = element._getRootProperty(['file:content', 'name'], properties);
       expect(root).to.eql('file:content.name');
+    });
+  });
+
+  suite('accessible name', () => {
+    test('names what is replaced, rather than reusing the bare tooltip', () => {
+      expect(element._computeAriaLabel()).to.eql(element.i18n('replaceBlobButton.ariaLabel'));
+      expect(element._computeAriaLabel()).to.not.eql(element._computeLabel());
+    });
+
+    test('exposes the accessible name on the icon button', async () => {
+      element.document = { uid: '1', properties: { 'file:content': { name: 'report.pdf' } } };
+      await flush();
+      const iconButton = element.shadowRoot.querySelector('#replaceBtn');
+      expect(iconButton).to.exist;
+      expect(iconButton.getAttribute('aria-label')).to.eql(element.i18n('replaceBlobButton.ariaLabel'));
+      expect(iconButton.hasAttribute('aria-labelledby')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Summary

The replace icon button announced only its tooltip word, "Replace", so screen reader users had no indication of what the action applies to. This is the same finding the accessibility audit raised for the other icon buttons in the blob actions row, under [WCAG 2.1 SC 1.1.1 Non-text Content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html).

The button now carries a dedicated accessible name backed by a new i18n key:

| Key | Value | Visible tooltip |
| --- | --- | --- |
| `replaceBlobButton.ariaLabel` | Replace the file | Replace |

The visible tooltip is unchanged, and the new name still contains that tooltip word, so voice control users can still say "Replace" and match the control ([WCAG 2.5.3 Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html)).

### Why "file" rather than "document"

The button replaces a blob attached to the document, not the document itself, and its dialog is headed "Replace File". Saying "the document" would overstate what the control does and contradict the dialog the user lands on next.

The same wording is used across the whole row — the sibling `nuxeo-elements` buttons announce "Preview the file", "Download the file" and "Remove the file" — since every control there acts on the attached file. Confirmed with product review.

### Implementation note

The button previously pointed at its label node via `aria-labelledby`. That attribute takes precedence over `aria-label`, so the reference had to be *replaced* rather than a label simply added — adding `aria-label` alongside it would have had no effect.

## Related PRs

The sibling buttons in this row — preview, download and remove — live in `nuxeo-elements`. This change ships as four PRs — both repos, on both maintenance lines:

- nuxeo-web-ui, LTS 2025: https://github.com/nuxeo/nuxeo-web-ui/pull/3442
- nuxeo-web-ui, LTS 2023 (`maintenance-3.1.x`): https://github.com/nuxeo/nuxeo-web-ui/pull/3441
- nuxeo-elements, LTS 2025: https://github.com/nuxeo/nuxeo-elements/pull/1602
- nuxeo-elements, LTS 2023 (`maintenance-3.1.x`): https://github.com/nuxeo/nuxeo-elements/pull/1603

## Test plan

- [ ] Lint passes
- [ ] Unit tests pass, including the updated `test/nuxeo-replace-blob-button.test.js`
- [ ] Manual check with a screen reader: the replace button announces the full action, not just "Replace"
- [ ] Visible tooltip is unchanged on hover
