### PR TITLE
WEBUI-1880: announce toast messages to screen readers [lts-2025]

### DIFF
--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -1943,7 +1943,7 @@ Polymer({
    * timer fires, so setting that instead would be undone (WEBUI-1880).
    */
   _muteSnackbarLabel(toast) {
-    const label = toast.mdcRoot && toast.mdcRoot.querySelector('.mdc-snackbar__label');
+    const label = toast.mdcRoot?.querySelector('.mdc-snackbar__label');
     if (label) {
       label.setAttribute('aria-hidden', 'true');
     }
@@ -1958,7 +1958,7 @@ Polymer({
    * Narrator does not reliably observe live regions nested in shadow DOM.
    */
   _getAnnouncer() {
-    if (!this._announcer || !this._announcer.isConnected) {
+    if (!this._announcer?.isConnected) {
       let announcer = document.getElementById(ANNOUNCER_ID);
       if (!announcer) {
         announcer = document.createElement('div');
@@ -1985,15 +1985,22 @@ Polymer({
    * tick by different elements: finishing a CSV export makes `nuxeo-csv-export-button` announce "CSV
    * export is ready" and, one microtask later, `nuxeo-operation-button` announce its own bulk summary.
    * Overwriting a pending message would silence the first of the pair (WEBUI-1880).
+   *
+   * A duplicate is only dropped while its twin has yet to be spoken — still queued, or still in the
+   * clear phase. Once the text has landed in the region it has been announced, so an identical message
+   * arriving later is a new event and is spoken again.
    */
   _announce(message) {
     if (!message) {
       return;
     }
     this._announceQueue = this._announceQueue || [];
-    const previous = this._announceQueue.length
-      ? this._announceQueue[this._announceQueue.length - 1]
-      : this._announcingMessage;
+    let previous = null;
+    if (this._announceQueue.length) {
+      previous = this._announceQueue[this._announceQueue.length - 1];
+    } else if (this._announceClearing) {
+      previous = this._announcingMessage;
+    }
     if (previous === message) {
       return; // the same event reported twice; no need to say it twice
     }
@@ -2011,11 +2018,13 @@ Polymer({
     const announcer = this._getAnnouncer();
     const message = this._announceQueue.shift();
     this._announcingMessage = message;
+    this._announceClearing = true;
     // A live region is only announced when its text changes, so clear it first: without this an
     // identical consecutive toast produces no mutation and stays silent.
     announcer.textContent = '';
     this._announceTimeout = setTimeout(() => {
       announcer.textContent = message;
+      this._announceClearing = false;
       this._announceTimeout = setTimeout(() => {
         this._announceTimeout = null;
         this._announcingMessage = null;
@@ -2030,6 +2039,7 @@ Polymer({
       this._announceTimeout = null;
     }
     this._announcingMessage = null;
+    this._announceClearing = false;
     this._announceQueue = [];
   },
 

--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -97,6 +97,16 @@ window.nuxeo.importBlacklist = window.nuxeo.importBlacklist || [
   'Root',
 ];
 const MAX_TOASTS = 3; // max number of toasts that can be displayed simultaneously besides the default one
+// Gap between clearing and refilling the live region. A synchronous clear/set pair is coalesced into a
+// single mutation, so without it a repeated message would not be announced again.
+const ARIA_ANNOUNCE_DELAY_MS = 150;
+// Gap between two consecutive messages, so each one lands as its own mutation and is queued by the
+// screen reader in order rather than overwriting the one before it.
+const ANNOUNCE_SPACING_MS = 500;
+// A long-running bulk operation reports progress every second; cap the backlog so those updates cannot
+// pile up faster than they are spoken. The newest messages are the ones worth keeping.
+const MAX_QUEUED_ANNOUNCEMENTS = 3;
+const ANNOUNCER_ID = 'nuxeo-toast-announcer';
 
 setPassiveTouchGestures(true);
 
@@ -834,7 +844,12 @@ Polymer({
       toast.mdcRoot.style.position = 'relative';
       toast.mdcRoot.querySelector('.mdc-snackbar__label').style.webkitFontSmoothing = 'auto';
       toast.mdcRoot.querySelector('.mdc-snackbar__surface').style.width = '344px';
+      this._muteSnackbarLabel(toast);
     });
+
+    // Create the live region up front: screen readers track regions that were present before the text
+    // changed, and ignore one that appears already carrying its message.
+    this._getAnnouncer();
 
     window.addEventListener('unhandledrejection', (e) => {
       if (e.reason && e.reason.status === 404) {
@@ -953,6 +968,7 @@ Polymer({
     this.removeEventListener('nuxeo-layout-updated', this._onDescendantLayoutUpdated);
     this._teardownInactivityTimer();
     this._teardownUnauthorizedRedirect();
+    this._cancelPendingAnnouncement();
     this._inactivityNeedsRearm = true; // re-arm from the next attached()
   },
 
@@ -1813,6 +1829,7 @@ Polymer({
       toast.mdcRoot.style.position = 'relative';
       toast.mdcRoot.querySelector('.mdc-snackbar__label').style.webkitFontSmoothing = 'auto';
       toast.mdcRoot.querySelector('.mdc-snackbar__surface').style.width = '344px';
+      this._muteSnackbarLabel(toast);
 
       const defaultAction = toast.mdcFoundation.handleActionButtonClick.bind(toast);
       toast.mdcFoundation.handleActionButtonClick = () => {
@@ -1913,7 +1930,107 @@ Polymer({
         toast.close();
       }
       toast.show();
+      this._announce(message);
     }
+  },
+
+  /**
+   * Takes the snackbar's own label out of the accessibility tree, so a message is not announced twice.
+   *
+   * From its second open onwards mwc-snackbar clears the label and restores it ARIA_LIVE_DELAY_MS later,
+   * precisely to provoke an announcement. That text is already spoken by our own region, and the two land
+   * about a second apart. `aria-hidden` is what silences it: the directive rewrites `aria-live` when its
+   * timer fires, so setting that instead would be undone (WEBUI-1880).
+   */
+  _muteSnackbarLabel(toast) {
+    const label = toast.mdcRoot && toast.mdcRoot.querySelector('.mdc-snackbar__label');
+    if (label) {
+      label.setAttribute('aria-hidden', 'true');
+    }
+  },
+
+  /**
+   * Returns the shared live region, creating it on first use.
+   *
+   * WEBUI-1880: mwc-snackbar builds its own live region lazily, inside a subtree that is hidden until
+   * the toast opens, so screen readers never see the text change and stay silent. This region replaces
+   * it. It is appended to the document body rather than declared in this element's template because
+   * Narrator does not reliably observe live regions nested in shadow DOM.
+   */
+  _getAnnouncer() {
+    if (!this._announcer || !this._announcer.isConnected) {
+      let announcer = document.getElementById(ANNOUNCER_ID);
+      if (!announcer) {
+        announcer = document.createElement('div');
+        announcer.id = ANNOUNCER_ID;
+        announcer.setAttribute('role', 'status');
+        announcer.setAttribute('aria-live', 'polite');
+        announcer.setAttribute('aria-atomic', 'true');
+        // Clipped rather than hidden: display none, visibility hidden, zero height and zero opacity
+        // all take the node out of the accessibility tree, which would stop it announcing.
+        announcer.style.cssText =
+          'position:absolute;width:1px;height:1px;margin:-1px;padding:0;border:0;overflow:hidden;' +
+          'clip:rect(0 0 0 0);clip-path:inset(50%);white-space:nowrap;';
+        document.body.appendChild(announcer);
+      }
+      this._announcer = announcer;
+    }
+    return this._announcer;
+  },
+
+  /**
+   * Queues `message` for announcement by screen readers.
+   *
+   * Messages are queued rather than replaced because a single event is often reported twice in the same
+   * tick by different elements: finishing a CSV export makes `nuxeo-csv-export-button` announce "CSV
+   * export is ready" and, one microtask later, `nuxeo-operation-button` announce its own bulk summary.
+   * Overwriting a pending message would silence the first of the pair (WEBUI-1880).
+   */
+  _announce(message) {
+    if (!message) {
+      return;
+    }
+    this._announceQueue = this._announceQueue || [];
+    const previous = this._announceQueue.length
+      ? this._announceQueue[this._announceQueue.length - 1]
+      : this._announcingMessage;
+    if (previous === message) {
+      return; // the same event reported twice; no need to say it twice
+    }
+    this._announceQueue.push(message);
+    if (this._announceQueue.length > MAX_QUEUED_ANNOUNCEMENTS) {
+      this._announceQueue.shift();
+    }
+    this._pumpAnnouncements();
+  },
+
+  _pumpAnnouncements() {
+    if (this._announceTimeout || !this._announceQueue || this._announceQueue.length === 0) {
+      return;
+    }
+    const announcer = this._getAnnouncer();
+    const message = this._announceQueue.shift();
+    this._announcingMessage = message;
+    // A live region is only announced when its text changes, so clear it first: without this an
+    // identical consecutive toast produces no mutation and stays silent.
+    announcer.textContent = '';
+    this._announceTimeout = setTimeout(() => {
+      announcer.textContent = message;
+      this._announceTimeout = setTimeout(() => {
+        this._announceTimeout = null;
+        this._announcingMessage = null;
+        this._pumpAnnouncements();
+      }, ANNOUNCE_SPACING_MS);
+    }, ARIA_ANNOUNCE_DELAY_MS);
+  },
+
+  _cancelPendingAnnouncement() {
+    if (this._announceTimeout) {
+      clearTimeout(this._announceTimeout);
+      this._announceTimeout = null;
+    }
+    this._announcingMessage = null;
+    this._announceQueue = [];
   },
 
   _clipboardUpdated(e) {

--- a/test/nuxeo-app.test.js
+++ b/test/nuxeo-app.test.js
@@ -1555,20 +1555,27 @@ suite('nuxeo-app', () => {
       app._resizeDuringAnimation.restore();
     });
 
-    test('default toast opening listener applies snackbar layout hacks', () => {
+    test('default toast opening listener applies snackbar layout hacks and mutes the label', () => {
       const { toast } = app.$;
       if (!toast) {
         return;
       }
+      const label = { style: {}, setAttribute: sinon.spy() };
       Object.defineProperty(toast, 'mdcRoot', {
         configurable: true,
         value: {
           style: {},
-          querySelector: sinon.stub().returns({ style: {} }),
+          querySelector: sinon.stub().callsFake((sel) => (sel === '.mdc-snackbar__label' ? label : { style: {} })),
         },
       });
       toast.dispatchEvent(new Event('MDCSnackbar:opening'));
       expect(toast.mdcRoot.style.position).to.equal('relative');
+      expect(label.setAttribute).to.have.been.calledWith('aria-hidden', 'true');
+    });
+
+    test('_muteSnackbarLabel does nothing while the label is not rendered', () => {
+      expect(() => app._muteSnackbarLabel({})).to.not.throw();
+      expect(() => app._muteSnackbarLabel({ mdcRoot: { querySelector: () => null } })).to.not.throw();
     });
   });
 
@@ -1847,6 +1854,142 @@ suite('nuxeo-app', () => {
       app._notify({ detail: { commandId: 'cmd-2', close: true } });
       expect(close).to.have.been.called;
       app._getToastFor.restore();
+    });
+  });
+
+  // WEBUI-1880: the snackbar's own live region is built inside a hidden subtree, so the app owns a
+  // permanently visible live region and writes every toast message into it.
+  suite('toast screen reader announcements', () => {
+    function stubToast() {
+      return {
+        __state: {},
+        open: false,
+        close: sinon.spy(),
+        show: sinon.spy(),
+        querySelector: sinon.stub().returns({ hidden: false }),
+      };
+    }
+
+    test('the live region lives in the document body, not in shadow DOM', () => {
+      const announcer = app._getAnnouncer();
+      expect(announcer.parentNode).to.equal(document.body);
+      expect(announcer.getAttribute('role')).to.equal('status');
+      expect(announcer.getAttribute('aria-live')).to.equal('polite');
+      expect(announcer.getAttribute('aria-atomic')).to.equal('true');
+    });
+
+    test('_getAnnouncer reuses the single shared live region', () => {
+      expect(app._getAnnouncer()).to.equal(app._getAnnouncer());
+      expect(document.querySelectorAll('#nuxeo-toast-announcer')).to.have.lengthOf(1);
+    });
+
+    test('_announce fills the live region after the aria delay', async () => {
+      const clock = sinon.useFakeTimers();
+      try {
+        app._announce('CSV export is ready');
+        expect(app._getAnnouncer().textContent).to.equal('');
+        await clock.tickAsync(150);
+        expect(app._getAnnouncer().textContent).to.equal('CSV export is ready');
+      } finally {
+        clock.restore();
+      }
+    });
+
+    test('_announce clears the region first so an identical message is announced again', async () => {
+      const clock = sinon.useFakeTimers();
+      try {
+        app._announce('CSV export is ready');
+        await clock.tickAsync(650);
+        app._announce('CSV export is ready');
+        expect(app._getAnnouncer().textContent).to.equal('');
+        await clock.tickAsync(150);
+        expect(app._getAnnouncer().textContent).to.equal('CSV export is ready');
+      } finally {
+        clock.restore();
+      }
+    });
+
+    // WEBUI-1880: finishing a CSV export notifies twice in the same tick, once from
+    // nuxeo-csv-export-button and once from nuxeo-operation-button. Neither may silence the other.
+    test('_announce speaks both messages when two arrive in the same tick', async () => {
+      const clock = sinon.useFakeTimers();
+      try {
+        app._announce('CSV export is ready');
+        app._announce('Export CSV: completed successfully');
+        await clock.tickAsync(150);
+        expect(app._getAnnouncer().textContent).to.equal('CSV export is ready');
+        await clock.tickAsync(500);
+        expect(app._getAnnouncer().textContent).to.equal('');
+        await clock.tickAsync(150);
+        expect(app._getAnnouncer().textContent).to.equal('Export CSV: completed successfully');
+      } finally {
+        clock.restore();
+      }
+    });
+
+    test('_announce skips a duplicate of the message being announced', () => {
+      const clock = sinon.useFakeTimers();
+      try {
+        app._announce('CSV export is running');
+        app._announce('CSV export is running');
+        expect(app._announceQueue).to.have.lengthOf(0);
+      } finally {
+        clock.restore();
+      }
+    });
+
+    test('_announce caps the backlog and keeps the newest messages', () => {
+      const clock = sinon.useFakeTimers();
+      try {
+        ['a', 'b', 'c', 'd', 'e'].forEach((m) => app._announce(m));
+        // 'a' is being announced already; 'b' is dropped so the three newest survive
+        expect(app._announceQueue).to.deep.equal(['c', 'd', 'e']);
+      } finally {
+        clock.restore();
+      }
+    });
+
+    test('_announce ignores an empty message', async () => {
+      const clock = sinon.useFakeTimers();
+      try {
+        app._getAnnouncer().textContent = 'previous';
+        app._announce('');
+        app._announce(undefined);
+        await clock.tickAsync(150);
+        expect(app._getAnnouncer().textContent).to.equal('previous');
+      } finally {
+        clock.restore();
+      }
+    });
+
+    test('_notify announces the toast message', () => {
+      sinon.stub(app, '_getToastFor').returns(stubToast());
+      sinon.stub(app, '_announce');
+      app._notify({ detail: { commandId: 'cmd-3', message: 'CSV export is ready' } });
+      expect(app._announce).to.have.been.calledWith('CSV export is ready');
+      app._announce.restore();
+      app._getToastFor.restore();
+    });
+
+    test('_notify does not announce when the event carries no message', () => {
+      sinon.stub(app, '_getToastFor').returns(stubToast());
+      sinon.stub(app, '_announce');
+      app._notify({ detail: { commandId: 'cmd-4', close: true } });
+      expect(app._announce).to.not.have.been.called;
+      app._announce.restore();
+      app._getToastFor.restore();
+    });
+
+    test('detached cancels a pending announcement', async () => {
+      const clock = sinon.useFakeTimers();
+      try {
+        app._announce('CSV export is ready');
+        app.detached();
+        await clock.tickAsync(150);
+        expect(app._getAnnouncer().textContent).to.equal('');
+      } finally {
+        clock.restore();
+      }
     });
   });
 

--- a/test/nuxeo-app.test.js
+++ b/test/nuxeo-app.test.js
@@ -1938,6 +1938,25 @@ suite('nuxeo-app', () => {
       }
     });
 
+    // The dedupe window must not outlive the clear phase. Once the text has landed in the region the
+    // message has been spoken, so an identical toast arriving later is a new event, not a replay.
+    test('_announce speaks a repeat that arrives after the message was spoken', async () => {
+      const clock = sinon.useFakeTimers();
+      try {
+        app._announce('CSV export is ready');
+        await clock.tickAsync(200); // past the aria delay, still inside the spacing window
+        expect(app._getAnnouncer().textContent).to.equal('CSV export is ready');
+        app._announce('CSV export is ready');
+        expect(app._announceQueue).to.deep.equal(['CSV export is ready']);
+        await clock.tickAsync(450); // spacing ends, the repeat is pumped and the region cleared
+        expect(app._getAnnouncer().textContent).to.equal('');
+        await clock.tickAsync(150);
+        expect(app._getAnnouncer().textContent).to.equal('CSV export is ready');
+      } finally {
+        clock.restore();
+      }
+    });
+
     test('_announce caps the backlog and keeps the newest messages', () => {
       const clock = sinon.useFakeTimers();
       try {


### PR DESCRIPTION
## Problem

Screen readers do not announce Web UI toast messages. Most visibly, after a CSV export the "CSV export is ready" toast appears on screen but is never spoken, so a screen-reader user gets no indication that the download is ready.

Jira: [WEBUI-1880](https://hyland.atlassian.net/browse/WEBUI-1880)

## Root cause

`mwc-snackbar` ships its own `aria-live` region via the `accessibleSnackbarLabel` directive, but it is built lazily inside a subtree that stays hidden until the toast opens. On the **first** open the directive creates the label with the text already in place and returns early:

```js
if (this.labelEl === null) {
  // Create the label element once, the first time we open.
  labelEl.textContent = labelText;
  // No need to do anything more for ARIA the first time we open.
  return labelEl;
}
```

No text mutation ever occurs, so the region stays silent. Only from the second open onwards does the directive run the clear-and-restore dance that actually provokes an announcement. `nuxeo-app._notify()` therefore had no reliable way to reach a screen reader.

## Changes

* **`elements/nuxeo-app.js`**
  * `_getAnnouncer()` creates a single visually-hidden `role="status"` / `aria-live="polite"` region on `document.body`. It is created eagerly in `ready()` so it exists before any message can arrive, and it lives outside shadow DOM because Narrator does not reliably observe live regions nested in a shadow root. It is clipped rather than hidden, because `display:none`, `visibility:hidden`, zero height and zero opacity all remove a node from the accessibility tree and would stop it announcing.
  * `_announce()` / `_pumpAnnouncements()` queue messages rather than overwrite. A single event is often reported twice in the same tick by different elements, so overwriting a pending message would silence the first of the pair. Consecutive duplicates are skipped, and the backlog is capped at 3 so a long-running bulk operation reporting progress every second cannot pile up faster than it is spoken.
  * `_muteSnackbarLabel()` sets `aria-hidden` on the snackbar's internal label, called from both `MDCSnackbar:opening` handlers. Without it the same message is announced twice — ours at 150 ms and mwc's at `ARIA_LIVE_DELAY_MS` (1000 ms), measured 845 ms apart in practice. `aria-hidden` is used rather than `aria-live="off"` because the directive rewrites `aria-live` when its timer fires and would undo it.
  * `detached()` cancels any pending announcement.
* **`test/nuxeo-app.test.js`** — covers announcer creation, reuse and placement, queue ordering, duplicate suppression, backlog capping, the label mute, and the early-return branches.

## Test plan

- [x] `npm test` passes — 2424 tests, 0 failures
- [x] ESLint and Prettier clean on both changed files
- [x] Verified against a real screen reader: **NVDA 2026.1.1 on Edge**, reading NVDA's own speech log rather than relying on listening. Two consecutive CSV exports, each message announced exactly once:

  ```
  02:31:46.205  'main landmark', 'clickable', 'Export CSV', 'button'
  02:31:46.511  'CSV export is running'
  02:31:48.054  'Downloading, 90aaa9be-....csv, 17.0 KB'     <- Edge, native
  02:31:48.091  'CSV export is ready'
  02:31:48.229  'Downloads completed. Press Ctrl+J...'        <- Edge, native
  ```

- [ ] Worth a confirming pass with JAWS and with Narrator, whose shadow-DOM live-region behaviour differs

## Notes

* Accessibility change only — no functional or visual change to the toasts themselves.
* `aria-hidden` on the snackbar label means the toast text is announced but no longer reachable with the virtual cursor. This matches the behaviour the element already had for repeat toasts and keeps a message from being spoken twice, but it is the one judgement call here and is worth a reviewer's eye.
* `@material/mwc-snackbar` is `^0.26.1` on both bases, so the directive behaviour this fix depends on is identical across them.

* Paired with the maintenance-3.1.x PR: nuxeo/nuxeo-web-ui#3446. Both branches carry the identical commit; any follow-up must be applied to both.


[WEBUI-1880]: https://hyland.atlassian.net/browse/WEBUI-1880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ