### PR TITLE
WEBUI-2198: Pin GitHub Actions to full commit SHAs (SonarCloud S7637) [maintenance-3.1.x]

### DIFF
--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -37,7 +37,7 @@ jobs:
           echo "Base branch: ${{ github.base_ref }}"
           echo "Ref: ${{ github.ref }}"
 
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2
         with:
           comment_on_pr: false
 
@@ -54,7 +54,7 @@ jobs:
           scope: '@nuxeo'
 
       - name: Setup Maven build
-        uses: nuxeo/gh-build-tools/.github/actions/setup-maven-build@v0.10.4
+        uses: nuxeo/gh-build-tools/.github/actions/setup-maven-build@314c39e8c2e913db2dc63a31670612ccb2b6e569 # v0.10.4
         with:
           java-version: ${{ (github.base_ref || inputs.branch || github.ref_name) == 'lts-2025' && 21 || 17 }}
 

--- a/.github/workflows/catalog.yaml
+++ b/.github/workflows/catalog.yaml
@@ -48,7 +48,7 @@ jobs:
           node-version: 18
 
       - name: Setup Maven build
-        uses: nuxeo/gh-build-tools/.github/actions/setup-maven-build@v0.10.4
+        uses: nuxeo/gh-build-tools/.github/actions/setup-maven-build@314c39e8c2e913db2dc63a31670612ccb2b6e569 # v0.10.4
         with:
           java-version: '17'
 

--- a/.github/workflows/cross-repo.yaml
+++ b/.github/workflows/cross-repo.yaml
@@ -78,7 +78,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2
         with:
           comment_on_pr: false
 
@@ -117,7 +117,7 @@ jobs:
           ref: ${{ steps.pick_nuxeo_web_ui_branch.outputs.branch }}
 
       - name: Setup Maven build
-        uses: nuxeo/gh-build-tools/.github/actions/setup-maven-build@v0.10.4
+        uses: nuxeo/gh-build-tools/.github/actions/setup-maven-build@314c39e8c2e913db2dc63a31670612ccb2b6e569 # v0.10.4
         with:
           java-version: '17'
 

--- a/.github/workflows/crowdin.yaml
+++ b/.github/workflows/crowdin.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Crowdin Action
         id: crowdin-sync
-        uses: crowdin/github-action@v2.16.2
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2.16.2
         with:
           # Disable 'git checkout "${GITHUB_REF#refs/heads/}"'
           skip_ref_checkout: true

--- a/.github/workflows/ftest.yaml
+++ b/.github/workflows/ftest.yaml
@@ -41,7 +41,7 @@ jobs:
           echo "Base branch: ${{ github.base_ref }}"
           echo "Ref: ${{ github.ref }}"
 
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2
         with:
           comment_on_pr: false
 
@@ -56,7 +56,7 @@ jobs:
           node-version: 22
 
       - name: Setup Maven build
-        uses: nuxeo/gh-build-tools/.github/actions/setup-maven-build@v0.10.4
+        uses: nuxeo/gh-build-tools/.github/actions/setup-maven-build@314c39e8c2e913db2dc63a31670612ccb2b6e569 # v0.10.4
         with:
           java-version: ${{ (github.base_ref || inputs.branch || github.ref_name) == 'lts-2025' && 21 || 17 }}
 
@@ -135,7 +135,7 @@ jobs:
           RUN_ALL: false
           BAIL: 0
           HEADLESS: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'video') && 'false' || 'true' }}
-        uses: Alfresco/alfresco-build-tools/.github/actions/xvfb-record@v17.6.2
+        uses: Alfresco/alfresco-build-tools/.github/actions/xvfb-record@157729461e042ea6cdcca867bed794bded85b303 # v17.6.2
         with:
           test_command: mvn -ntp install -Pftest -DskipInstall
           timeout_minutes: 120

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -64,7 +64,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2
         with:
           comment_on_pr: false
 
@@ -86,7 +86,7 @@ jobs:
             npm-${{ runner.os }}-
 
       - name: Setup Maven build
-        uses: nuxeo/gh-build-tools/.github/actions/setup-maven-build@v0.10.4
+        uses: nuxeo/gh-build-tools/.github/actions/setup-maven-build@314c39e8c2e913db2dc63a31670612ccb2b6e569 # v0.10.4
         with:
           java-version: '17'
 

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -32,7 +32,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2
         with:
           comment_on_pr: false
 
@@ -106,7 +106,7 @@ jobs:
         id: sonar_scan
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        uses: SonarSource/sonarqube-scan-action@v8.0.0
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
         with:
           projectBaseDir: ${{ github.workspace }}
           args: >

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2
         with:
           comment_on_pr: false
 

--- a/.github/workflows/veracode-2025.yaml
+++ b/.github/workflows/veracode-2025.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on:
       group: medium-4cpu-runners
     steps:
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2
         with:
           comment_on_pr: false
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can
@@ -154,7 +154,7 @@ jobs:
           pwd
 
       - name: Veracode Upload And Scan
-        uses: veracode/veracode-uploadandscan-action@0.2.11
+        uses: veracode/veracode-uploadandscan-action@ddca86b1d1d45639d1c414003f3495f71851cfe2 # 0.2.11
         with:
           version: 'Nuxeo WebUI - LTS2025 - ${{ github.run_id }}'
           appname: 'Nuxeo Web UI'

--- a/.github/workflows/veracode-3.1.x.yaml
+++ b/.github/workflows/veracode-3.1.x.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on:
       group: medium-4cpu-runners
     steps:
-    - uses: catchpoint/workflow-telemetry-action@v2
+    - uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2
       with:
         comment_on_pr: false
 
@@ -153,7 +153,7 @@ jobs:
           pwd
 
       - name: Veracode Upload And Scan
-        uses: veracode/veracode-uploadandscan-action@0.2.11
+        uses: veracode/veracode-uploadandscan-action@ddca86b1d1d45639d1c414003f3495f71851cfe2 # 0.2.11
         with:
           version: 'Nuxeo WebUI - LTS2023 - ${{ github.run_id }}'
           appname: 'Nuxeo Web UI'


### PR DESCRIPTION
## What

Pins every SonarCloud-flagged GitHub Action reference in `.github/workflows/` to an immutable 40-character commit SHA, keeping the human-readable version as a trailing comment (e.g. `uses: owner/action@<sha> # v2`). Resolves the **19 HIGH-severity SECURITY** findings from rule `githubactions:S7637` on `maintenance-3.1.x`.

Jira: [WEBUI-2198](https://hyland.atlassian.net/browse/WEBUI-2198)

## Actions pinned (SHA = exact commit the in-use tag resolves to → no behaviour change)

| Action | Tag | Pinned SHA |
|---|---|---|
| `catchpoint/workflow-telemetry-action` | `v2` | `94c3c3d9567a0205de6da68a76c428ce4e769af1` |
| `nuxeo/gh-build-tools/.../setup-maven-build` | `v0.10.4` | `314c39e8c2e913db2dc63a31670612ccb2b6e569` |
| `veracode/veracode-uploadandscan-action` | `0.2.11` | `ddca86b1d1d45639d1c414003f3495f71851cfe2` |
| `SonarSource/sonarqube-scan-action` | `v8.0.0` | `59db25f34e16620e48ab4bb9e4a5dce155cb5432` |
| `Alfresco/alfresco-build-tools/.../xvfb-record` | `v17.6.2` | `157729461e042ea6cdcca867bed794bded85b303` |
| `crowdin/github-action` | `v2.16.2` | `8868a33591d21088edfc398968173a3b98d51706` |

18 of the 19 S7637 findings are pinned here; the 19th is the same-repo reusable workflow (see below).

## Decisions applied

- **GitHub-owned `actions/*`** (checkout, setup-node, cache, upload/download-artifact, …) are trusted by S7637 and left unpinned.
- **`nuxeo/gh-build-tools`** is pinned (Dependabot still bumps it).
- **Same-repo reusable workflow** `nuxeo/nuxeo-web-ui/.github/workflows/crowdin.yaml@lts-2025` is intentionally **kept as a branch ref** so it keeps auto-tracking our own fixes. This one finding will be marked **Won't Fix** in SonarCloud (required for acceptance criterion 2).
- **Dependabot** for the `github-actions` ecosystem is already enabled on this branch (acceptance criterion 4 is already met).

## Acceptance criteria

- [x] Every flagged `uses:` references a full 40-char SHA with the version as a trailing comment
- [ ] SonarCloud reports zero open HIGH SECURITY on `maintenance-3.1.x` (after this merges + the one same-repo finding is marked Won't Fix)
- [x] No behaviour change — each SHA is the exact commit the previous tag pointed to
- [x] Dependabot enabled for `github-actions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[WEBUI-2198]: https://hyland.atlassian.net/browse/WEBUI-2198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ