### PR TITLE
WEBUI-2219: harden GitHub Actions npm installs and secret handling [lts-2025]

### DIFF
--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -75,10 +75,10 @@ jobs:
         run: |
           npm ci --ignore-scripts
           pushd packages/nuxeo-web-ui-ftest
-          npm ci
+          npm ci --ignore-scripts
           popd
           pushd packages/nuxeo-designer-catalog
-          npm ci
+          npm ci --ignore-scripts
           popd
 
       - name: Ensure latest @nuxeo RC packages

--- a/.github/workflows/catalog.yaml
+++ b/.github/workflows/catalog.yaml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: packages/nuxeo-designer-catalog
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Generate catalog
         working-directory: packages/nuxeo-designer-catalog

--- a/.github/workflows/cross-repo.yaml
+++ b/.github/workflows/cross-repo.yaml
@@ -125,13 +125,13 @@ jobs:
         run: |
           npm ci --ignore-scripts
           pushd packages/nuxeo-web-ui-ftest
-          npm ci
+          npm ci --ignore-scripts
           popd
           pushd plugin/a11y
-          npm ci
+          npm ci --ignore-scripts
           popd
           pushd packages/nuxeo-designer-catalog
-          npm ci
+          npm ci --ignore-scripts
           popd
 
       - name: Lint Web UI

--- a/.github/workflows/crowdin.yaml
+++ b/.github/workflows/crowdin.yaml
@@ -3,7 +3,15 @@ name: Crowdin Sync
 
 on:
   # Make workflow reusable, to be called by the scheduled crowdin workflow in the default branch
+  # Secrets are declared explicitly so callers pass only these three rather than inheriting every repository secret.
   workflow_call:
+    secrets:
+      CROWDIN_PROJECT_ID:
+        required: true
+      CROWDIN_PERSONAL_TOKEN:
+        required: true
+      WEBUI_JX_BOT_GITHUB_ACTIONS_TOKEN:
+        required: true
 
   # Sync when a commit is done on lts-2025
   push:

--- a/.github/workflows/ftest.yaml
+++ b/.github/workflows/ftest.yaml
@@ -78,7 +78,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y imagemagick poppler-utils libreoffice ffmpeg libwpd-tools ghostscript exiftool
           sudo sed -i '/disable ghostscript format types/,+6d' /etc/ImageMagick-6/policy.xml
-          npm install -g bower gulp-cli
+          npm install -g --ignore-scripts bower@1.8.14 gulp-cli@3.1.0
 
       - name: Determine nuxeo-elements branch to link
         id: pick_nuxeo_elements_branch
@@ -95,10 +95,10 @@ jobs:
         run: |
           npm ci --ignore-scripts
           pushd packages/nuxeo-web-ui-ftest
-          npm ci
+          npm ci --ignore-scripts
           popd
           pushd packages/nuxeo-designer-catalog
-          npm ci
+          npm ci --ignore-scripts
           popd
 
       - name: Checkout the nuxeo-elements repo

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Prepare environment
         run: |
-          echo "PACKAGE_VERSION=$(npx -c 'echo "$npm_package_version"')" >> $GITHUB_ENV
+          echo "PACKAGE_VERSION=$(npx --no-install -c 'echo "$npm_package_version"')" >> $GITHUB_ENV
 
       - name: Get prerelease version
         run: |
@@ -143,8 +143,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
         run: |
           npm ci --ignore-scripts
-          (cd packages/nuxeo-web-ui-ftest && npm ci)
-          (cd packages/nuxeo-designer-catalog && npm ci)
+          (cd packages/nuxeo-web-ui-ftest && npm ci --ignore-scripts)
+          (cd packages/nuxeo-designer-catalog && npm ci --ignore-scripts)
 
       - name: Build packages
         env:
@@ -173,9 +173,10 @@ jobs:
       - name: Publish Nuxeo packages
         env:
           CONNECT_PREPROD_URL: https://nos-preprod-connect.nuxeocloud.com/nuxeo
+          CONNECT_PREPROD_AUTH: ${{ secrets.CONNECT_PREPROD_AUTH }}
         run: |
           PACKAGE="plugin/web-ui/marketplace/target/nuxeo-web-ui-marketplace-${PADDED_VERSION}.zip"
-          curl -fS -u "${{ secrets.CONNECT_PREPROD_AUTH }}" \
+          curl -fS -u "$CONNECT_PREPROD_AUTH" \
                -F package=@$PACKAGE \
                "$CONNECT_PREPROD_URL/site/marketplace/upload?batch=true"
 

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -119,9 +119,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
         run: |
           npm ci --ignore-scripts
-          npm install --no-package-lock ./nuxeo-elements/core
-          npm install --no-package-lock ./nuxeo-elements/ui
-          npm install --no-package-lock ./nuxeo-elements/dataviz
+          npm install --no-package-lock --ignore-scripts ./nuxeo-elements/core
+          npm install --no-package-lock --ignore-scripts ./nuxeo-elements/ui
+          npm install --no-package-lock --ignore-scripts ./nuxeo-elements/dataviz
 
       - name: Webpack build
         env:

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -41,7 +41,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
         run: |
-          OLD_VERSION=$(npx -c 'echo "$npm_package_version"')
+          OLD_VERSION=$(npx --no-install -c 'echo "$npm_package_version"')
           npm version $VERSION --no-git-tag-version
           pushd packages/nuxeo-web-ui-ftest/
           npm version $VERSION --no-git-tag-version
@@ -90,10 +90,11 @@ jobs:
         env:
           PACKAGE: nuxeo-web-ui-${{ env.VERSION }}
           CONNECT_PREPROD_URL: https://nos-preprod-connect.nuxeocloud.com/nuxeo
+          CONNECT_PREPROD_AUTH: ${{ secrets.CONNECT_PREPROD_AUTH }}
         run: |
           PADDED=$(printf '%03d' $(echo ${{ github.event.inputs.version }} | sed -r s/[0-9]+\.[0-9]+\.[0-9]+-rc\.\([0-9]+\)/\\1/g))
           PADDED_VERSION=$(echo ${{ github.event.inputs.version }} | sed -E "s/([0-9]+\.[0-9]+\.[0-9]+-rc\.)[0-9]+/\\1$PADDED/g")
-          curl -o $PACKAGE.zip -L -u "${{ secrets.CONNECT_PREPROD_AUTH }}" "$CONNECT_PREPROD_URL/site/marketplace/package/nuxeo-web-ui/download?version=$PADDED_VERSION"
+          curl -o $PACKAGE.zip -L --proto '=https' --proto-redir '=https' -u "$CONNECT_PREPROD_AUTH" "$CONNECT_PREPROD_URL/site/marketplace/package/nuxeo-web-ui/download?version=$PADDED_VERSION"
           # Extract and remove RC from package.xml
           unzip -d $PACKAGE $PACKAGE.zip && rm $PACKAGE.zip
           pushd $PACKAGE
@@ -123,14 +124,16 @@ jobs:
         env:
           PACKAGE: nuxeo-web-ui-${{ env.VERSION }}
           CONNECT_PREPROD_URL: https://nos-preprod-connect.nuxeocloud.com/nuxeo
-        run: curl -i -u "${{ secrets.CONNECT_PREPROD_AUTH }}" -F package=@$PACKAGE.zip "$CONNECT_PREPROD_URL/site/marketplace/upload?batch=true"
+          CONNECT_PREPROD_AUTH: ${{ secrets.CONNECT_PREPROD_AUTH }}
+        run: curl -i -u "$CONNECT_PREPROD_AUTH" -F package=@$PACKAGE.zip "$CONNECT_PREPROD_URL/site/marketplace/upload?batch=true"
 
       - name: Push promoted Web UI to Connect PROD
         if: ${{ github.event.inputs.dryRun == 'false' }}
         env:
           PACKAGE: nuxeo-web-ui-${{ env.VERSION }}
           CONNECT_URL: https://connect.nuxeo.com/nuxeo
-        run: curl -i -u "${{ secrets.CONNECT_AUTH }}" -F package=@$PACKAGE.zip "$CONNECT_URL/site/marketplace/upload?batch=true"
+          CONNECT_AUTH: ${{ secrets.CONNECT_AUTH }}
+        run: curl -i -u "$CONNECT_AUTH" -F package=@$PACKAGE.zip "$CONNECT_URL/site/marketplace/upload?batch=true"
 
       - uses: actions/checkout@v6
         with:
@@ -144,7 +147,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
         run: |
-          OLD_SNAPSHOT=$(npx -c 'echo "$npm_package_version"')
+          OLD_SNAPSHOT=$(npx --no-install -c 'echo "$npm_package_version"')
           # bump version to next SNAPSHOT and align on the corresponding Elements release candidate
           NEW_SNAPSHOT=$NEW_VERSION-SNAPSHOT
           npm version $NEW_SNAPSHOT --no-git-tag-version

--- a/.github/workflows/veracode-3.1.x.yaml
+++ b/.github/workflows/veracode-3.1.x.yaml
@@ -64,7 +64,7 @@ jobs:
       run: |
           npm ci --ignore-scripts
           pushd packages/nuxeo-web-ui-ftest
-          npm ci
+          npm ci --ignore-scripts
           popd
     - name: Checkout the nuxeo-elements repo
       uses: actions/checkout@v6

--- a/.github/workflows/veracode-lts-2025.yaml
+++ b/.github/workflows/veracode-lts-2025.yaml
@@ -64,7 +64,7 @@ jobs:
         run: |
           npm ci --ignore-scripts
           pushd packages/nuxeo-web-ui-ftest
-          npm ci
+          npm ci --ignore-scripts
           popd
 
       - name: Checkout the nuxeo-elements repo


### PR DESCRIPTION
## WEBUI-2219

Resolves the 25 open MEDIUM-severity SECURITY findings SonarCloud reports on `lts-2025`. Every change is confined to `.github/workflows/` — no application code is touched and there is no user-visible change.

Direct follow-up to WEBUI-2198, which closed the HIGH-severity S7637 action-pinning findings and explicitly deferred these rules.

### What changed

**S6505 — npm lifecycle scripts (19 findings).** Any package in a dependency tree can run arbitrary code at install time with the full privileges of the CI job. The root `npm ci --ignore-scripts` was already hardened, but every nested install was missed, which made that protection largely moot. Added the flag to all 15 sub-package installs (`nuxeo-web-ui-ftest`, `nuxeo-designer-catalog`, `plugin/a11y`, and the local `nuxeo-elements` installs).

The same rule also covers three `npx -c 'echo "$npm_package_version"'` calls in `main.yaml` and `promote.yaml`. These exist only to read a version out of a local `package.json`, but `npx` will fetch and execute a registry package if it cannot resolve one locally. Added `--no-install` so it fails instead. This matches the idiom `alpha.yaml` already uses for the same purpose.

**S8543 + S6505 — unpinned global install.** `npm install -g bower gulp-cli` in `ftest.yaml` floated to whatever was latest at build time. Now pinned to `bower@1.8.14` and `gulp-cli@3.1.0`, with `--ignore-scripts`. Both pins equal what the floating form resolves to today, so nothing changes operationally.

**S7636 — secrets in `run:` blocks (4 findings).** GitHub substitutes `${{ secrets.* }}` into the step's script text before writing that script to a file on the runner, so the credential sat in plaintext on disk for the life of the job, readable by any later step or third-party action in the same job. `CONNECT_PREPROD_AUTH` and `CONNECT_AUTH` now reach the shell through the step's `env:` instead.

Worth stating plainly: this does not remove the credential from curl's argv, since the shell expands the variable before `exec`. It removes the on-disk script exposure, which is what the rule targets.

**S6506 — protocol downgrade on redirect.** The authenticated artifact download in `promote.yaml` used `-L` without constraining the protocol, so a redirect could drop it to plain HTTP. Since this is the marketplace package that then gets promoted to production, added `--proto '=https' --proto-redir '=https'`.

**Crowdin secret declaration.** `crowdin.yaml` now declares its three secrets explicitly under `workflow_call.secrets` so callers no longer need `secrets: inherit`. See merge order below.

### Merge order

**This PR must merge before its `maintenance-3.1.x` counterpart, #3462.**

That branch calls `crowdin.yaml@lts-2025`, and passing an explicit secret to a reusable workflow that has not declared it is a hard failure. All three secrets here are declared `required: true`, so the existing `secrets: inherit` caller keeps working in the window between the two merges — nightly translation sync is not interrupted.

### Verification

Run locally against a pristine baseline of `origin/lts-2025`; CI remains the authority.

- **actionlint 1.7.12** output is byte-identical before and after, so no new workflow defects. Its pre-existing findings (deprecated `always-auth`, an undefined `get-tag` property in the veracode workflows, one script-injection warning in `sonar.yaml`) are unrelated.
- **`--ignore-scripts` is behaviourally inert.** In a `node:20` container, `npm ci` and `npm ci --ignore-scripts` produced identical installed trees for every affected sub-package: ftest 774 packages / 21,349 files, designer-catalog 439 / 8,398, a11y 619 / 16,407. The `@esbuild/linux-x64` binary is present and executable either way, because esbuild ships platform binaries as optional dependencies rather than via its install script.
- **`npx --no-install` is equivalent** — returns the same version string, and correctly refuses to fetch-and-run an uninstalled package.
- **curl flags behave as intended** — HTTPS allowed, HTTPS-to-HTTPS redirects followed, plain HTTP refused.
- **Coverage** — all 25 Sonar findings mapped to a changed line.

### Reviewer notes

- `preview.yaml`: `--ignore-scripts` does not suppress `prepare` for local-path installs, only `preinstall`/`postinstall`. This is moot here because `nuxeo-elements` `core`, `ui` and `dataviz` declare no lifecycle scripts at all, so the flag is a no-op on those three lines.
- The `ftest` job is the one most exposed to the `--ignore-scripts` change and is worth watching on this run.
