### PR TITLE
WEBUI-2225: verify message origin in Live Connect popup listener [lts-2025]

### DIFF
--- a/addons/nuxeo-liveconnect/elements/nuxeo-liveconnect-behavior.js
+++ b/addons/nuxeo-liveconnect/elements/nuxeo-liveconnect-behavior.js
@@ -84,9 +84,9 @@ export const LiveConnectBehavior = {
         // not a resolvable URL, nothing to allow
       }
     };
-    const resource = this.$ && this.$.oauth2;
-    const connection = resource && resource.$ && resource.$.nx;
-    addOrigin(connection && connection.url);
+    const resource = this.$?.oauth2;
+    const connection = resource?.$?.nx;
+    addOrigin(connection?.url);
     try {
       addOrigin(new URL(url, window.location.href).searchParams.get('redirect_uri'));
     } catch {
@@ -116,6 +116,16 @@ export const LiveConnectBehavior = {
       `height=${settings.height},width=${settings.width},top=${top},left=${left}`,
     );
 
+    // if the popup could not be opened (e.g. blocked by the browser) there is no window to
+    // authenticate messages against and nothing to poll; notify the caller and bail out rather
+    // than registering a listener and a timer that would never be cleared.
+    if (!popup) {
+      if (typeof settings.onClose === 'function') {
+        settings.onClose();
+      }
+      return;
+    }
+
     // the popup is opened before the listener is registered so that the listener can authenticate the
     // sender against it; nothing can be posted in between, both statements run in the same task
     let listener;
@@ -131,7 +141,7 @@ export const LiveConnectBehavior = {
     }
 
     const checkCompleted = setInterval(() => {
-      if (!popup || !popup.closed) {
+      if (!popup.closed) {
         return;
       }
 

--- a/addons/nuxeo-liveconnect/elements/nuxeo-liveconnect-behavior.js
+++ b/addons/nuxeo-liveconnect/elements/nuxeo-liveconnect-behavior.js
@@ -116,13 +116,13 @@ export const LiveConnectBehavior = {
       `height=${settings.height},width=${settings.width},top=${top},left=${left}`,
     );
 
-    // if the popup could not be opened (e.g. blocked by the browser) there is no window to
-    // authenticate messages against and nothing to poll; notify the caller and bail out rather
-    // than registering a listener and a timer that would never be cleared.
+    // a blocked popup (browser popup blocker, extension, …) yields a falsy handle: there is no
+    // window to authenticate messages against and nothing to poll. Warn so the failure is not
+    // silent, then bail out without registering a listener or a timer that would never be cleared.
+    // onClose is intentionally NOT called: it signals "the auth popup was closed" and would let a
+    // provider replay a stale token even though no authentication ever happened.
     if (!popup) {
-      if (typeof settings.onClose === 'function') {
-        settings.onClose();
-      }
+      console.warn('nuxeo-liveconnect: the authentication popup could not be opened (blocked?); aborting.');
       return;
     }
 
@@ -132,7 +132,22 @@ export const LiveConnectBehavior = {
     if (typeof settings.onMessageReceive === 'function') {
       const allowedOrigins = this._allowedMessageOrigins(url);
       listener = function (event) {
-        if (event.source !== popup || !allowedOrigins.has(event.origin)) {
+        // A null/absent source is tolerated: some engines drop the sender reference once the
+        // popup is discarded, and the origin allow-list is the check that actually stops
+        // cross-origin forgery (S2819). A same-origin window keeps its source identity, so it is
+        // still rejected here and, being same-origin, needs no postMessage to script this element.
+        const fromPopup = !event.source || event.source === popup;
+        if (!fromPopup || !allowedOrigins.has(event.origin)) {
+          // Only surface the case that indicates a real allow-list/deployment misconfiguration —
+          // our popup posted but from an unexpected origin — so the console is not spammed with
+          // unrelated postMessage traffic coming from other windows on the page.
+          if (fromPopup) {
+            console.warn(
+              `nuxeo-liveconnect: ignored an OAuth message from unexpected origin "${event.origin}"; allowed: ${[
+                ...allowedOrigins,
+              ].join(', ')}.`,
+            );
+          }
           return;
         }
         settings.onMessageReceive(event);

--- a/addons/nuxeo-liveconnect/elements/nuxeo-liveconnect-behavior.js
+++ b/addons/nuxeo-liveconnect/elements/nuxeo-liveconnect-behavior.js
@@ -60,6 +60,41 @@ export const LiveConnectBehavior = {
     this.fire('nx-blob-picked', { blobs: Array.isArray(blobs) ? blobs : [blobs] });
   },
 
+  /**
+   * Origins allowed to post a message back to this window while an OAuth2 popup is open.
+   *
+   * The popup is sent to the provider's authorization page, but the window that ends up calling
+   * `window.opener.postMessage` is the Nuxeo OAuth2 callback page the provider redirects to, and it
+   * posts with a `*` target. Its origin is the one of the `redirect_uri` carried by the
+   * authorization URL, and it falls back to the Nuxeo server this element is connected to. The
+   * current origin is always accepted: a same-origin script already has full access to this window.
+   *
+   * Note this is only half of the check: `openPopup` also requires the message to come from the
+   * popup window it opened, so another window on an allowed origin cannot inject a token.
+   */
+  _allowedMessageOrigins(url) {
+    const origins = new Set([window.location.origin]);
+    const addOrigin = (value) => {
+      if (!value) {
+        return;
+      }
+      try {
+        origins.add(new URL(value, window.location.href).origin);
+      } catch {
+        // not a resolvable URL, nothing to allow
+      }
+    };
+    const resource = this.$ && this.$.oauth2;
+    const connection = resource && resource.$ && resource.$.nx;
+    addOrigin(connection && connection.url);
+    try {
+      addOrigin(new URL(url, window.location.href).searchParams.get('redirect_uri'));
+    } catch {
+      // authorization URL not parseable, rely on the connection origin
+    }
+    return origins;
+  },
+
   openPopup(url, options) {
     const settings = {
       width: '1000',
@@ -75,19 +110,25 @@ export const LiveConnectBehavior = {
     const left = window.screenX + window.outerWidth / 2 - settings.width / 2;
     const top = window.screenY + window.outerHeight / 2 - settings.height / 2;
 
-    let listener;
-    if (typeof settings.onMessageReceive === 'function') {
-      listener = function (event) {
-        settings.onMessageReceive(event);
-      };
-      window.addEventListener('message', listener);
-    }
-
     const popup = window.open(
       url,
       'popup',
       `height=${settings.height},width=${settings.width},top=${top},left=${left}`,
     );
+
+    // the popup is opened before the listener is registered so that the listener can authenticate the
+    // sender against it; nothing can be posted in between, both statements run in the same task
+    let listener;
+    if (typeof settings.onMessageReceive === 'function') {
+      const allowedOrigins = this._allowedMessageOrigins(url);
+      listener = function (event) {
+        if (event.source !== popup || !allowedOrigins.has(event.origin)) {
+          return;
+        }
+        settings.onMessageReceive(event);
+      };
+      window.addEventListener('message', listener);
+    }
 
     const checkCompleted = setInterval(() => {
       if (!popup || !popup.closed) {

--- a/addons/nuxeo-liveconnect/test/nuxeo-liveconnect-behavior.test.js
+++ b/addons/nuxeo-liveconnect/test/nuxeo-liveconnect-behavior.test.js
@@ -102,6 +102,17 @@ suite('LiveConnectBehavior', () => {
       addListenerSpy.restore();
       globalThis.open.restore();
     });
+
+    test('should invoke onClose and register no listener when the popup is blocked', () => {
+      sinon.stub(globalThis, 'open').returns(null);
+      const addListenerSpy = sinon.spy(globalThis, 'addEventListener');
+      const onClose = sinon.spy();
+      behavior.openPopup('https://auth.example.com', { onClose, onMessageReceive: sinon.spy() });
+      expect(onClose).to.have.been.calledOnce;
+      expect(addListenerSpy).to.not.have.been.calledWith('message', sinon.match.func);
+      addListenerSpy.restore();
+      globalThis.open.restore();
+    });
   });
 
   suite('openPopup message sender verification', () => {
@@ -123,6 +134,10 @@ suite('LiveConnectBehavior', () => {
     };
 
     setup(() => {
+      // openPopup polls the popup with setInterval; the fake popup never reports itself as
+      // closed, so fake timers keep that interval from leaking into the rest of the run
+      // (the global teardown restores the clock).
+      sinon.useFakeTimers();
       onMessageReceive = sinon.spy();
       listener = null;
       popup = null;

--- a/addons/nuxeo-liveconnect/test/nuxeo-liveconnect-behavior.test.js
+++ b/addons/nuxeo-liveconnect/test/nuxeo-liveconnect-behavior.test.js
@@ -104,6 +104,83 @@ suite('LiveConnectBehavior', () => {
     });
   });
 
+  suite('openPopup message sender verification', () => {
+    let onMessageReceive;
+    let listener;
+    let popup;
+
+    const open = (url) => {
+      popup = { closed: false };
+      sinon.stub(globalThis, 'open').returns(popup);
+      const addListenerStub = sinon.stub(globalThis, 'addEventListener').callsFake((type, fn) => {
+        if (type === 'message') {
+          listener = fn;
+        }
+      });
+      behavior.openPopup(url, { onMessageReceive });
+      addListenerStub.restore();
+      globalThis.open.restore();
+    };
+
+    setup(() => {
+      onMessageReceive = sinon.spy();
+      listener = null;
+      popup = null;
+    });
+
+    test('should ignore messages coming from an unexpected origin', () => {
+      open('https://auth.example.com');
+      listener({ origin: 'https://evil.example.com', source: popup, data: '{"token":"stolen"}' });
+      expect(onMessageReceive).to.not.have.been.called;
+    });
+
+    test('should ignore messages not sent by the popup it opened', () => {
+      open('https://auth.example.com');
+      listener({ origin: globalThis.location.origin, source: {}, data: '{"token":"stolen"}' });
+      expect(onMessageReceive).to.not.have.been.called;
+    });
+
+    test('should accept messages coming from the current origin', () => {
+      open('https://auth.example.com');
+      const event = { origin: globalThis.location.origin, source: popup, data: '{"token":"abc"}' };
+      listener(event);
+      expect(onMessageReceive).to.have.been.calledWith(event);
+    });
+
+    test('should accept messages coming from the redirect_uri origin', () => {
+      const redirectUri = encodeURIComponent('https://nuxeo.example.com/nuxeo/site/oauth2/box/callback');
+      open(`https://auth.example.com/authorize?redirect_uri=${redirectUri}`);
+      const event = { origin: 'https://nuxeo.example.com', source: popup, data: '{"token":"abc"}' };
+      listener(event);
+      expect(onMessageReceive).to.have.been.calledWith(event);
+    });
+
+    test('should accept messages coming from the Nuxeo server origin', () => {
+      behavior.$ = { oauth2: { $: { nx: { url: 'https://server.example.com/nuxeo' } } } };
+      open('https://auth.example.com');
+      const event = { origin: 'https://server.example.com', source: popup, data: '{"token":"abc"}' };
+      listener(event);
+      expect(onMessageReceive).to.have.been.calledWith(event);
+    });
+
+    test('should resolve a relative Nuxeo server url against the current origin', () => {
+      behavior.$ = { oauth2: { $: { nx: { url: '/nuxeo' } } } };
+      open('https://auth.example.com');
+      listener({ origin: globalThis.location.origin, source: popup, data: '{"token":"abc"}' });
+      expect(onMessageReceive).to.have.been.calledOnce;
+    });
+
+    // org.nuxeo.ecm.contextPath only changes the path, so the origin to trust is unaffected by it
+    test('should accept messages when the server runs on a non-default context path', () => {
+      behavior.$ = { oauth2: { $: { nx: { url: '/mycms' } } } };
+      const redirectUri = encodeURIComponent('https://nuxeo.example.com/mycms/site/oauth2/googledrive/callback');
+      open(`https://auth.example.com/authorize?redirect_uri=${redirectUri}`);
+      const event = { origin: 'https://nuxeo.example.com', source: popup, data: '{"token":"abc"}' };
+      listener(event);
+      expect(onMessageReceive).to.have.been.calledWith(event);
+    });
+  });
+
   suite('updateProviderInfo', () => {
     test('should throw when oauth2 element is missing', () => {
       behavior.$ = {};

--- a/addons/nuxeo-liveconnect/test/nuxeo-liveconnect-behavior.test.js
+++ b/addons/nuxeo-liveconnect/test/nuxeo-liveconnect-behavior.test.js
@@ -103,13 +103,20 @@ suite('LiveConnectBehavior', () => {
       globalThis.open.restore();
     });
 
-    test('should invoke onClose and register no listener when the popup is blocked', () => {
+    test('should warn and register no listener when the popup is blocked', () => {
       sinon.stub(globalThis, 'open').returns(null);
       const addListenerSpy = sinon.spy(globalThis, 'addEventListener');
+      const warnStub = sinon.stub(console, 'warn');
       const onClose = sinon.spy();
-      behavior.openPopup('https://auth.example.com', { onClose, onMessageReceive: sinon.spy() });
-      expect(onClose).to.have.been.calledOnce;
+      const onMessageReceive = sinon.spy();
+      behavior.openPopup('https://auth.example.com', { onClose, onMessageReceive });
+      // a blocked popup never authenticated the user, so onClose must not fire (it would let a
+      // provider replay a stale token) and no message listener may be registered
+      expect(onClose).to.not.have.been.called;
+      expect(onMessageReceive).to.not.have.been.called;
       expect(addListenerSpy).to.not.have.been.calledWith('message', sinon.match.func);
+      expect(warnStub).to.have.been.calledOnce;
+      warnStub.restore();
       addListenerSpy.restore();
       globalThis.open.restore();
     });
@@ -193,6 +200,39 @@ suite('LiveConnectBehavior', () => {
       const event = { origin: 'https://nuxeo.example.com', source: popup, data: '{"token":"abc"}' };
       listener(event);
       expect(onMessageReceive).to.have.been.calledWith(event);
+    });
+
+    // some engines drop the sender reference once the popup is discarded; the origin allow-list is
+    // the real cross-origin guard, so a null source from an allowed origin must still be accepted
+    test('should accept messages from an allowed origin even when the source is null', () => {
+      open('https://auth.example.com');
+      const event = { origin: globalThis.location.origin, source: null, data: '{"token":"abc"}' };
+      listener(event);
+      expect(onMessageReceive).to.have.been.calledWith(event);
+    });
+
+    test('should still reject a null-source message when the origin is not allowed', () => {
+      open('https://auth.example.com');
+      listener({ origin: 'https://evil.example.com', source: null, data: '{"token":"stolen"}' });
+      expect(onMessageReceive).to.not.have.been.called;
+    });
+
+    test('should warn when the popup posts from an unexpected origin (likely misconfiguration)', () => {
+      const warnStub = sinon.stub(console, 'warn');
+      open('https://auth.example.com');
+      listener({ origin: 'https://evil.example.com', source: popup, data: '{"token":"stolen"}' });
+      expect(onMessageReceive).to.not.have.been.called;
+      expect(warnStub).to.have.been.calledOnce;
+      warnStub.restore();
+    });
+
+    test('should not warn for unrelated messages coming from another window', () => {
+      const warnStub = sinon.stub(console, 'warn');
+      open('https://auth.example.com');
+      listener({ origin: 'https://ads.example.com', source: {}, data: 'unrelated' });
+      expect(onMessageReceive).to.not.have.been.called;
+      expect(warnStub).to.not.have.been.called;
+      warnStub.restore();
     });
   });
 


### PR DESCRIPTION
## Problem
The Live Connect addon registers a `window` `message` listener during the OAuth popup / blob-picking flow (`openPopup`) that forwarded **every** message to `onMessageReceive` without authenticating the sender. Any window (including a malicious page/frame) could `postMessage` a forged OAuth token into the flow while the popup is open. Jira: [WEBUI-2225](https://hyland.atlassian.net/browse/WEBUI-2225)

- SonarCloud rule `javascript:S2819` — Origins should be verified during cross-origin communications
- VULNERABILITY, SECURITY impact HIGH (Sonar CRITICAL), CWE-345 (Insufficient Verification of Data Authenticity), OWASP A01:2021

## Root cause
In `addons/nuxeo-liveconnect/elements/nuxeo-liveconnect-behavior.js`, `openPopup()` did:

```js
listener = function (event) {
  settings.onMessageReceive(event); // Noncompliant: event.origin / event.source never checked
};
window.addEventListener('message', listener);
```

The listener never confirmed the message came from the popup window it opened, nor from an expected origin, so the received data was trusted unconditionally.

## Changes
* **`addons/nuxeo-liveconnect/elements/nuxeo-liveconnect-behavior.js`**:
  * `window.open(...)` is now called **before** the listener is registered so the listener can authenticate the sender against the exact popup handle. Both statements run in the same task, so nothing can be posted in between.
  * The `message` listener now early-returns unless **both** conditions hold:
    * the message came from the popup we opened — `event.source === popup`, **tolerating a null/absent `event.source`** (some engines drop the sender reference once the popup is discarded; the origin allow-list is what actually stops cross-origin forgery, and a same-origin window keeps its source identity so it is still rejected); and
    * `event.origin` is in an allow-list.
  * New helper `_allowedMessageOrigins(url)` builds that allow-list from: `window.location.origin` (a same-origin script already has full access to this window), the `redirect_uri` carried by the authorization URL, and the `nuxeo-connection` origin. The genuine token is posted by the Nuxeo OAuth2 callback page (`skin/resources/script/oauth2.js`, `window.opener.postMessage(JSON.stringify(data), "*")`) from the Nuxeo server origin, which is exactly what this allow-list trusts.
  * **Diagnostics:** when the popup posts from an unexpected origin (the symptom of an allow-list / deployment misconfiguration) the listener now logs a `console.warn` naming the rejected origin and the allowed set, instead of failing silently. Unrelated `postMessage` traffic from other windows is still dropped without noise.
  * **Blocked popup:** if `window.open()` returns a falsy handle (popup blocker/extension), `openPopup` now logs a `console.warn` and aborts without registering a listener or a polling `setInterval` (previously the interval could never clear — leaked timer + listener). `onClose` is intentionally **not** called in this case: it signals "the auth popup was closed" and would let a provider replay a stale token even though no authentication happened. This restores the original no-`onClose`-on-blocked-popup behavior while fixing the leak.
* **`addons/nuxeo-liveconnect/test/nuxeo-liveconnect-behavior.test.js`**: adds a `openPopup message sender verification` suite covering rejection of unexpected origins, rejection of messages not sent by the opened popup, acceptance of the current origin / `redirect_uri` origin / Nuxeo server origin / relative connection URLs / non-default `org.nuxeo.ecm.contextPath` deployments, plus null-`event.source` acceptance (allowed origin) and rejection (disallowed origin), the misconfiguration `console.warn`, no-warn for unrelated windows, and the blocked-popup path (warn, no listener, `onClose` not called). The suite installs `sinon.useFakeTimers()` so the polling interval cannot leak across tests.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (2652 passing; includes the Live Connect sender-verification suite)
- [x] Manual end-to-end on a real Nuxeo backend (Tomcat 2025 + configured Google Drive provider): OAuth popup → Google sign-in → Nuxeo callback `postMessage` → guarded listener accepts the genuine token → Google Picker opens → file selected → document created. Forged same-origin `postMessage` (not from the popup) is rejected before `onMessageReceive`.

## Notes
- Backport pair: this PR targets `lts-2025`; a matching PR targets `maintenance-3.1.x`.
- Behavior-preserving for legitimate flows: the check only adds sender authentication; the provider callback still delivers the token as before.
- The Nuxeo server posts with a `*` target from its own origin, so the fix trusts the Nuxeo/redirect origin (not the external provider origin) — this is what actually delivers the token and avoids a silent functional regression.
- Review follow-ups addressed in later commits: null-`event.source` tolerance (cross-browser regression guard), rejection/blocked-popup diagnostics, and the blocked-popup `onClose` behavior documented above. Scope was deliberately kept to the Live Connect popup fix; the structurally similar (but not exploitable — no `onMessageReceive` wired) `_openPopup` in `elements/nuxeo-user-cloud-services.html` was left untouched to avoid widening a security PR.

Made with [Cursor](https://cursor.com)

[WEBUI-2225]: https://hyland.atlassian.net/browse/WEBUI-2225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
