### PR TITLE
task: Fix alpha build pinning wrong-line nuxeo-elements version [lts-2025]

### DIFF
--- a/.github/workflows/alpha.yaml
+++ b/.github/workflows/alpha.yaml
@@ -86,13 +86,20 @@ jobs:
 
           npm version ${VERSION} --no-git-tag-version
 
+          # Derive the elements version base from THIS branch's package version so the build
+          # consumes elements from the same release line (2025.19.0 on lts-2025, 3.1.34 on
+          # maintenance-3.1.x). Hardcoding a "2025." prefix here silently pins 2025 elements
+          # onto a maintenance build.
+          ELEMENTS_BASE="${PACKAGE_VERSION%-SNAPSHOT}"
+          ELEMENTS_BASE_RE=$(printf '%s' "$ELEMENTS_BASE" | sed 's/\./\\./g')
+
           # Get latest ALPHA UI Elements version, fall back to latest rc if none published yet.
           # `|| true` keeps a no-match grep (exit 1) from aborting the step under bash -eo
           # pipefail, so the empty value reaches the fallback and the guard below.
-          ELEMENTS_VERSION=$(npm view @nuxeo/nuxeo-ui-elements versions --json | jq -r '.[]' | grep -E "2025\.[0-9]+\.[0-9]+-${PREID}\.[0-9]+$" | sort -V | tail -n1 || true)
+          ELEMENTS_VERSION=$(npm view @nuxeo/nuxeo-ui-elements versions --json | jq -r '.[]' | grep -E "^${ELEMENTS_BASE_RE}-${PREID}\.[0-9]+$" | sort -V | tail -n1 || true)
           if [ -z "$ELEMENTS_VERSION" ]; then
             echo "No ${PREID} nuxeo-ui-elements found on npm, falling back to latest rc"
-            ELEMENTS_VERSION=$(npm view @nuxeo/nuxeo-ui-elements versions --json | jq -r '.[]' | grep -E "2025\.[0-9]+\.[0-9]+-rc\.[0-9]+$" | sort -V | tail -n1 || true)
+            ELEMENTS_VERSION=$(npm view @nuxeo/nuxeo-ui-elements versions --json | jq -r '.[]' | grep -E "^${ELEMENTS_BASE_RE}-rc\.[0-9]+$" | sort -V | tail -n1 || true)
           fi
 
           if [ -z "$ELEMENTS_VERSION" ]; then


### PR DESCRIPTION
## Problem
The manually-dispatched **Alpha build** (`.github/workflows/alpha.yaml`) pins the wrong `@nuxeo/nuxeo-elements` line into the built `package.json`. When dispatched on the maintenance line it produced a build whose elements still referenced the 2025 alpha (e.g. `3.1.34-alpha.1` pinned `@nuxeo/nuxeo-elements@2025.19.0-alpha.4`). The lts-2025 build only worked by coincidence.

## Root cause
The `Update versions` step resolves the elements version with a **hardcoded `2025.` grep prefix**, independent of the branch:

```
grep -E "2025\.[0-9]+\.[0-9]+-${PREID}\.[0-9]+$"
```

The two release lines version elements off the web-ui `package.json` version — `2025.19.0` on `lts-2025`, `3.1.34` on `maintenance-3.1.x`. On the maintenance line the `2025.` pattern matches nothing; the `|| true` swallows the empty result, the rc fallback (also `2025.`) matches, and a 2025 elements alpha gets pinned onto the maintenance build.

## Changes
* **`.github/workflows/alpha.yaml`**: derive the elements base from this branch's own `PACKAGE_VERSION` (`${PACKAGE_VERSION%-SNAPSHOT}`) and anchor the grep to it (`^<base>-${PREID}.N$`, rc fallback `^<base>-rc.N$`). Each line now consumes its matching elements. On `lts-2025` this resolves the same `2025.19.0-alpha.N` as before — no behavior change.

## Test plan
- [x] YAML-only change; shell logic verified: `${PACKAGE_VERSION%-SNAPSHOT}` yields `2025.19.0`/`3.1.34`, escaped for the grep anchor.
- [ ] Dispatch `alpha.yaml` on this branch and confirm the built `package.json` pins `2025.19.0-alpha.N` (or `-rc.N` fallback) elements.

## Notes
Paired backport to `maintenance-3.1.x` (task-fix-alpha-build-elements-version-maintenance-3.1.x), where this bug actually manifests. No Jira ticket. `main.yaml` has the same hardcoded prefix but only runs on `lts-2025`, so it is unaffected.

Made with [Cursor](https://cursor.com)