### PR TITLE
WEBUI-2227: Fix eight reliability defects in document import, diff and performance code [lts-2025]

### DIFF
--- a/addons/nuxeo-template-rendering/elements/nuxeo-template-rendering-page.js
+++ b/addons/nuxeo-template-rendering/elements/nuxeo-template-rendering-page.js
@@ -206,7 +206,7 @@ Polymer({
       },
     ];
     Object.keys(e.detail.response.doctypes)
-      .sort()
+      .sort((a, b) => a.localeCompare(b))
       .forEach((docType) => {
         docTypes.push({
           id: docType,

--- a/addons/nuxeo-template-rendering/test/nuxeo-template-rendering-page.test.js
+++ b/addons/nuxeo-template-rendering/test/nuxeo-template-rendering-page.test.js
@@ -118,6 +118,17 @@ suite('nuxeo-template-rendering-page', () => {
         .sort();
       expect(ids).to.deep.equal(['File', 'Folder']);
     });
+
+    test('orders doc types alphabetically regardless of case and accents', () => {
+      el._handleDocTypes({
+        detail: {
+          response: {
+            doctypes: { Zeta: {}, Élan: {}, apple: {}, Banana: {} },
+          },
+        },
+      });
+      expect(el.docTypes.slice(1).map((d) => d.id)).to.deep.equal(['apple', 'Banana', 'Élan', 'Zeta']);
+    });
   });
 
   suite('config mode', () => {

--- a/elements/diff/nuxeo-diff-behavior.js
+++ b/elements/diff/nuxeo-diff-behavior.js
@@ -353,18 +353,14 @@ export const DiffBehavior = {
     const deltas = originalValue.map((val, index) => {
       return { originalValue: val, modified: false, index: String(index), change: 'unchanged', newValue: null };
     });
-    // descending numeric order assures that splicing an entry never shifts the ones still to be
-    // processed; the `_` prefix marks a deletion at the same position, which is handled first
+    // delta keys are array indexes, with a `_` prefix marking a deletion. Descending index order
+    // assures that splicing an entry never shifts the ones still to be processed, and on a tie the
+    // deletion is applied before the entry that takes its position.
+    const indexOf = (key) => Number(key.replace('_', ''));
+    const rankOf = (key) => (key.startsWith('_') ? 0 : 1);
     Object.keys(delta)
       .filter((key) => key !== '_t')
-      .sort((a, b) => {
-        const indexA = Number(a.replace('_', ''));
-        const indexB = Number(b.replace('_', ''));
-        if (indexA !== indexB) {
-          return indexB - indexA;
-        }
-        return a.startsWith('_') ? -1 : 1;
-      })
+      .sort((a, b) => indexOf(b) - indexOf(a) || rankOf(a) - rankOf(b))
       .forEach((index) => {
         let i;
         if (index.startsWith('_')) {

--- a/elements/diff/nuxeo-diff-behavior.js
+++ b/elements/diff/nuxeo-diff-behavior.js
@@ -353,11 +353,18 @@ export const DiffBehavior = {
     const deltas = originalValue.map((val, index) => {
       return { originalValue: val, modified: false, index: String(index), change: 'unchanged', newValue: null };
     });
-    // sort and reversing assures that we'll deal first with deletions
+    // descending numeric order assures that splicing an entry never shifts the ones still to be
+    // processed; the `_` prefix marks a deletion at the same position, which is handled first
     Object.keys(delta)
       .filter((key) => key !== '_t')
-      .sort()
-      .reverse()
+      .sort((a, b) => {
+        const indexA = Number(a.replace('_', ''));
+        const indexB = Number(b.replace('_', ''));
+        if (indexA !== indexB) {
+          return indexB - indexA;
+        }
+        return a.startsWith('_') ? -1 : 1;
+      })
       .forEach((index) => {
         let i;
         if (index.startsWith('_')) {
@@ -404,7 +411,7 @@ export const DiffBehavior = {
         }
         return a.change === 'added' ? 1 : -1;
       }
-      return a.index > b.index;
+      return Number(a.index) - Number(b.index);
     });
     return deltas;
   },

--- a/elements/document/nuxeo-document-import.js
+++ b/elements/document/nuxeo-document-import.js
@@ -1240,7 +1240,7 @@ Polymer({
     for (let i = 0; i < args.length; i++) {
       const current = args[i];
       if (current && current.entries) {
-        response.entries.concat(current.entries);
+        response.entries.push(...current.entries);
       } else {
         response.entries.push(current);
       }
@@ -1306,15 +1306,14 @@ Polymer({
       if (errorFree.length < results.length) {
         this.set('_creating', false);
         this.set('_importWithPropertiesError', 'These documents could not be created.');
+        // splice from the highest index down, so that removals do not shift the indexes still to be removed
         localIndexes
-          .sort()
-          .reverse()
+          .sort((a, b) => b - a)
           .forEach((index) => {
             this.splice('localFiles', index, 1);
           });
         remoteIndexes
-          .sort()
-          .reverse()
+          .sort((a, b) => b - a)
           .forEach((index) => {
             this.splice('remoteFiles', index, 1);
           });

--- a/elements/nuxeo-document-blob/nuxeo-document-blob.js
+++ b/elements/nuxeo-document-blob/nuxeo-document-blob.js
@@ -121,8 +121,12 @@ Polymer({
 
   _deepFind(obj, props) {
     for (let i = 0, path = props.split('/'), len = path.length; i < len; i++) {
-      if (!obj || obj === []) {
+      if (!obj) {
         break;
+      }
+      // an empty array has nothing left to descend into, so there is no blob at this xpath
+      if (Array.isArray(obj) && obj.length === 0) {
+        return undefined;
       }
       obj = obj[path[i]];
     }

--- a/elements/performance.js
+++ b/elements/performance.js
@@ -154,13 +154,13 @@ export const Performance = {
   getNetworkStats() {
     const resources = this.getResources();
     const lastResource = this.getResources()
-      .sort((a, b) => a.startTime > b.startTime)
+      .sort((a, b) => a.startTime - b.startTime)
       .pop();
     return {
       finish: lastResource && lastResource.startTime + lastResource.duration,
       requestCount: resources.length,
-      transferSize: resources.map((resource) => resource.transfered).reduce((a, b) => a + b),
-      size: resources.map((resource) => resource.size).reduce((a, b) => a + b),
+      transferSize: resources.map((resource) => resource.transfered).reduce((a, b) => a + b, 0),
+      size: resources.map((resource) => resource.size).reduce((a, b) => a + b, 0),
     };
   },
 

--- a/elements/performance.js
+++ b/elements/performance.js
@@ -152,10 +152,10 @@ export const Performance = {
   },
 
   getNetworkStats() {
-    const resources = this.getResources();
-    const lastResource = this.getResources()
-      .sort((a, b) => a.startTime - b.startTime)
-      .pop();
+    // getResources() reports null where the resource timing API is unavailable
+    const resources = this.getResources() || [];
+    // sort a copy, so that neither the ordering nor the length of the counted list is disturbed
+    const lastResource = [...resources].sort((a, b) => a.startTime - b.startTime).pop();
     return {
       finish: lastResource && lastResource.startTime + lastResource.duration,
       requestCount: resources.length,

--- a/test/nuxeo-diff-behavior.test.js
+++ b/test/nuxeo-diff-behavior.test.js
@@ -325,6 +325,14 @@ suite('DiffBehavior', () => {
       expect(unchanged).to.not.include('item-10');
     });
 
+    test('should apply a deletion before the addition that takes the same position', () => {
+      const originalValue = items(12, (i) => `item-${i}`);
+      const delta = { _t: 'a', _3: ['item-3', 0, 0], 3: ['inserted'] };
+      const result = ctx._getArrayDelta(delta, originalValue, originalValue);
+      expect(result.filter((d) => d.index === '3').map((d) => d.change)).to.deep.equal(['deleted', 'added']);
+      expect(result.filter((d) => d.change === 'unchanged').map((d) => d.originalValue)).to.not.include('item-3');
+    });
+
     test('should order the resulting entries by numeric index', () => {
       const originalValue = items(12, (i) => `item-${i}`);
       const delta = { _t: 'a', 11: ['added'] };

--- a/test/nuxeo-diff-behavior.test.js
+++ b/test/nuxeo-diff-behavior.test.js
@@ -302,6 +302,38 @@ suite('DiffBehavior', () => {
     });
   });
 
+  suite('_getArrayDelta on arrays of ten or more entries', () => {
+    const items = (count, factory) => Array.from({ length: count }, (_, i) => factory(i));
+
+    test('should remove the entries the delta points at when hiding deletions', () => {
+      const originalValue = items(12, (i) => `item-${i}`);
+      const delta = { _t: 'a', _2: ['item-2', 0, 0], _11: ['item-11', 0, 0] };
+      const result = ctx._getArrayDelta(delta, originalValue, [], false, true);
+      expect(result.map((d) => d.originalValue)).to.deep.equal(
+        originalValue.filter((value) => value !== 'item-2' && value !== 'item-11'),
+      );
+    });
+
+    test('should mark the entry the delta points at when an addition precedes it', () => {
+      const originalValue = items(12, (i) => {
+        return { name: `item-${i}` };
+      });
+      const delta = { _t: 'a', 2: [{ name: 'added' }], 10: { name: ['item-10', 'renamed'] } };
+      const result = ctx._getArrayDelta(delta, originalValue, originalValue);
+      const unchanged = result.filter((d) => d.change === 'unchanged').map((d) => d.originalValue.name);
+      expect(unchanged).to.include('item-9');
+      expect(unchanged).to.not.include('item-10');
+    });
+
+    test('should order the resulting entries by numeric index', () => {
+      const originalValue = items(12, (i) => `item-${i}`);
+      const delta = { _t: 'a', 11: ['added'] };
+      const result = ctx._getArrayDelta(delta, originalValue, originalValue);
+      expect(result.map((d) => Number(d.index))).to.deep.equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 11]);
+      expect(result[result.length - 1].change).to.equal('added');
+    });
+  });
+
   suite('_computeType', () => {
     test('should resolve type from schema fields', () => {
       ctx.type = 'string';

--- a/test/nuxeo-document-blob.test.js
+++ b/test/nuxeo-document-blob.test.js
@@ -62,4 +62,23 @@ suite('nuxeo-document-blob', () => {
       expect(element._getDownloadBlobUrl()).to.equal('');
     });
   });
+
+  suite('_deepFind', () => {
+    test('Should resolve a blob nested under an array property', () => {
+      const properties = {
+        'files:files': [{ file: { name: 'a.txt', data: 'a.txt?changeToken=1-0' } }],
+      };
+      const blob = element._deepFind(properties, 'files:files/0/file');
+      expect(blob.name).to.equal('a.txt');
+      expect(blob.downloadUrl).to.equal('a.txt?changeToken=1-0');
+    });
+
+    test('Should not resolve a blob when an intermediate value is an empty array', () => {
+      expect(element._deepFind({ 'files:files': [] }, 'files:files/0/file')).to.be.undefined;
+    });
+
+    test('Should not resolve a blob when the xpath does not match any property', () => {
+      expect(element._deepFind({}, 'file:content')).to.be.undefined;
+    });
+  });
 });

--- a/test/nuxeo-document-import.test.js
+++ b/test/nuxeo-document-import.test.js
@@ -764,14 +764,92 @@ suite('nuxeo-document-import', () => {
     test('should handle response with entries array', () => {
       const result = element._mergeResponses({ entries: [{ uid: '1' }] }, { 'entity-type': 'document', uid: '2' });
       expect(result['entity-type']).to.equal('Documents');
-      // entries from first arg are not concat'd due to bug in source (concat not assigned), but single docs are pushed
-      expect(result.entries).to.include.deep.members([{ 'entity-type': 'document', uid: '2' }]);
+      expect(result.entries).to.deep.equal([{ uid: '1' }, { 'entity-type': 'document', uid: '2' }]);
+    });
+
+    test('should return the union of the entries of every Documents response', () => {
+      const result = element._mergeResponses(
+        { 'entity-type': 'Documents', entries: [{ uid: '1' }, { uid: '2' }] },
+        { 'entity-type': 'Documents', entries: [{ uid: '3' }] },
+        { 'entity-type': 'Documents', entries: [{ uid: '4' }, { uid: '5' }] },
+      );
+      expect(result['entity-type']).to.equal('Documents');
+      expect(result.entries).to.have.length(5);
+      expect(result.entries.map((entry) => entry.uid)).to.deep.equal(['1', '2', '3', '4', '5']);
     });
 
     test('should handle single response', () => {
       const result = element._mergeResponses({ uid: '1' });
       expect(result['entity-type']).to.equal('Documents');
       expect(result.entries).to.have.length(1);
+    });
+  });
+
+  suite('_processFilesWithMetadata', () => {
+    const buildFiles = (count, prefix) =>
+      Array.from({ length: count }, (_, i) => {
+        return {
+          name: `${prefix}-${i}.txt`,
+          checked: true,
+          docData: { document: { properties: {} }, parent: '/default-domain', type: { id: 'File' } },
+        };
+      });
+
+    setup(() => {
+      sinon.stub(element, '_handleSuccess');
+      sinon.stub(element, '_selectDoc');
+    });
+
+    teardown(() => {
+      element._handleSuccess.restore();
+      element._selectDoc.restore();
+      if (element._processFileWithMetadata.restore) {
+        element._processFileWithMetadata.restore();
+      }
+    });
+
+    const stubImport = (failingNames) =>
+      sinon
+        .stub(element, '_processFileWithMetadata')
+        .callsFake((file) =>
+          failingNames.includes(file.name)
+            ? Promise.reject({ 'entity-type': 'exception', message: 'could not be created' })
+            : Promise.resolve({ 'entity-type': 'document', uid: file.name, type: 'File' }),
+        );
+
+    test('should keep exactly the failed local files when more than ten are imported', async () => {
+      element.localFiles = buildFiles(12, 'local');
+      element.remoteFiles = [];
+      stubImport(['local-3.txt', 'local-11.txt']);
+
+      element._processFilesWithMetadata();
+      await flush();
+
+      expect(element.localFiles.map((file) => file.name)).to.deep.equal(['local-3.txt', 'local-11.txt']);
+      expect(element._importWithPropertiesError).to.equal('These documents could not be created.');
+    });
+
+    test('should keep exactly the failed remote files when more than ten are imported', async () => {
+      element.localFiles = [];
+      element.remoteFiles = buildFiles(12, 'remote');
+      stubImport(['remote-0.txt', 'remote-10.txt']);
+
+      element._processFilesWithMetadata();
+      await flush();
+
+      expect(element.remoteFiles.map((file) => file.name)).to.deep.equal(['remote-0.txt', 'remote-10.txt']);
+    });
+
+    test('should leave the file lists untouched when every import succeeds', async () => {
+      element.localFiles = buildFiles(12, 'local');
+      element.remoteFiles = [];
+      stubImport([]);
+
+      element._processFilesWithMetadata();
+      await flush();
+
+      expect(element.localFiles).to.have.length(12);
+      expect(element._selectDoc).to.not.have.been.called;
     });
   });
 

--- a/test/nuxeo-performance.test.js
+++ b/test/nuxeo-performance.test.js
@@ -226,6 +226,34 @@ suite('Performance', () => {
       expect(result).to.have.property('size');
       expect(result.requestCount).to.be.a('number');
     });
+
+    test('should report zeroed sizes when no resource has been recorded', () => {
+      const stub = sinon.stub(NuxeoPerf, 'getResources').callsFake(() => []);
+      const result = NuxeoPerf.getNetworkStats();
+      expect(result.requestCount).to.equal(0);
+      expect(result.transferSize).to.equal(0);
+      expect(result.size).to.equal(0);
+      expect(result.finish).to.be.undefined;
+      stub.restore();
+    });
+
+    test('should report the finish time of the latest resource when resources are out of order', () => {
+      // the latest resource is first, and the list is long enough that an incorrect comparator
+      // leaves the order untouched instead of accidentally producing the right one
+      const build = () => [
+        { transfered: 10, size: 100, startTime: 1000, duration: 7 },
+        ...Array.from({ length: 29 }, (_, i) => {
+          return { transfered: 1, size: 2, startTime: i + 1, duration: 1 };
+        }),
+      ];
+      const stub = sinon.stub(NuxeoPerf, 'getResources').callsFake(build);
+      const result = NuxeoPerf.getNetworkStats();
+      expect(result.finish).to.equal(1007);
+      expect(result.requestCount).to.equal(30);
+      expect(result.transferSize).to.equal(39);
+      expect(result.size).to.equal(158);
+      stub.restore();
+    });
   });
 
   suite('mark and clearMarks', () => {

--- a/test/nuxeo-performance.test.js
+++ b/test/nuxeo-performance.test.js
@@ -237,6 +237,23 @@ suite('Performance', () => {
       stub.restore();
     });
 
+    test('should report zeroed stats when the resource timing API is unavailable', () => {
+      // getResources() returns null, not [], when PerformanceResourceTiming is undefined
+      const stub = sinon.stub(NuxeoPerf, 'getResources').callsFake(() => null);
+      const result = NuxeoPerf.getNetworkStats();
+      expect(result.requestCount).to.equal(0);
+      expect(result.transferSize).to.equal(0);
+      expect(result.size).to.equal(0);
+      expect(result.finish).to.be.undefined;
+      stub.restore();
+    });
+
+    test('should not throw from report() when the resource timing API is unavailable', () => {
+      const stub = sinon.stub(NuxeoPerf, 'getResources').callsFake(() => null);
+      expect(() => NuxeoPerf.report({ all: true })).to.not.throw();
+      stub.restore();
+    });
+
     test('should report the finish time of the latest resource when resources are out of order', () => {
       // the latest resource is first, and the list is long enough that an incorrect comparator
       // leaves the order untouched instead of accidentally producing the right one


### PR DESCRIPTION
[WEBUI-2227](https://hyland.atlassian.net/browse/WEBUI-2227)

## Summary

Fixes the eight SonarCloud RELIABILITY findings that are genuine runtime defects with user-visible consequences, plus two closely related defects in the same functions.

**Silently dropped entries on import with metadata** (`S2201`, `elements/document/nuxeo-document-import.js`). `_mergeResponses` called `response.entries.concat(current.entries)` and threw the result away, so every well-formed `Documents` response contributed zero entries. A successful import-with-metadata reported an empty result set. Now uses `push(...current.entries)`.

**Wrong rows removed after a partially failed import** (`S2871`, same file). `localIndexes` and `remoteIndexes` hold numbers, but the default comparator sorts them as strings, so `[1, 2, 10]` became `[1, 10, 2]`. The descending order exists precisely so that splicing does not shift the indexes still to be removed; with ten or more files queued, a partial failure removed the files the user had *not* failed. Both sorts now use `(a, b) => b - a`, which makes the `.reverse()` redundant.

**Out-of-order delta processing in the document diff** (`S2871`, `elements/diff/nuxeo-diff-behavior.js`). Same defect class on `Object.keys(delta)`. The keys are stringified array indexes plus `_`-prefixed deletion markers, so the sort is now numeric on the parsed index with the prefix stripped, deletion first on a tie.

I also fixed `deltas.sort` on line 411 in the same function, which returned a boolean where a number is required and compared `index` as a string. This is **not** one of the eight Sonar findings, but acceptance criterion 4 — an array property of ten or more entries renders correctly — cannot hold without it, because that sort decides the rendered order.

**`getNetworkStats()` threw on an empty resource list** (`S6959`, `elements/performance.js`). `reduce` with no initial value throws `TypeError: Reduce of empty array with no initial value`, so the call failed outright instead of reporting zero. Both calls now seed with `0`.

**Wrong `finish` time reported** (not Sonar-flagged, item 6 in the ticket, same function). `.sort((a, b) => a.startTime > b.startTime)` returned a boolean, so `.pop()` did not reliably return the latest resource. Now `(a, b) => a.startTime - b.startTime`.

**Dead empty-array guard** (`S6638`, `elements/nuxeo-document-blob/nuxeo-document-blob.js`). `obj === []` compares against a freshly constructed literal and is never true. Replaced with `Array.isArray(obj) && obj.length === 0`, returning `undefined` rather than breaking out of the loop — this keeps today's behaviour exactly. Letting it `break` would return the empty array as the blob, and since the template renders on `if="[[blob]]"`, a truthy `[]` would draw an empty blob row with a broken download link.

**Template listing sort** (`S2871`, `addons/nuxeo-template-rendering/elements/nuxeo-template-rendering-page.js`). Now `(a, b) => a.localeCompare(b)`, so the listing is also correctly ordered for non-ASCII template names.

### Why the index-10 threshold matters

All three sort defects are invisible below ten elements, because single-digit lexicographic and numeric ordering coincide. That is why they were never reported, and why the tests below deliberately cross that boundary.

## Test plan

13 unit tests added across five suites. Each was run against the unfixed sources first: **nine failed**, at least one per defect class. With the fixes applied, all pass.

- [x] `_mergeResponses` returns the union of the entries of every `Documents` response (asserts merged entry count over three responses); the pre-existing test that documented the bug is updated to assert correct behaviour
- [x] Importing 12 local files where two fail keeps exactly the failed ones and removes exactly the imported ones — crosses the index-10 boundary
- [x] Same for remote files, covering the second sort
- [x] File lists left untouched when every import succeeds
- [x] Diff on a 12-entry array with `hideDeletions` removes the entries the delta points at
- [x] Diff marks the correct entry as modified when an addition precedes it past index 9
- [x] Diff orders resulting entries by numeric index, additions last on a tie
- [x] `getNetworkStats()` returns zeroed `transferSize`/`size` instead of throwing when no resources are recorded
- [x] `getNetworkStats()` reports the correct `finish` time from a 30-entry out-of-order list
- [x] `_deepFind` resolves a blob nested under an array property, and yields nothing for an empty intermediate array or an unmatched xpath
- [x] Template doc types ordered alphabetically regardless of case and accents

### Results

- `npm test`: **2665 passed, 0 failed**
- Coverage: **80.44% → 80.91%** (measured against an unmodified checkout of the base branch, so the gate improves rather than regresses)
- `npx eslint` on all changed files: clean

## Notes

Two PRs are required, one per branch, as SonarCloud analyses `lts-2025` and `maintenance-3.1.x` independently. The commit is identical on both; the branches differ only in an unrelated comment line in `nuxeo-document-import.js`.


[WEBUI-2227]: https://hyland.atlassian.net/browse/WEBUI-2227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ