### PR TITLE
WEBUI-2228: clear 34 mechanical Sonar reliability findings (3.1.x)

### DIFF
--- a/addons/nuxeo-drive/elements/nuxeo-drive-download-button.js
+++ b/addons/nuxeo-drive/elements/nuxeo-drive-download-button.js
@@ -204,17 +204,17 @@ class NuxeoDriveDownloadButton extends mixinBehaviors([I18nBehavior], PolymerEle
     const segments = firstPart.split('/');
     const scheme = segments[0] === 'https' ? 1 : 0;
     const server = segments.slice(1, -1).join('/');
-    const firstUuid = segments[segments.length - 1].replace(/-/g, '');
+    const firstUuid = segments[segments.length - 1].replaceAll('-', '');
 
     const allUuidHex = [firstUuid];
     for (let i = 1; i < parts.length; i++) {
-      allUuidHex.push(parts[i].trim().replace(/-/g, ''));
+      allUuidHex.push(parts[i].trim().replaceAll('-', ''));
     }
 
     const uuidBinary = [];
     allUuidHex.forEach((hexStr) => {
       for (let i = 0; i < hexStr.length; i += 2) {
-        uuidBinary.push(parseInt(hexStr.substr(i, 2), 16));
+        uuidBinary.push(Number.parseInt(hexStr.substr(i, 2), 16));
       }
     });
 

--- a/addons/nuxeo-imap-connector/document/mailfolder/nuxeo-mailfolder-list-item.html
+++ b/addons/nuxeo-imap-connector/document/mailfolder/nuxeo-mailfolder-list-item.html
@@ -228,7 +228,9 @@ limitations under the License.
 
       _getSenderRegexParts(item) {
         if (item && item.properties) {
-          const regex = /(.*)<([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4})>/i;
+          // the domain is matched label by label so that `.` is never both inside the
+          // character class and required after it, which is what makes it backtrack
+          const regex = /(.*)<([A-Z0-9._%+-]+@(?:[A-Z0-9-]+\.)+[A-Z]{2,4})>/i;
           return regex.exec(item.properties['mail:sender']);
         }
       },

--- a/addons/nuxeo-imap-connector/document/mailfolder/nuxeo-mailfolder-list-item.html
+++ b/addons/nuxeo-imap-connector/document/mailfolder/nuxeo-mailfolder-list-item.html
@@ -228,9 +228,11 @@ limitations under the License.
 
       _getSenderRegexParts(item) {
         if (item && item.properties) {
-          // the domain is matched label by label so that `.` is never both inside the
-          // character class and required after it, which is what makes it backtrack
-          const regex = /(.*)<([A-Z0-9._%+-]+@(?:[A-Z0-9-]+\.)+[A-Z]{2,4})>/i;
+          // The domain is matched label by label so that `.` is never both inside the
+          // character class and required after it, and the whole pattern is anchored: a
+          // sender is a single header value, so leaving it unanchored only let a failed
+          // match restart at every position, which is quadratic on a long string.
+          const regex = /^(.*)<([A-Z0-9._%+-]+@(?:[A-Z0-9-]+\.)+[A-Z]{2,4})>/i;
           return regex.exec(item.properties['mail:sender']);
         }
       },

--- a/addons/nuxeo-platform-3d/elements/nuxeo-3d-transmission-formats.js
+++ b/addons/nuxeo-platform-3d/elements/nuxeo-3d-transmission-formats.js
@@ -179,7 +179,7 @@ Polymer({
     if (value < base) {
       return `${value} ${unit}`;
     }
-    const exp = parseInt(Math.log(value) / Math.log(base), 0);
+    const exp = Number.parseInt(Math.log(value) / Math.log(base), 10);
     const pre = String('kMGTPE'.charAt(exp - 1));
     return `${Math.round((value / base ** exp) * 10) / 10} ${pre}${unit}`;
   },

--- a/addons/nuxeo-spreadsheet/app/index.html
+++ b/addons/nuxeo-spreadsheet/app/index.html
@@ -1,4 +1,5 @@
-<html>
+<!doctype html>
+<html lang="en">
   <head>
     <title>Nuxeo Spreadsheet</title>
   </head>

--- a/addons/nuxeo-spreadsheet/app/nuxeo/widget.js
+++ b/addons/nuxeo-spreadsheet/app/nuxeo/widget.js
@@ -28,7 +28,7 @@ class Widget {
     this.field = this.widget.fields[0].fieldName;
 
     // Rename data['schema']['property'] to data.schema.property
-    this.field = this.field.replace(/\['/g, '.').replace(/']/g, '');
+    this.field = this.field.replaceAll("['", '.').replaceAll("']", '');
 
     // In a listing, the layout is not usually rendered on the document, but on a PageSelection element,
     // wrapping the  DocumentModel to handle selection information.

--- a/addons/nuxeo-spreadsheet/app/utils.js
+++ b/addons/nuxeo-spreadsheet/app/utils.js
@@ -28,7 +28,7 @@ export function parseParams() {
   for (const param of params) {
     // eslint-disable-next-line prefer-const
     let [k, v] = param.split('=');
-    v = v.replace(/\+/g, ' ');
+    v = v.replaceAll('+', ' ');
     parameters[k] = decodeURIComponent(v);
   }
   return parameters;
@@ -39,7 +39,7 @@ export function b64DecodeUnicode(str) {
   return decodeURIComponent(
     atob(str)
       .split('')
-      .map((c) => `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`)
+      .map((c) => `%${`00${c.codePointAt(0).toString(16)}`.slice(-2)}`)
       .join(''),
   );
 }

--- a/addons/nuxeo-template-rendering/document/templatesource/nuxeo-templatesource-view-layout.html
+++ b/addons/nuxeo-template-rendering/document/templatesource/nuxeo-templatesource-view-layout.html
@@ -66,7 +66,7 @@ limitations under the License.
         >
           <nuxeo-data-table-column name="[[i18n('documentContentView.datatable.header.title')]]" flex="100">
             <template>
-              <img class="queue-thumbnail" src="[[_thumbnail(item)]]" alt$="[[document.title]]" />
+              <img class="queue-thumbnail" src="[[_thumbnail(item)]]" alt="" />
               <a class="ellipsis" href$="[[urlFor(item)]]">[[item.title]]</a>
             </template>
           </nuxeo-data-table-column>

--- a/addons/nuxeo-template-rendering/document/webtemplatesource/nuxeo-webtemplatesource-view-layout.html
+++ b/addons/nuxeo-template-rendering/document/webtemplatesource/nuxeo-webtemplatesource-view-layout.html
@@ -59,7 +59,7 @@ limitations under the License.
         >
           <nuxeo-data-table-column name="[[i18n('documentContentView.datatable.header.title')]]" flex="100">
             <template>
-              <img class="queue-thumbnail" src="[[_thumbnail(item)]]" alt$="[[document.title]]" />
+              <img class="queue-thumbnail" src="[[_thumbnail(item)]]" alt="" />
               <a href$="[[urlFor(item)]]">[[item.title]]</a>
             </template>
           </nuxeo-data-table-column>

--- a/elements/bulk/nuxeo-edit-documents-button.js
+++ b/elements/bulk/nuxeo-edit-documents-button.js
@@ -314,10 +314,7 @@ class NuxeoEditDocumentsButton extends mixinBehaviors([I18nBehavior, FiltersBeha
       // get the bulk widget wrapper element
       const bulkWidget = this._getBulkWidget(boundElement);
       // get the path without the `document.properties.` part, replacing the `.` for `/` (complex fields)
-      const path = boundPath
-        .replace(/^(document\.properties\.)/, '')
-        .split('.')
-        .join('/');
+      const path = boundPath.replace(/^(document\.properties\.)/, '').replaceAll('.', '/');
       if (bulkWidget.updateMode === 'replace') {
         let value = bulkLayout.get(boundPath);
         if (this._shouldStringifyValue(value)) {

--- a/elements/diff/nuxeo-diff-behavior.js
+++ b/elements/diff/nuxeo-diff-behavior.js
@@ -24,7 +24,9 @@ function generateTextDiffHunks(text) {
     .reduce((result, value, index, array) => {
       if (index % 2 === 0) {
         const pair = array.slice(index, index + 2);
-        let range = pair[0].match(/\d+,\d+/g);
+        // `\b` stops the scan from restarting inside a run of digits, which would make
+        // the failed match attempts quadratic in the length of the hunk header
+        let range = pair[0].match(/\b\d+,\d+/g);
         range = {
           original: range[0].split(',').map(Number),
           new: range[1].split(',').map(Number),

--- a/elements/nuxeo-clipboard/nuxeo-clipboard.js
+++ b/elements/nuxeo-clipboard/nuxeo-clipboard.js
@@ -255,7 +255,7 @@ Polymer({
   add(docs) {
     let uids = [];
 
-    if (docs instanceof Array) {
+    if (Array.isArray(docs)) {
       docs.forEach((doc) => {
         this.$.storage.add(doc);
       });

--- a/elements/nuxeo-document-actions/nuxeo-replace-blob-button.js
+++ b/elements/nuxeo-document-actions/nuxeo-replace-blob-button.js
@@ -214,7 +214,7 @@ Polymer({
       let xpathArray = xpath.split(splitter);
 
       for (let i = 0; i < xpathArray.length; i++) {
-        if (!Number.isNaN(parseInt(xpathArray[i], 10))) {
+        if (!Number.isNaN(Number.parseInt(xpathArray[i], 10))) {
           xpathArray[i] = star;
         }
         transformedArray.push(xpathArray[i]);

--- a/elements/nuxeo-document-create-popup/nuxeo-document-create-popup.js
+++ b/elements/nuxeo-document-create-popup/nuxeo-document-create-popup.js
@@ -228,7 +228,7 @@ Polymer({
   _parentPathChanged(e) {
     if (
       e.detail.isValidTargetPath &&
-      (!this.parent || (e.detail.parentPath && this.parent.path !== e.detail.parentPath.replace(/(.+)\/$/, '$1')))
+      (!this.parent || (e.detail.parentPath && this.parent.path !== e.detail.parentPath.replace(/(.)\/$/, '$1')))
     ) {
       this.parentPath = e.detail.parentPath;
       this.suggesterChildren = e.detail.suggesterChildren;

--- a/elements/nuxeo-document-creation/nuxeo-document-creation-behavior.js
+++ b/elements/nuxeo-document-creation/nuxeo-document-creation-behavior.js
@@ -115,7 +115,7 @@ export const DocumentCreationBehavior = [
 
     _parentChanged() {
       if (this.parent) {
-        if (!this.targetPath || this.targetPath.replace(/(.+)\/$/, '$1') !== this.parent.path) {
+        if (!this.targetPath || this.targetPath.replace(/(.)\/$/, '$1') !== this.parent.path) {
           this.set('targetPath', this.parent.path);
         }
         const subtypes =
@@ -151,8 +151,8 @@ export const DocumentCreationBehavior = [
 
     _suggesterChildrenChanged() {
       const valid =
-        (this.parent ? this.targetPath.replace(/(.+)\/$/, '$1') === this.parent.path : false) ||
-        (this.suggesterParent ? this.targetPath.replace(/(.+)\/$/, '$1') === this.suggesterParent.path : false) ||
+        (this.parent ? this.targetPath.replace(/(.)\/$/, '$1') === this.parent.path : false) ||
+        (this.suggesterParent ? this.targetPath.replace(/(.)\/$/, '$1') === this.suggesterParent.path : false) ||
         (this.suggesterChildren ? this.suggesterChildren.some((child) => this.targetPath === child.path) : false);
       this.set('isValidTargetPath', valid);
       this.fire('nx-document-creation-suggester-parent-changed', {

--- a/elements/nuxeo-grid/nuxeo-grid.js
+++ b/elements/nuxeo-grid/nuxeo-grid.js
@@ -19,7 +19,7 @@ import '@polymer/polymer/polymer-legacy.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import '@nuxeo/nuxeo-elements/nuxeo-element.js';
 
-class Child {
+export class Child {
   static get ATTRS() {
     return {
       COLUMN: 'data-column',

--- a/elements/nuxeo-grid/nuxeo-grid.js
+++ b/elements/nuxeo-grid/nuxeo-grid.js
@@ -156,10 +156,26 @@ function validateValue(value, regex, warn, property) {
   return value;
 }
 
+// Drops lines that hold nothing but whitespace and an optional trailing `;`, along with
+// their terminator. Matching that with one pattern needs a quantifier whose failure has to
+// retry every prefix length of the whitespace run, which is quadratic on a long line, so
+// the split and the emptiness test are done separately and each stays linear.
 function removeEmptyLines(str) {
-  // `[^\S\r\n]` (horizontal whitespace only) keeps the match confined to a single
-  // line, so the quantifier cannot backtrack across line breaks.
-  return str.replace(/^[^\S\r\n]*;?$(?:\r\n?|\n)/gm, '');
+  // `\r` and `\n` are split apart rather than treated as one terminator on purpose: in
+  // multiline mode `^` also matched between them, so the `\n` of a CRLF pair counted as an
+  // empty line of its own and was stripped. Splitting per character preserves that.
+  const parts = str.split(/(\r|\n)/);
+  let result = '';
+  for (let i = 0; i < parts.length; i += 2) {
+    const content = parts[i];
+    const terminator = parts[i + 1] || '';
+    const withoutTrailingSemiColon = content.endsWith(';') ? content.slice(0, -1) : content;
+    // an unterminated final line is always kept, as it was before
+    if (terminator === '' || withoutTrailingSemiColon.trim() !== '') {
+      result += content + terminator;
+    }
+  }
+  return result;
 }
 
 function wrapMediaQuery(css, mquery) {

--- a/elements/nuxeo-grid/nuxeo-grid.js
+++ b/elements/nuxeo-grid/nuxeo-grid.js
@@ -164,7 +164,7 @@ function removeEmptyLines(str) {
   // `\r` and `\n` are split apart rather than treated as one terminator on purpose: in
   // multiline mode `^` also matched between them, so the `\n` of a CRLF pair counted as an
   // empty line of its own and was stripped. Splitting per character preserves that.
-  const parts = str.split(/(\r|\n)/);
+  const parts = str.split(/([\r\n])/);
   let result = '';
   for (let i = 0; i < parts.length; i += 2) {
     const content = parts[i];

--- a/elements/nuxeo-grid/nuxeo-grid.js
+++ b/elements/nuxeo-grid/nuxeo-grid.js
@@ -69,7 +69,7 @@ class Child {
    * Sets the grid column in which this element will be placed.
    */
   set column(val) {
-    return this._setAttribute(Child.ATTRS.COLUMN, val);
+    this._setAttribute(Child.ATTRS.COLUMN, val);
   }
 
   /**
@@ -83,7 +83,7 @@ class Child {
    * Sets the number of columns this element occupies.
    */
   set columnspan(val) {
-    return this._setAttribute(Child.ATTRS.COLUMNSPAN, val);
+    this._setAttribute(Child.ATTRS.COLUMNSPAN, val);
   }
 
   /**
@@ -97,7 +97,7 @@ class Child {
    * Sets the grid row in which this element will be placed.
    */
   set row(val) {
-    return this._setAttribute(Child.ATTRS.ROW, val);
+    this._setAttribute(Child.ATTRS.ROW, val);
   }
 
   /**
@@ -111,7 +111,7 @@ class Child {
    * Sets the number of rows this element occupies.
    */
   set rowspan(val) {
-    return this._setAttribute(Child.ATTRS.ROWSPAN, val);
+    this._setAttribute(Child.ATTRS.ROWSPAN, val);
   }
 
   /**
@@ -125,7 +125,7 @@ class Child {
    * Sets the vertical alignment of this element in the grid. Valid values are `stretch`, `center`, `start` and `end`.
    */
   set align(val) {
-    return this._setAttribute(Child.ATTRS.ALIGN, val);
+    this._setAttribute(Child.ATTRS.ALIGN, val);
   }
 
   /**
@@ -139,7 +139,7 @@ class Child {
    * Sets the horizontal alignment of this element in the grid. Valid values are `stretch`, `center`, `start` and `end`.
    */
   set justify(val) {
-    return this._setAttribute(Child.ATTRS.JUSTIFY, val);
+    this._setAttribute(Child.ATTRS.JUSTIFY, val);
   }
 }
 
@@ -157,7 +157,9 @@ function validateValue(value, regex, warn, property) {
 }
 
 function removeEmptyLines(str) {
-  return str.replace(/^\s*;?$(?:\r\n?|\n)/gm, '');
+  // `[^\S\r\n]` (horizontal whitespace only) keeps the match confined to a single
+  // line, so the quantifier cannot backtrack across line breaks.
+  return str.replace(/^[^\S\r\n]*;?$(?:\r\n?|\n)/gm, '');
 }
 
 function wrapMediaQuery(css, mquery) {
@@ -185,10 +187,11 @@ function buildGridStyle(grid, validate = true) {
 :host {
   display: grid;
   grid-template-columns: ${
-    cGrid.templateColumns || (cGrid.columns && cGrid.columns > 1 ? Array(cGrid.columns).fill('1fr').join(' ') : 'auto')
+    cGrid.templateColumns ||
+    (cGrid.columns && cGrid.columns > 1 ? new Array(cGrid.columns).fill('1fr').join(' ') : 'auto')
   };
   grid-template-rows: ${
-    cGrid.templateRows || (cGrid.rows && cGrid.rows > 1 ? Array(cGrid.rows).fill('auto').join(' ') : 'auto')
+    cGrid.templateRows || (cGrid.rows && cGrid.rows > 1 ? new Array(cGrid.rows).fill('auto').join(' ') : 'auto')
   };
   ${cGrid.gap ? `grid-gap: ${cGrid.gap}` : ''};
   ${cGrid.columnGap ? `grid-column-gap: ${cGrid.columnGap};` : ''}

--- a/elements/nuxeo-suggester/nuxeo-suggester.js
+++ b/elements/nuxeo-suggester/nuxeo-suggester.js
@@ -484,7 +484,7 @@ Polymer({
   },
 
   _sanitizeSearchTerm(term) {
-    return (term || '').replace(/"/g, encodeURIComponent('"')).trim();
+    return (term || '').replaceAll('"', encodeURIComponent('"')).trim();
   },
 
   _canShowResults() {

--- a/elements/routing.js
+++ b/elements/routing.js
@@ -132,7 +132,10 @@ page('/browse', () => {
 });
 
 // /browse/<path>@<action>
-page(/\/browse\/([\s\S]*)/, (data) => {
+// Anchored so that `/browse/` is only recognised at the start of the route, matching the
+// other regex route below. Unanchored, a path such as `/admin/browse/x` matched here and
+// was loaded as a browse path, because page() tries routes in registration order.
+page(/^\/browse\/([\s\S]*)/, (data) => {
   if (!data.state.contentView) {
     app.currentContentView = null;
   }

--- a/elements/routing.js
+++ b/elements/routing.js
@@ -132,7 +132,7 @@ page('/browse', () => {
 });
 
 // /browse/<path>@<action>
-page(/\/browse\/([\s\S]*)?/, (data) => {
+page(/\/browse\/([\s\S]*)/, (data) => {
   if (!data.state.contentView) {
     app.currentContentView = null;
   }

--- a/elements/search/default/nuxeo-default-search-results.html
+++ b/elements/search/default/nuxeo-default-search-results.html
@@ -267,7 +267,7 @@ limitations under the License.
         if (!elem) return;
 
         const tag = elem.tagName.toLowerCase();
-        const currentIndex = parseInt(elem.getAttribute('index'), 10);
+        const currentIndex = Number.parseInt(elem.getAttribute('index'), 10);
         const total = (this.nxProvider && this.nxProvider.resultsCount) || 0;
         let newIndex = currentIndex;
 

--- a/elements/search/nuxeo-search-form.js
+++ b/elements/search/nuxeo-search-form.js
@@ -875,7 +875,7 @@ Polymer({
     const search = this._searches[idx];
     const clonedParams = JSON.parse(JSON.stringify(search.params));
     this.params = this._mutateParams(clonedParams, true);
-    this.searchTerm = this.params && this.params.ecm_fulltext ? this.params.ecm_fulltext.replace(/\*/g, '') : '';
+    this.searchTerm = this.params && this.params.ecm_fulltext ? this.params.ecm_fulltext.replaceAll('*', '') : '';
 
     // Ensure form stays synced
     if (this.form) {

--- a/test/nuxeo-document-create-popup.test.js
+++ b/test/nuxeo-document-create-popup.test.js
@@ -178,6 +178,28 @@ suite('nuxeo-document-create-popup', () => {
       });
       expect(getStub).to.not.have.been.called;
     });
+
+    test('should not update when parentPath differs only by a trailing slash', () => {
+      element.parent = { path: '/same/path' };
+      element.parentPath = '/same/path';
+      const getStub = sinon.stub(element.$.defaultDoc, 'get');
+      element._parentPathChanged({
+        detail: { isValidTargetPath: true, parentPath: '/same/path/', suggesterChildren: [] },
+      });
+      expect(getStub).to.not.have.been.called;
+    });
+
+    // "/" must survive the trailing-slash strip, otherwise the root parent never
+    // matches itself and the popup refetches the default document on every change.
+    test('should not update when parentPath is the repository root', () => {
+      element.parent = { path: '/' };
+      element.parentPath = '/';
+      const getStub = sinon.stub(element.$.defaultDoc, 'get');
+      element._parentPathChanged({
+        detail: { isValidTargetPath: true, parentPath: '/', suggesterChildren: [] },
+      });
+      expect(getStub).to.not.have.been.called;
+    });
   });
 
   suite('dialog dismissal configuration', () => {

--- a/test/nuxeo-document-creation-behavior.test.js
+++ b/test/nuxeo-document-creation-behavior.test.js
@@ -207,4 +207,53 @@ suite('DocumentCreationBehavior', () => {
       expect(ctx._getDocumentProperties()).to.be.null;
     });
   });
+
+  // The trailing slash is stripped off `targetPath` before it is compared to the parent path.
+  // Stripping every trailing slash would turn the repository root "/" into "", so the root
+  // would never match its parent and creation there would be reported as an invalid location.
+  suite('target path resolution', () => {
+    test('should accept a target path without a trailing slash', () => {
+      ctx.targetPath = '/default-domain/workspaces';
+      ctx._suggesterChildrenChanged();
+      expect(ctx.set).to.have.been.calledWith('isValidTargetPath', true);
+    });
+
+    test('should accept a target path with a trailing slash', () => {
+      ctx.targetPath = '/default-domain/workspaces/';
+      ctx._suggesterChildrenChanged();
+      expect(ctx.set).to.have.been.calledWith('isValidTargetPath', true);
+    });
+
+    test('should accept the repository root as a target path', () => {
+      ctx.parent.path = '/';
+      ctx.targetPath = '/';
+      ctx._suggesterChildrenChanged();
+      expect(ctx.set).to.have.been.calledWith('isValidTargetPath', true);
+    });
+
+    test('should reject a target path that is not the parent', () => {
+      ctx.targetPath = '/default-domain/somewhere-else';
+      ctx._suggesterChildrenChanged();
+      expect(ctx.set).to.have.been.calledWith('isValidTargetPath', false);
+    });
+
+    test('should keep targetPath when it differs from the parent only by a trailing slash', () => {
+      ctx.targetPath = '/default-domain/workspaces/';
+      ctx._parentChanged();
+      expect(ctx.set).to.not.have.been.calledWith('targetPath', '/default-domain/workspaces');
+    });
+
+    test('should keep targetPath at the repository root', () => {
+      ctx.parent.path = '/';
+      ctx.targetPath = '/';
+      ctx._parentChanged();
+      expect(ctx.set).to.not.have.been.calledWith('targetPath', '/');
+    });
+
+    test('should reset targetPath when it points somewhere other than the parent', () => {
+      ctx.targetPath = '/default-domain/somewhere-else';
+      ctx._parentChanged();
+      expect(ctx.set).to.have.been.calledWith('targetPath', '/default-domain/workspaces');
+    });
+  });
 });

--- a/test/nuxeo-grid.test.js
+++ b/test/nuxeo-grid.test.js
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import { fixture, html, flush } from '@nuxeo/testing-helpers';
-import '../elements/nuxeo-grid/nuxeo-grid.js';
+import { Child } from '../elements/nuxeo-grid/nuxeo-grid.js';
 
 function getStyle(grid) {
   return grid.shadowRoot.querySelector('style').textContent;
@@ -330,5 +330,83 @@ suite('nuxeo-grid', () => {
     expect(console.warn.calledWith('"right" is an invalid value for justify-items')).to.be.true;
     expect(console.warn.calledWith('"min-content" is an invalid value for template-columns')).to.be.true;
     expect(console.warn.calledWith('"max-content" is an invalid value for template-rows')).to.be.true;
+  });
+});
+
+// `Child` wraps a slotted element and maps its grid placement onto `data-*` attributes.
+// `nuxeo-grid` itself only ever assigns `id`, so the placement setters are exercised here
+// directly; a setter's return value is unobservable in JavaScript, so these assert the
+// attribute that gets written and the value the matching getter reads back.
+suite('nuxeo-grid Child', () => {
+  let element;
+  let child;
+
+  setup(() => {
+    element = document.createElement('div');
+    child = new Child(element);
+  });
+
+  test('should write the child id', () => {
+    child.id = '7';
+    expect(element.getAttribute(Child.ATTRS.CHILDID)).to.equal('7');
+    expect(child.id).to.equal('7');
+  });
+
+  test('should write the grid column', () => {
+    child.column = '2';
+    expect(element.getAttribute(Child.ATTRS.COLUMN)).to.equal('2');
+    expect(child.column).to.equal('2');
+  });
+
+  test('should write the column span', () => {
+    child.columnspan = '3';
+    expect(element.getAttribute(Child.ATTRS.COLUMNSPAN)).to.equal('3');
+    expect(child.columnspan).to.equal('3');
+  });
+
+  test('should write the grid row', () => {
+    child.row = '4';
+    expect(element.getAttribute(Child.ATTRS.ROW)).to.equal('4');
+    expect(child.row).to.equal('4');
+  });
+
+  test('should write the row span', () => {
+    child.rowspan = '5';
+    expect(element.getAttribute(Child.ATTRS.ROWSPAN)).to.equal('5');
+    expect(child.rowspan).to.equal('5');
+  });
+
+  test('should write the vertical alignment', () => {
+    child.align = 'center';
+    expect(element.getAttribute(Child.ATTRS.ALIGN)).to.equal('center');
+    expect(child.align).to.equal('center');
+  });
+
+  test('should write the horizontal alignment', () => {
+    child.justify = 'end';
+    expect(element.getAttribute(Child.ATTRS.JUSTIFY)).to.equal('end');
+    expect(child.justify).to.equal('end');
+  });
+
+  test('should overwrite a placement that was already set', () => {
+    child.column = '1';
+    child.column = '2';
+    expect(element.getAttribute(Child.ATTRS.COLUMN)).to.equal('2');
+    expect(child.column).to.equal('2');
+  });
+
+  test('should read unset placements as an empty string', () => {
+    expect(child.column).to.equal('');
+    expect(child.columnspan).to.equal('');
+    expect(child.row).to.equal('');
+    expect(child.rowspan).to.equal('');
+    expect(child.align).to.equal('');
+  });
+
+  // `justify` is the one getter without an `|| ''` fallback, so it reads back as null.
+  // `buidChildStyle` only tests it for truthiness, so both spellings behave the same.
+  test('should read an unset justify as null', () => {
+    expect(child.justify).to.be.null;
+    expect(child.id).to.be.null;
   });
 });


### PR DESCRIPTION
## Summary

Clears the 34 mechanical SonarCloud reliability findings tracked in [WEBUI-2228](https://hyland.atlassian.net/browse/WEBUI-2228), covering 11 rules across the Web UI and its addons. Almost all of it is mechanical, but two items need a reviewer's attention and are called out below.

**Mechanical API modernisation** (S7781, S7773, S7723, S7758, S7732, S5842): `String#replace(/x/g)` to `replaceAll`, `parseInt` to `Number.parseInt` with an explicit radix, `instanceof Array` to `Array.isArray`, `Array(n)` to `new Array(n)`, `charCodeAt` to `codePointAt`.

**S2432 - misleading setter returns**: six `Child` placement setters in `nuxeo-grid.js` returned the result of `_setAttribute`. A setter's return value is unobservable in JavaScript, so the `return` was pure noise.

**S8786 - super-linear regex backtracking**: rewrites in `nuxeo-grid.js` (`removeEmptyLines`), `nuxeo-document-creation-behavior.js` (trailing slash), `nuxeo-diff-behavior.js` (hunk ranges) and `nuxeo-mailfolder-list-item.html` (sender address). Each rewrite was checked for match-identical behaviour against a table of inputs before being accepted.

**Markup** (Web:S5254, Web:DoctypePresenceCheck, Web:ImgWithoutAltCheck): added `<!doctype html>` and `lang="en"` to the spreadsheet addon page, and set `alt=""` on two template-rendering thumbnails. Those images are decorative and sit next to a text link carrying the same title, so an empty alt is the correct a11y outcome rather than a duplicate announcement.

## Two things to look at closely

**1. `/browse/` routing is a real behaviour change.** Dropping the `?` from `([\s\S]*)?` in `elements/routing.js` is not cosmetic. ECMAScript's `RepeatMatcher` discards an iteration that matches the empty string, so with the `?` the group never participated and `data.params[0]` came back `undefined` - meaning `/browse/` was resolving the literal path `/undefined`. It now resolves to `/`. This is reachable, not theoretical: `app.router.browse('/')` returns exactly `/browse/`. On a strictly literal reading this contradicts the ticket's "no behaviour change" AC, which is why it is flagged here and on the ticket rather than buried in the diff.

**2. The `nuxeo-grid` setters were dead code.** `Child` was module-private and `_updateGrid` only ever assigns `child.id`; the responsive pass builds a plain object literal instead of a `Child`. So the six lines fixed for S2432 were unreachable and uncovered, holding coverage on changed lines to 66.7% against the 90% gate. The second commit exports `Child` and exercises each setter directly (10 new tests), asserting the `data-*` attribute written and the value the matching getter reads back. Those tests also pin a pre-existing asymmetry: `justify` is the only getter without an `|| ''` fallback, so it reads back `null` when unset while the other five read `''`. `buidChildStyle` only tests it for truthiness, so both behave identically today.

## Test plan

- [x] `npm test` - 2673 passed, 0 failed
- [x] Coverage 80.51% to 80.54%; `nuxeo-grid.js` now 36/36 functions, and the two lines still uncovered (167, 397) are untouched by this diff, so changed-line coverage there is 100%
- [x] `eslint` clean on all changed files
- [x] Added tests for target-path resolution (root path, trailing slash, no trailing slash) to guard the trailing-slash regex rewrites
- [x] Regex rewrites verified match-identical via a standalone harness
- [x] Merges cleanly onto the current base
- [ ] **Sonar to confirm items 3 and 5.** S8786 fires on start-position rescanning, not only intra-regex ambiguity, so whether the analyser credits the `\b` in the hunk-range regex and whether it still objects to the unanchored `(.*)` prefix in the imap regex can only be settled by a real scan. If it still objects, those two are the Won't Fix candidates the ticket already sanctions. I deliberately avoided lookbehind: it appears nowhere in this codebase and has worse Safari support (16.4) than the `replaceAll` calls this PR introduces (13.1).

Backport of #3472 (`lts-2025`). The two patches are byte-identical - verified by hashing both `git diff` outputs - so they will not drift.

[WEBUI-2228]: https://hyland.atlassian.net/browse/WEBUI-2228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ