### PR TITLE
WEBUI-2231: exclude vendored three.js loaders and controls from Sonar analysis [lts-2025]

### DIFF
--- a/addons/nuxeo-platform-3d/README.md
+++ b/addons/nuxeo-platform-3d/README.md
@@ -2,3 +2,5 @@ Following the resolution of [WEBUI-237](https://jira.nuxeo.com/browse/WEBUI-237)
 - The `threejs` dependency was updated from `v0.81.0` to `v0.125.0`.
 - The `loaders` directory was added with the (`v0.81.0`) loader utilities necessary to maintain the load of GLTF v1.0 models. These are now imported via ESM.
 - The `controls` directory was added with the (`v0.81.0`) control utilities so that they can now be imported via ESM.
+
+Both of those directories hold code vendored verbatim from three.js and are excluded from SonarCloud analysis. See [`loaders/README.md`](loaders/README.md) and [`controls/README.md`](controls/README.md) for their provenance and for why they must not be edited in place.

--- a/addons/nuxeo-platform-3d/README.md
+++ b/addons/nuxeo-platform-3d/README.md
@@ -1,5 +1,5 @@
 Following the resolution of [WEBUI-237](https://jira.nuxeo.com/browse/WEBUI-237):
-- The `threejs` dependency was updated from `v0.81.0` to `v0.125.0`.
+- The `three` dependency was updated from `v0.81.0` to `v0.125.0`.
 - The `loaders` directory was added with the (`v0.81.0`) loader utilities necessary to maintain the load of GLTF v1.0 models. These are now imported via ESM.
 - The `controls` directory was added with the (`v0.81.0`) control utilities so that they can now be imported via ESM.
 

--- a/addons/nuxeo-platform-3d/controls/README.md
+++ b/addons/nuxeo-platform-3d/controls/README.md
@@ -1,0 +1,17 @@
+# Vendored three.js controls — do not edit
+
+`OrbitControls.js` is **third-party code copied from [three.js](https://github.com/mrdoob/three.js) r81 (`v0.81.0`)** `examples/js/controls/OrbitControls.js`. It is not Nuxeo-authored and keeps its original upstream authorship header (`@author qiao`, `@author mrdoob`, and others).
+
+## Why the copy is still here
+
+[WEBUI-237](https://jira.nuxeo.com/browse/WEBUI-237) upgraded the `threejs` dependency from `v0.81.0` to `v0.125.0` (it is `^0.184.0` today) and copied this file in so that the orbit/zoom/pan controls could be imported as an ES module. `nuxeo-3d-viewer._setupControls()` instantiates it for every 3D preview, so it is live code.
+
+## Local modifications
+
+Limited to what ES module imports require: a named `export { OrbitControls }` at the end of the file. The control logic is upstream, and the file still expects a global `THREE`.
+
+## SonarCloud
+
+This directory is listed in `sonar.exclusions` in `sonar-project.properties` and is **deliberately not analysed** — see [WEBUI-2231](https://hyland.atlassian.net/browse/WEBUI-2231). Patching an upstream file to satisfy a linter would fork it permanently and make any future refresh from three.js harder. The exclusion is scoped to `loaders/` and `controls/` only; the Nuxeo-authored parts of this addon (`elements/`, `document/`, `index.js`) are still analysed.
+
+Do not "fix" findings in this directory. If the controls need to change, prefer moving to the maintained `OrbitControls` shipped with the npm `three` dependency over editing this copy.

--- a/addons/nuxeo-platform-3d/controls/README.md
+++ b/addons/nuxeo-platform-3d/controls/README.md
@@ -4,7 +4,7 @@
 
 ## Why the copy is still here
 
-[WEBUI-237](https://jira.nuxeo.com/browse/WEBUI-237) upgraded the `threejs` dependency from `v0.81.0` to `v0.125.0` (it is `^0.184.0` today) and copied this file in so that the orbit/zoom/pan controls could be imported as an ES module. `nuxeo-3d-viewer._setupControls()` instantiates it for every 3D preview, so it is live code.
+[WEBUI-237](https://jira.nuxeo.com/browse/WEBUI-237) upgraded the `three` dependency from `v0.81.0` to `v0.125.0` (it is `^0.184.0` today) and copied this file in so that the orbit/zoom/pan controls could be imported as an ES module. `nuxeo-3d-viewer._setupControls()` instantiates it for every 3D preview, so it is live code.
 
 ## Local modifications
 

--- a/addons/nuxeo-platform-3d/loaders/README.md
+++ b/addons/nuxeo-platform-3d/loaders/README.md
@@ -1,0 +1,31 @@
+# Vendored three.js loaders — do not edit
+
+The files in this directory are **third-party code copied from [three.js](https://github.com/mrdoob/three.js) r81 (`v0.81.0`)** `examples/js/loaders/`. They are not Nuxeo-authored. They keep their original upstream authorship headers (`@author mrdoob`, and others).
+
+| File                        | Upstream origin (three.js r81)                    |
+| --------------------------- | ------------------------------------------------- |
+| `GLTFLoader.js`             | `examples/js/loaders/GLTFLoader.js`               |
+| `gltf/glTFLoader.js`        | `examples/js/loaders/gltf/glTFLoader.js`          |
+| `gltf/glTF-parser.js`       | `examples/js/loaders/gltf/glTF-parser.js`         |
+| `gltf/glTFLoaderUtils.js`   | `examples/js/loaders/gltf/glTFLoaderUtils.js`     |
+| `gltf/glTFAnimation.js`     | `examples/js/loaders/gltf/glTFAnimation.js`       |
+| `gltf/glTFShaders.js`       | `examples/js/loaders/gltf/glTFShaders.js`         |
+
+## Why the copies are still here
+
+[WEBUI-237](https://jira.nuxeo.com/browse/WEBUI-237) upgraded the `threejs` dependency from `v0.81.0` to `v0.125.0` (it is `^0.184.0` today). Current three.js no longer ships these ES5 example scripts, and its modern `GLTFLoader` reads glTF 2.0 only — it cannot load the glTF 1.0 models that existing 3D documents still hold. The r81 copies were therefore kept so that `nuxeo-3d-viewer` can continue to render them.
+
+Both loader generations are live; neither is dead code. `nuxeo-3d-viewer._loaderChanged()` picks between them by transmission format:
+
+- `loader === 'complete'` → `gltf/glTFLoader.js` (the older glTF 1.0 loader)
+- otherwise → `GLTFLoader.js`
+
+## Local modifications
+
+Limited to what ES module imports require: named `export { ... }` statements at the end of each file, relative `import` statements between them, and a small number of strict-mode fixes noted inline. The loader logic itself is upstream. These files still expect a global `THREE`.
+
+## SonarCloud
+
+This directory is listed in `sonar.exclusions` in `sonar-project.properties` and is **deliberately not analysed** — see [WEBUI-2231](https://hyland.atlassian.net/browse/WEBUI-2231). Patching upstream files to satisfy a linter would fork them permanently and make any future refresh from three.js harder. The exclusion is scoped to `loaders/` and `controls/` only; the Nuxeo-authored parts of this addon (`elements/`, `document/`, `index.js`) are still analysed.
+
+Do not "fix" findings in this directory. If these loaders need to change, the right move is to replace the vendored copies with a supported upstream path (for example, converting stored glTF 1.0 assets so the npm `three` loader can be used), not to edit them in place.

--- a/addons/nuxeo-platform-3d/loaders/README.md
+++ b/addons/nuxeo-platform-3d/loaders/README.md
@@ -13,7 +13,7 @@ The files in this directory are **third-party code copied from [three.js](https:
 
 ## Why the copies are still here
 
-[WEBUI-237](https://jira.nuxeo.com/browse/WEBUI-237) upgraded the `threejs` dependency from `v0.81.0` to `v0.125.0` (it is `^0.184.0` today). Current three.js no longer ships these ES5 example scripts, and its modern `GLTFLoader` reads glTF 2.0 only — it cannot load the glTF 1.0 models that existing 3D documents still hold. The r81 copies were therefore kept so that `nuxeo-3d-viewer` can continue to render them.
+[WEBUI-237](https://jira.nuxeo.com/browse/WEBUI-237) upgraded the `three` dependency from `v0.81.0` to `v0.125.0` (it is `^0.184.0` today). Current three.js no longer ships these ES5 example scripts, and its modern `GLTFLoader` reads glTF 2.0 only — it cannot load the glTF 1.0 models that existing 3D documents still hold. The r81 copies were therefore kept so that `nuxeo-3d-viewer` can continue to render them.
 
 Both loader generations are live; neither is dead code. `nuxeo-3d-viewer._loaderChanged()` picks between them by transmission format:
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -24,7 +24,7 @@ sonar.inclusions=**/*.js,**/*.html,**/*.json,**/*.css,**/*.yaml,**/*.yml
 #
 # addons/nuxeo-platform-3d/loaders/** and .../controls/** are vendored third-party code: the
 # glTF 1.0 loader utilities and OrbitControls taken verbatim from three.js r81 (v0.81.0)
-# examples/js, kept when the threejs dependency was upgraded (see WEBUI-237 and the READMEs in
+# examples/js, kept when the npm three dependency was upgraded (see WEBUI-237 and the READMEs in
 # both directories). Modern three.js no longer ships these ES5 example scripts and its current
 # GLTFLoader cannot read glTF 1.0, so nuxeo-3d-viewer still needs the r81 copies for documents
 # whose transmission format is "complete". They keep their upstream authorship headers and are

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,6 +21,20 @@ sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.inclusions=**/*.js,**/*.html,**/*.json,**/*.css,**/*.yaml,**/*.yml
 
 # Exclude build output, node_modules, generated files, vendor and coverage
+#
+# addons/nuxeo-platform-3d/loaders/** and .../controls/** are vendored third-party code: the
+# glTF 1.0 loader utilities and OrbitControls taken verbatim from three.js r81 (v0.81.0)
+# examples/js, kept when the threejs dependency was upgraded (see WEBUI-237 and the READMEs in
+# both directories). Modern three.js no longer ships these ES5 example scripts and its current
+# GLTFLoader cannot read glTF 1.0, so nuxeo-3d-viewer still needs the r81 copies for documents
+# whose transmission format is "complete". They keep their upstream authorship headers and are
+# not Nuxeo-authored: patching them to satisfy a linter would fork an upstream file permanently
+# and make any future refresh harder, so they are deliberately not analysed. See WEBUI-2231.
+#
+# Scoped to loaders/ and controls/ only — the rest of the addon (elements/, document/, index.js)
+# is Nuxeo-authored and stays in analysis. Coverage is unaffected: the whole addon is already
+# outside the coverage denominator via addons/nuxeo-platform-3d/** in sonar.coverage.exclusions
+# below, so this changes no coverage metric and cannot move the quality gate.
 sonar.exclusions=\
   **/node_modules/**,\
   **/dist/**,\
@@ -37,6 +51,8 @@ sonar.exclusions=\
   server/**,\
   addons/**/vendor/**,\
   addons/**/webpack.config.js,\
+  addons/nuxeo-platform-3d/loaders/**,\
+  addons/nuxeo-platform-3d/controls/**,\
   i18n/**/*.json
 
 # Exclude files from coverage metrics that cannot be practically covered by unit tests.


### PR DESCRIPTION
https://hyland.atlassian.net/browse/WEBUI-2231

## Summary

Excludes the vendored three.js code in `addons/nuxeo-platform-3d/loaders/**` and `addons/nuxeo-platform-3d/controls/**` from SonarCloud analysis, closing the 18 open RELIABILITY findings that sit in files we did not write and documenting where those files came from.

No product code is touched. The change is two entries in `sonar.exclusions`, a comment block explaining them, and three markdown files.

**The exclusion lives in `sonar-project.properties`, not in the SonarCloud UI.** Marking 18 issues Won't Fix by hand would leave no trace in version control and would have to be redone after any re-analysis or upstream refresh. As configuration it applies automatically and is reviewable.

One wrinkle on the file format worth knowing for future edits: a `#` comment cannot sit inside a backslash-continued properties value, because `java.util.Properties` only treats `#` as a comment at the start of a logical line and would otherwise swallow it into the value. The explanation therefore goes in the comment block above `sonar.exclusions` rather than inline beside the two new entries.

### Findings closed

| Rule | Count | Description |
| --- | --- | --- |
| `javascript:S6861` | 9 | Exporting mutable `let` binding, use `const` |
| `javascript:S1763` | 3 | Unreachable code |
| `javascript:S7758` | 3 | Prefer `String#codePointAt()` over `charCodeAt()` |
| `javascript:S8786` | 2 | Regex with super-linear backtracking |
| `javascript:S1656` | 1 | Variable assigned to itself |

Spread over `loaders/gltf/glTFLoader.js` (6), `loaders/gltf/glTFAnimation.js` (3), `loaders/gltf/glTFLoaderUtils.js` (3), `loaders/gltf/glTFShaders.js` (3), `loaders/GLTFLoader.js` (2) and `controls/OrbitControls.js` (1).

### Provenance

`loaders/README.md` and `controls/README.md` record that these files are three.js r81 (`v0.81.0`) `examples/js` sources, kept when WEBUI-237 upgraded the dependency (now `three@^0.184.0`), because current three.js no longer ships these ES5 example scripts and its modern `GLTFLoader` cannot read the glTF 1.0 models existing 3D documents still hold. They retain their upstream authorship headers; local changes are limited to ESM conversion (named exports, relative imports between them) and they still expect a global `THREE`. Both READMEs say plainly that findings there must not be "fixed" in place and that the right move is to return to a supported upstream path. The addon `README.md` points at both.

## Notes on the ticket's open questions

- **Both loader generations are live — deleting `loaders/gltf/**` is not available.** The ticket suggested five minutes of checking whether that tree is dead code superseded by `loaders/GLTFLoader.js`, which would have closed 15 findings outright. It is not dead: `nuxeo-3d-viewer._loaderChanged()` instantiates the older glTF 1.0 loader when `loader === 'complete'` and the newer one otherwise, so both are reachable from the viewer. This PR therefore takes the exclusion route the ticket scoped, and the QA implication of the deletion alternative does not arise.
- **Coverage cannot move, so the quality-gate re-check has nothing to catch.** `addons/nuxeo-platform-3d/**` is already listed in `sonar.coverage.exclusions`, so every `.js` in the addon was outside the coverage denominator before this change. Verified mechanically rather than assumed.
- **Both the README and the inline-comment options were taken**, since the ticket allowed either and they serve different readers: the comment answers "why is this exclusion here" for someone auditing the Sonar config, the READMEs answer "why must I not edit this file" for someone opening the loader.

## Verification

The scoping was checked mechanically, not by eye. A throwaway script parsed `sonar-project.properties` the way `java.util.Properties` would — honouring comments and backslash continuations — and glob-matched the resulting exclusion list against the repo's tracked files. It confirmed:

- the properties value parses into 18 clean entries, with no comment text or stray whitespace leaked into it by the new lines;
- exactly the 7 vendored files are excluded — 6 under `loaders/`, 1 under `controls/`;
- every Nuxeo-authored file in the addon (`elements/`, `document/`, `index.js`) is still analysed;
- `elements/nuxeo-3d-transmission-formats.js` specifically is still analysed, so the ticket's canary finding (`javascript:S7773` at line 182) must still report — this is the AC 2 check that the exclusion is not over-broad;
- repo-wide, nothing outside `loaders/`/`controls/` is matched by the two added patterns;
- every `.js` in the addon was already coverage-excluded before the change.

## Test plan

- [x] No product code changed — nothing to exercise at runtime, and per the ticket no QA sub-task is needed
- [x] Exclusion scoping and properties parsing verified as described above
- [ ] After merge, confirm on SonarCloud that the 18 RELIABILITY findings under `loaders/` and `controls/` are gone from the open/confirmed view for this branch
- [ ] Confirm `elements/nuxeo-3d-transmission-formats.js:182` (`javascript:S7773`) is still listed, proving the exclusion is correctly scoped
- [ ] Confirm the quality gate still passes and reported coverage is unchanged

## Related

- Paired PR for `maintenance-3.1.x`: https://github.com/nuxeo/nuxeo-web-ui/pull/3483 — same change, cherry-picked with no conflicts. The two patches are byte-identical; the only difference between the branches was a pre-existing trailing newline in `sonar-project.properties`.
- The other 693 reliability findings are triaged under the sibling tickets (WEBUI-2227 real defects, WEBUI-2228 mechanical cleanups, WEBUI-2229 `role="widget"`, WEBUI-2230 label association). This PR touches none of their files, so it should not conflict with them.
- Longer term, replacing the vendored copies with the npm `three` dependency would remove this exclusion entirely. That needs the stored glTF 1.0 assets dealt with and a 3D viewer regression pass, so it belongs in its own ticket rather than here.
