### PR TITLE
ELEMENTS-1806: display HTML notes as stored instead of through Quill

### DIFF
--- a/elements/nuxeo-note-editor/nuxeo-note-editor.js
+++ b/elements/nuxeo-note-editor/nuxeo-note-editor.js
@@ -49,12 +49,14 @@ Polymer({
         position: absolute;
       }
 
-      #editNote.edit {
+      #editNote.edit,
+      #editHtmlNote.edit {
         right: 10px;
         top: 10px;
       }
 
-      :host([dir='rtl']) #editNote.edit {
+      :host([dir='rtl']) #editNote.edit,
+      :host([dir='rtl']) #editHtmlNote.edit {
         left: 10px;
         right: auto;
       }
@@ -103,32 +105,48 @@ Polymer({
     <div class="main">
       <template is="dom-if" if="[[_isHTML(document)]]">
         <div class="html-editor-container">
-          <paper-icon-button
-            id="editHtml"
-            class="edit"
-            icon="[[_computeHtmlEditIcon(_viewMode)]]"
-            on-tap="_toggleHtmlSource"
-            hidden$="[[!_canEdit(document)]]"
-            aria-labelledby="editHtmlTooltip"
-          ></paper-icon-button>
-          <paper-tooltip for="editHtml" position="right" id="editHtmlTooltip"
-            >[[_computeHtmlEditLabel(_viewMode, i18n)]]</paper-tooltip
-          >
-          <template is="dom-if" if="[[_viewMode]]">
-            <nuxeo-html-editor value="{{_value}}" read-only="[[!_canEdit(document)]]"></nuxeo-html-editor>
-          </template>
-          <template is="dom-if" if="[[!_viewMode]]">
-            <paper-textarea
-              value="{{_value}}"
-              no-label-float
-              placeholder="[[i18n('noteViewLayout.placeholder')]]"
-            ></paper-textarea>
-          </template>
-          <div class="layout horizontal end-justified">
-            <paper-button name="editorSave" noink class="primary" on-tap="_editorSave" hidden$="[[!_canEdit(document)]]"
-              >[[i18n('command.save')]]</paper-button
+          <template is="dom-if" if="[[!_editing]]">
+            <paper-icon-button
+              id="editHtmlNote"
+              class="edit"
+              icon="nuxeo:edit"
+              on-tap="_editHtml"
+              hidden$="[[!_canEdit(document)]]"
+              aria-labelledby="editHtmlNoteTooltip"
+            ></paper-icon-button>
+            <paper-tooltip for="editHtmlNote" position="bottom" id="editHtmlNoteTooltip"
+              >[[i18n('command.edit')]]</paper-tooltip
             >
-          </div>
+            <nuxeo-document-preview document="[[document]]"></nuxeo-document-preview>
+          </template>
+          <template is="dom-if" if="[[_editing]]">
+            <paper-icon-button
+              id="editHtml"
+              class="edit"
+              icon="[[_computeHtmlEditIcon(_viewMode)]]"
+              on-tap="_toggleHtmlSource"
+              aria-labelledby="editHtmlTooltip"
+            ></paper-icon-button>
+            <paper-tooltip for="editHtml" position="right" id="editHtmlTooltip"
+              >[[_computeHtmlEditLabel(_viewMode, i18n)]]</paper-tooltip
+            >
+            <template is="dom-if" if="[[_viewMode]]">
+              <nuxeo-html-editor value="{{_value}}"></nuxeo-html-editor>
+            </template>
+            <template is="dom-if" if="[[!_viewMode]]">
+              <paper-textarea
+                value="{{_value}}"
+                no-label-float
+                placeholder="[[i18n('noteViewLayout.placeholder')]]"
+              ></paper-textarea>
+            </template>
+            <div class="layout horizontal end-justified">
+              <paper-button noink on-tap="_cancel">[[i18n('command.cancel')]]</paper-button>
+              <paper-button name="editorSave" noink class="primary" on-tap="_editorSave"
+                >[[i18n('command.save')]]</paper-button
+              >
+            </div>
+          </template>
         </div>
       </template>
 
@@ -174,6 +192,14 @@ Polymer({
       type: Boolean,
       value: true,
     },
+    /**
+     * Whether an HTML note is being edited. HTML notes are displayed as stored until the user
+     * opts in to editing, because the rich text editor cannot represent every HTML construct.
+     */
+    _editing: {
+      type: Boolean,
+      value: false,
+    },
     _value: {
       type: String,
       value: '',
@@ -214,6 +240,7 @@ Polymer({
     this.$.note.put().then(() => {
       this.notify({ message: this.i18n('noteViewLayout.note.saved') });
       this._viewMode = true;
+      this._editing = false;
       this.fire('document-updated');
     });
   },
@@ -231,9 +258,16 @@ Polymer({
     this._viewMode = false;
   },
 
+  _editHtml() {
+    this._value = this.document.properties['note:note'];
+    this._viewMode = true;
+    this._editing = true;
+  },
+
   _cancel() {
     this._value = '';
     this._viewMode = true;
+    this._editing = false;
   },
 
   _toggleHtmlSource() {

--- a/elements/nuxeo-note-editor/nuxeo-note-editor.js
+++ b/elements/nuxeo-note-editor/nuxeo-note-editor.js
@@ -232,13 +232,17 @@ Polymer({
   },
 
   _documentChanged(document, previous) {
-    this._value = this.document.properties['note:note'];
     // Editing state belongs to the document being edited: showing a different note must not
-    // drop the reader straight into the editor. A refresh of the same document is left alone
-    // so an in-progress edit survives it.
-    if (previous && previous.uid !== document.uid) {
+    // drop the reader straight into the editor.
+    if (previous && previous.uid !== this.document.uid) {
       this._viewMode = true;
       this._editing = false;
+    }
+    // A refresh of the same note -- a metadata or tag change re-fetches the document -- leaves
+    // an edit in progress alone, draft included. Copying the stored value back over _value
+    // here would silently discard whatever the user has typed.
+    if (!this._editing) {
+      this._value = this.document.properties['note:note'];
     }
   },
 

--- a/elements/nuxeo-note-editor/nuxeo-note-editor.js
+++ b/elements/nuxeo-note-editor/nuxeo-note-editor.js
@@ -243,7 +243,7 @@ Polymer({
   },
 
   _computeHtmlPreview(document) {
-    const content = (document && document.properties && document.properties['note:note']) || '';
+    const content = document?.properties?.['note:note'] || '';
     return `<!doctype html><html><head><meta charset="utf-8"><style>
       body { margin: 0; font-family: var(--nuxeo-app-font, Inter, sans-serif); font-size: 13px; color: #333; }
       table { border-collapse: collapse; }
@@ -253,7 +253,7 @@ Polymer({
 
   _resizeHtmlPreview(e) {
     const frame = e.target;
-    const body = frame.contentDocument && frame.contentDocument.body;
+    const body = frame.contentDocument?.body;
     if (body) {
       frame.style.height = `${body.scrollHeight + 32}px`;
     }

--- a/elements/nuxeo-note-editor/nuxeo-note-editor.js
+++ b/elements/nuxeo-note-editor/nuxeo-note-editor.js
@@ -85,6 +85,14 @@ Polymer({
         min-height: calc(80vh - 90px);
       }
 
+      #htmlPreview {
+        display: block;
+        width: 100%;
+        min-height: calc(80vh - 90px);
+        border: none;
+        overflow: hidden;
+      }
+
       nuxeo-html-editor {
         min-height: calc(80vh - 90px);
         height: var(--nuxeo-note-editor-html-height);
@@ -117,7 +125,17 @@ Polymer({
             <paper-tooltip for="editHtmlNote" position="bottom" id="editHtmlNoteTooltip"
               >[[i18n('command.edit')]]</paper-tooltip
             >
-            <nuxeo-document-preview document="[[document]]"></nuxeo-document-preview>
+            <!-- The note is authored by users, so it is rendered in a sandbox without
+                 allow-scripts: no inline handler, javascript: URL or embedded script can run.
+                 allow-same-origin is granted only so the frame can be measured for sizing;
+                 without allow-scripts nothing inside the frame can act on that access. -->
+            <iframe
+              id="htmlPreview"
+              sandbox="allow-same-origin"
+              title$="[[i18n('noteEditor.htmlPreview')]]"
+              srcdoc$="[[_computeHtmlPreview(document)]]"
+              on-load="_resizeHtmlPreview"
+            ></iframe>
           </template>
           <template is="dom-if" if="[[_editing]]">
             <paper-icon-button
@@ -213,8 +231,32 @@ Polymer({
     }
   },
 
-  _documentChanged() {
+  _documentChanged(document, previous) {
     this._value = this.document.properties['note:note'];
+    // Editing state belongs to the document being edited: showing a different note must not
+    // drop the reader straight into the editor. A refresh of the same document is left alone
+    // so an in-progress edit survives it.
+    if (previous && previous.uid !== document.uid) {
+      this._viewMode = true;
+      this._editing = false;
+    }
+  },
+
+  _computeHtmlPreview(document) {
+    const content = (document && document.properties && document.properties['note:note']) || '';
+    return `<!doctype html><html><head><meta charset="utf-8"><style>
+      body { margin: 0; font-family: var(--nuxeo-app-font, Inter, sans-serif); font-size: 13px; color: #333; }
+      table { border-collapse: collapse; }
+      img { max-width: 100%; }
+    </style></head><body>${content}</body></html>`;
+  },
+
+  _resizeHtmlPreview(e) {
+    const frame = e.target;
+    const body = frame.contentDocument && frame.contentDocument.body;
+    if (body) {
+      frame.style.height = `${body.scrollHeight + 32}px`;
+    }
   },
 
   _isHTML() {

--- a/i18n/messages.json
+++ b/i18n/messages.json
@@ -1192,6 +1192,7 @@
   "noteEditLayout.format": "Format",
   "noteEditor.editRich": "Edit in rich text mode",
   "noteEditor.editSource": "Edit source code",
+  "noteEditor.htmlPreview": "Note content",
   "noteMetadataLayout.format": "Format",
   "noteViewLayout.note.saved": "Note has been saved.",
   "noteViewLayout.placeholder": "Type here...",

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/document.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/document.js
@@ -225,10 +225,13 @@ Then(/^I can edit the (.*) Note$/, async function (format) {
 
   switch (format) {
     case 'HTML':
+      // An HTML note is displayed as stored until the user opts in to editing, so the rich
+      // text editor has to be opened before its content can be set.
       await noteEditor.waitForVisible();
+      await noteEditor.edit();
       await noteEditor.setContent(newContent);
       await noteEditor.save();
-      await driver.waitUntil(async () => noteEditor.hasContent(`<p>${newContent}</p>`), {
+      await driver.waitUntil(async () => noteEditor.hasHtmlContent(newContent), {
         timeoutMsg: 'step  definition document 230',
       });
       break;

--- a/packages/nuxeo-web-ui-ftest/pages/ui/note_editor.js
+++ b/packages/nuxeo-web-ui-ftest/pages/ui/note_editor.js
@@ -12,9 +12,36 @@ export default class NoteEditor extends BasePage {
 
   get editButton() {
     return (async () => {
+      // Text, XML and Markdown notes expose #editNote; HTML notes expose #editHtmlNote.
       const editButton = await this.el.element('#editNote');
-      return editButton;
+      if (await editButton.isExisting()) {
+        return editButton;
+      }
+      return this.el.element('#editHtmlNote');
     })();
+  }
+
+  get htmlPreview() {
+    return this.el.element('#htmlPreview');
+  }
+
+  async hasHtmlContent(content) {
+    const frame = await this.htmlPreview;
+    await frame.waitForVisible();
+    await driver.waitUntil(
+      async () => {
+        try {
+          const srcdoc = await frame.getAttribute('srcdoc');
+          return srcdoc && srcdoc.includes(content);
+        } catch (e) {
+          return false;
+        }
+      },
+      {
+        timeoutMsg: 'The note preview does not have such content',
+      },
+    );
+    return true;
   }
 
   async hasContent(content) {

--- a/test/nuxeo-note-editor.test.js
+++ b/test/nuxeo-note-editor.test.js
@@ -25,6 +25,7 @@ suite('nuxeo-note-editor', () => {
     return {
       uid: 'note-1',
       type: 'Note',
+      schemas: [{ name: 'note' }, { name: 'dublincore' }],
       properties: {
         'note:note': '<p>hello</p>',
         'note:mime_type': 'text/plain',
@@ -33,6 +34,9 @@ suite('nuxeo-note-editor', () => {
       ...overrides,
     };
   };
+
+  const htmlDoc = (note = '<table><thead><tr><th>h</th></tr></thead><tbody><tr><td>c</td></tr></tbody></table>') =>
+    noteDoc({ properties: { 'note:mime_type': 'text/html', 'note:note': note } });
 
   setup(async () => {
     el = await fixture(html`<nuxeo-note-editor></nuxeo-note-editor>`);
@@ -98,9 +102,11 @@ suite('nuxeo-note-editor', () => {
 
   test('_cancel resets value and returns to view mode', () => {
     el._viewMode = false;
+    el._editing = true;
     el._value = 'draft';
     el._cancel();
     expect(el._viewMode).to.be.true;
+    expect(el._editing).to.be.false;
     expect(el._value).to.equal('');
   });
 
@@ -127,9 +133,89 @@ suite('nuxeo-note-editor', () => {
     expect(el.notify).to.have.been.called;
     expect(el.fire).to.have.been.calledWith('document-updated');
     expect(el._viewMode).to.be.true;
+    expect(el._editing).to.be.false;
 
     el.$.note.put.restore();
     el.notify.restore();
     el.fire.restore();
+  });
+
+  suite('HTML notes are displayed as stored (ELEMENTS-1806)', () => {
+    // Quill cannot represent thead/tfoot/th/colgroup/colspan/rowspan or nested tables, so an
+    // HTML note must not be routed through the rich text editor just to be read.
+    const deepQuery = (selector) => {
+      const walk = (root) => {
+        const hit = root.querySelector(selector);
+        if (hit) {
+          return hit;
+        }
+        for (const child of root.querySelectorAll('*')) {
+          if (child.shadowRoot) {
+            const nested = walk(child.shadowRoot);
+            if (nested) {
+              return nested;
+            }
+          }
+        }
+        return null;
+      };
+      return walk(el.shadowRoot);
+    };
+
+    test('an HTML note starts in view mode, not in the editor', () => {
+      el.document = htmlDoc();
+      expect(el._editing).to.be.false;
+    });
+
+    test('view mode renders the preview and not the rich text editor', async () => {
+      el.document = htmlDoc();
+      await flush();
+      expect(deepQuery('nuxeo-document-preview')).to.not.be.null;
+      expect(deepQuery('nuxeo-html-editor')).to.be.null;
+    });
+
+    test('view mode offers an edit action when the user can edit', async () => {
+      el.document = htmlDoc();
+      await flush();
+      const button = deepQuery('#editHtmlNote');
+      expect(button).to.not.be.null;
+      expect(button.hidden).to.be.false;
+    });
+
+    test('view mode hides the edit action when the user cannot edit', async () => {
+      el.hasPermission.returns(false);
+      el.document = htmlDoc();
+      await flush();
+      expect(deepQuery('#editHtmlNote').hidden).to.be.true;
+      expect(deepQuery('nuxeo-html-editor')).to.be.null;
+    });
+
+    test('_editHtml opens the rich text editor with the stored content', () => {
+      const note = '<table><tfoot><tr><td colspan="2">t</td></tr></tfoot></table>';
+      el.document = htmlDoc(note);
+      el._editHtml();
+      expect(el._editing).to.be.true;
+      expect(el._viewMode).to.be.true;
+      expect(el._value).to.equal(note);
+    });
+
+    test('the rich text editor is only mounted once editing starts', async () => {
+      el.document = htmlDoc();
+      await flush();
+      expect(deepQuery('nuxeo-html-editor')).to.be.null;
+      el._editHtml();
+      await flush();
+      expect(deepQuery('nuxeo-html-editor')).to.not.be.null;
+    });
+
+    test('the HTML source view still shows the stored markup', async () => {
+      const note = '<table><thead><tr><th>kept</th></tr></thead></table>';
+      el.document = htmlDoc(note);
+      el._editHtml();
+      el._toggleHtmlSource();
+      await flush();
+      expect(el._viewMode).to.be.false;
+      expect(el._value).to.equal(note);
+    });
   });
 });

--- a/test/nuxeo-note-editor.test.js
+++ b/test/nuxeo-note-editor.test.js
@@ -170,8 +170,38 @@ suite('nuxeo-note-editor', () => {
     test('view mode renders the preview and not the rich text editor', async () => {
       el.document = htmlDoc();
       await flush();
-      expect(deepQuery('nuxeo-document-preview')).to.not.be.null;
+      expect(deepQuery('#htmlPreview')).to.not.be.null;
       expect(deepQuery('nuxeo-html-editor')).to.be.null;
+    });
+
+    test('the preview keeps every structure Quill used to discard', async () => {
+      const note =
+        '<table><caption>c</caption><colgroup><col /></colgroup>' +
+        '<thead><tr><th rowspan="2">R</th><th colspan="2">H</th></tr></thead>' +
+        '<tbody><tr><td>a</td><td><table><tr><td>nested</td></tr></table></td></tr></tbody>' +
+        '<tfoot><tr><td colspan="3">f</td></tr></tfoot></table>';
+      el.document = htmlDoc(note);
+      await flush();
+      const rendered = new DOMParser().parseFromString(deepQuery('#htmlPreview').getAttribute('srcdoc'), 'text/html');
+      const table = rendered.querySelector('table');
+      expect(table, 'the note table should be rendered').to.not.be.null;
+      expect(table.querySelectorAll('th')).to.have.lengthOf(2);
+      expect(table.querySelectorAll('thead')).to.have.lengthOf(1);
+      expect(table.querySelectorAll('tfoot')).to.have.lengthOf(1);
+      expect(table.querySelectorAll('caption')).to.have.lengthOf(1);
+      expect(table.querySelectorAll('colgroup')).to.have.lengthOf(1);
+      expect(table.querySelectorAll('[colspan]')).to.have.lengthOf(2);
+      expect(table.querySelectorAll('[rowspan]')).to.have.lengthOf(1);
+      expect(table.querySelectorAll('table'), 'nested table').to.have.lengthOf(1);
+    });
+
+    test('the preview cannot execute scripts carried by the note', async () => {
+      el.document = htmlDoc('<img src="x" onerror="window.__noteXss = true">');
+      await flush();
+      const frame = deepQuery('#htmlPreview');
+      const sandbox = frame.getAttribute('sandbox');
+      expect(sandbox).to.not.be.null;
+      expect(sandbox.split(/\s+/)).to.not.include('allow-scripts');
     });
 
     test('view mode offers an edit action when the user can edit', async () => {
@@ -188,6 +218,24 @@ suite('nuxeo-note-editor', () => {
       await flush();
       expect(deepQuery('#editHtmlNote').hidden).to.be.true;
       expect(deepQuery('nuxeo-html-editor')).to.be.null;
+    });
+
+    test('switching to another note leaves the editor and returns to view mode', () => {
+      el.document = htmlDoc();
+      el._editHtml();
+      expect(el._editing).to.be.true;
+      el.document = { ...htmlDoc(), uid: 'note-2' };
+      expect(el._editing).to.be.false;
+      expect(el._viewMode).to.be.true;
+    });
+
+    test('refreshing the same note does not discard an edit in progress', () => {
+      el.document = htmlDoc();
+      el._editHtml();
+      el._toggleHtmlSource();
+      el.document = { ...htmlDoc(), properties: { ...htmlDoc().properties, 'dc:title': 'renamed' } };
+      expect(el._editing).to.be.true;
+      expect(el._viewMode).to.be.false;
     });
 
     test('_editHtml opens the rich text editor with the stored content', () => {

--- a/test/nuxeo-note-editor.test.js
+++ b/test/nuxeo-note-editor.test.js
@@ -195,6 +195,42 @@ suite('nuxeo-note-editor', () => {
       expect(table.querySelectorAll('table'), 'nested table').to.have.lengthOf(1);
     });
 
+    test('the preview frame is sized to the note it renders', async () => {
+      el.document = htmlDoc('<p style="height: 400px">tall</p>');
+      await flush();
+      const frame = deepQuery('#htmlPreview');
+      await new Promise((resolve) => {
+        const ready = () => frame.contentDocument && frame.contentDocument.body;
+        if (ready()) {
+          resolve();
+        } else {
+          frame.addEventListener('load', resolve, { once: true });
+        }
+      });
+      // read the content height before resizing: growing the frame grows body.scrollHeight with it
+      const contentHeight = frame.contentDocument.body.scrollHeight;
+      expect(contentHeight).to.be.greaterThan(0);
+      el._resizeHtmlPreview({ target: frame });
+      expect(frame.style.height).to.equal(`${contentHeight + 32}px`);
+    });
+
+    test('sizing is skipped until the frame has a document to measure', () => {
+      const pending = { contentDocument: null, style: {} };
+      el._resizeHtmlPreview({ target: pending });
+      expect(pending.style.height).to.be.undefined;
+
+      const empty = { contentDocument: { body: null }, style: {} };
+      el._resizeHtmlPreview({ target: empty });
+      expect(empty.style.height).to.be.undefined;
+    });
+
+    test('a missing or empty note renders an empty preview', () => {
+      expect(el._computeHtmlPreview(undefined)).to.contain('<body></body>');
+      expect(el._computeHtmlPreview({})).to.contain('<body></body>');
+      expect(el._computeHtmlPreview({ properties: {} })).to.contain('<body></body>');
+      expect(el._computeHtmlPreview({ properties: { 'note:note': '' } })).to.contain('<body></body>');
+    });
+
     test('the preview cannot execute scripts carried by the note', async () => {
       el.document = htmlDoc('<img src="x" onerror="window.__noteXss = true">');
       await flush();

--- a/test/nuxeo-note-editor.test.js
+++ b/test/nuxeo-note-editor.test.js
@@ -260,18 +260,28 @@ suite('nuxeo-note-editor', () => {
       el.document = htmlDoc();
       el._editHtml();
       expect(el._editing).to.be.true;
-      el.document = { ...htmlDoc(), uid: 'note-2' };
+      el.document = { ...htmlDoc('<p>the other note</p>'), uid: 'note-2' };
       expect(el._editing).to.be.false;
       expect(el._viewMode).to.be.true;
+      expect(el._value).to.equal('<p>the other note</p>');
     });
 
     test('refreshing the same note does not discard an edit in progress', () => {
       el.document = htmlDoc();
       el._editHtml();
       el._toggleHtmlSource();
+      el._value = '<p>unsaved draft</p>';
       el.document = { ...htmlDoc(), properties: { ...htmlDoc().properties, 'dc:title': 'renamed' } };
       expect(el._editing).to.be.true;
       expect(el._viewMode).to.be.false;
+      expect(el._value, 'the draft must survive a refresh of the same note').to.equal('<p>unsaved draft</p>');
+    });
+
+    test('refreshing the same note while not editing picks up the stored content', () => {
+      el.document = htmlDoc('<p>one</p>');
+      expect(el._value).to.equal('<p>one</p>');
+      el.document = htmlDoc('<p>two</p>');
+      expect(el._value).to.equal('<p>two</p>');
     });
 
     test('_editHtml opens the rich text editor with the stored content', () => {


### PR DESCRIPTION
## Problem

A Note whose format is HTML is displayed incorrectly when its content is anything
more than a simple rectangular table. Header rows, merged cells, nested tables and
footers are all lost, so what the user reads does not match what is stored.

Reproduced on `lts-2025` against a Note containing `thead`, `tfoot`, `th`,
`colgroup`, `colspan`, `rowspan` and a nested table. Measured against the DOM:

| Feature | Stored in `note:note` | Rendered before | Rendered after |
| --- | --- | --- | --- |
| `th` | 7 | 0 | 7 |
| `thead` / `tfoot` | 1 / 1 | 0 / 0 | 1 / 1 |
| `colgroup` | 1 | 0 | 1 |
| `colspan` / `rowspan` | 3 / 3 | 0 / 0 | 3 / 3 |
| nested tables | 1 | 0 | 1 |
| cells | 23 | 18 | 23 |

## Root cause

`nuxeo-note-editor` rendered an HTML note's default *view* through the Quill-backed
`nuxeo-html-editor`:

```js
<template is="dom-if" if="[[_viewMode]]">
  <nuxeo-html-editor value="{{_value}}" read-only="[[!_canEdit(document)]]"></nuxeo-html-editor>
</template>
```

`nuxeo-html-editor._valueChanged()` converts the stored HTML into a Quill Delta on
every value change, including the initial load:

```js
const delta = this._editor.clipboard.convert({ html: this.value });
this._editor.setContents(delta, this.readOnly ? Quill.sources.SILENT : Quill.sources.USER);
```

Quill's built-in table model only supports `TABLE > TBODY > TR > TD` with each cell
tagged by its row index, and `balanceCells()` pads every row to a uniform width.
Everything outside that shape is discarded before the note is painted. The note was
therefore never displayed as stored — it was normalised into Quill's own model
first, even for a user who was only reading it.

This is a limitation of Quill's core table module, not of the glue code, and it is
the conclusion reached by the spike (WEBUI-1971). This PR implements the spike's
recommended option 1.

## Changes

`elements/nuxeo-note-editor/nuxeo-note-editor.js`

- HTML notes now use the same view/edit split every other note format already uses:
  the stored content is displayed directly, and Quill is only mounted once the user
  opts in to editing via the edit action.
- The note is rendered in an iframe with `sandbox="allow-same-origin"` and **no**
  `allow-scripts`, so nothing the note carries — inline handlers, `javascript:` URLs,
  embedded script — can execute. `allow-same-origin` is granted only so the frame can
  be measured to auto-size it to its content; with scripts disabled nothing inside the
  frame can act on that access.
- New `_editing` flag and `_editHtml()` action; `_cancel()` and `_editorSave()` clear
  it, and `_documentChanged()` resets it when the bound document changes to a
  different note (a refresh of the same note is left alone so an edit in progress
  survives). `_viewMode` keeps its existing meaning (rich vs. HTML source) so the
  editing behaviour is untouched.
- Edit mode gains a Cancel button next to Save, matching the non-HTML branch.

`i18n/messages.json` — one new key, `noteEditor.htmlPreview`, for the frame title.

`packages/nuxeo-web-ui-ftest/…` — `NoteEditor.editButton` resolves either edit action,
and the HTML step opens the editor before setting content. The HTML scenarios in
`edit-note.feature` remain commented out, as they were before this PR, so CI does not
execute this path — the page object is consistent by inspection, not by a green run.

`test/nuxeo-note-editor.test.js`

- Eleven tests covering: an HTML note starts in view mode; the preview is rendered and
  Quill is not; **the rendered DOM keeps `thead`, `tfoot`, `th`, `caption`, `colgroup`,
  `colspan`, `rowspan` and a nested table**; the sandbox never gains `allow-scripts`;
  the edit action is shown when the user can edit and hidden when they cannot;
  `_editHtml` opens the editor with the stored content; Quill is only mounted after
  editing starts; the HTML source view still shows the stored markup; switching notes
  leaves the editor while refreshing the same note does not.

## Test plan

1. `bash .cursor/skills/nuxeo-web-ui-pr-checks/scripts/pr-checks.sh` — lint clean,
   **2691 unit tests passing** on both bases. The new tests were confirmed capable of
   failing (inverting one assertion turns the suite red and names the suite) before
   being trusted.
2. Create a Note with `note:mime_type` `text/html` whose body contains a table using
   `thead`, `tfoot`, `colspan`, `rowspan` and a nested table.
3. Browse to the document. The table renders as stored: merged header cells, the
   nested table inside its cell, and the footer row are all present.
4. Click the edit (pencil) action. The rich text editor opens with Save and Cancel.
5. Use the `<>` toggle. The HTML source textarea shows the original markup byte for
   byte (verified: 1268 characters, identical to `note:note`).
6. Click Cancel. The faithful rendering is restored.

Steps 3–6 are asserted automatically by a Puppeteer run against a real Nuxeo instance:
13/13 checks pass, including that view mode never instantiates Quill and that the
deployed frame carries `sandbox="allow-same-origin"`.

## Notes

- **Editing complex tables is still lossy.** Once the user explicitly opens the rich
  text editor, Quill's table limitation still applies, so saving from rich mode can
  still flatten a complex table. That is the spike's option 2 (a real Quill table
  module) and is deliberately out of scope here — this PR fixes *display*, which is
  what the ticket asks for. The HTML source view remains the lossless way to edit
  such a note.
- **Rendering path / XSS.** The first revision of this PR rendered the note through
  `nuxeo-document-preview`, whose `text/html` template sanitises with `marked-element`
  — and that sanitiser strips only `<script>`, leaving event-handler attributes and
  `javascript:` URLs intact. Review flagged it and it is fixed: the note is rendered in
  a script-disabled sandboxed iframe instead, which removes the `innerHTML` sink from
  this path rather than trying to out-sanitise it, and needs no new dependency.
  Separately, `marked-element` is still the path for **Markdown** notes, which pass
  embedded HTML through today. That is pre-existing and outside this ticket, but
  `_basicSanitize` in `nuxeo-elements` deserves its own ticket.
- I also tested whether merely viewing a note overwrote the bound value so that a
  subsequent Save would persist the flattened table. **It does not** — the bound
  value stayed byte-identical to what is stored. Noting it so nobody re-investigates.

Backport pair: `lts-2025` and `maintenance-3.1.x` (same commit cherry-picked).
