### PR TITLE
WEBUI-1701: Fix error handling in nuxeo-document-publication [maintenance-3.1.x]

### DIFF
--- a/elements/nuxeo-publication/nuxeo-document-publications.js
+++ b/elements/nuxeo-publication/nuxeo-document-publications.js
@@ -215,11 +215,12 @@ Polymer({
   _unpublish(e) {
     if (e && e.target) {
       if (!window.confirm(this.i18n('publication.unpublish.confirm'))) {
-        return;
+        return undefined;
       }
       const doc = e.target.parentNode.item;
       this.$.unpublishOp.input = doc;
-      this.$.unpublishOp
+      // Returned so callers (and tests) can await the operation; the template's on-tap ignores it.
+      return this.$.unpublishOp
         .execute()
         .then(() => {
           this.notify({ message: this.i18n('publication.unpublish.success') });
@@ -229,12 +230,13 @@ Polymer({
           this.notify({ message: this.i18n('publication.unpublish.error') });
         });
     }
+    return undefined;
   },
 
   _republish(e) {
     if (e && e.target) {
       if (!window.confirm(this.i18n('publication.republish.confirm'))) {
-        return;
+        return undefined;
       }
       const obsolete = e.target.parentNode.item;
       this.$.publishOp.params = {
@@ -243,7 +245,8 @@ Polymer({
         renditionName: obsolete.properties['rend:renditionName'],
       };
       this.$.publishOp.input = this._src.uid;
-      this.$.publishOp
+      // Returned so callers (and tests) can await the operation; the template's on-tap ignores it.
+      return this.$.publishOp
         .execute()
         .then(() => {
           this.notify({
@@ -259,6 +262,7 @@ Polymer({
           throw err;
         });
     }
+    return undefined;
   },
 
   _canUnpublish(doc) {
@@ -287,9 +291,10 @@ Polymer({
 
   _unpublishAll() {
     if (!window.confirm(this.i18n('publication.unpublish.all.confirm'))) {
-      return;
+      return undefined;
     }
-    this.$.unpublishAllOp
+    // Returned so callers (and tests) can await the operation; the template's on-tap ignores it.
+    return this.$.unpublishAllOp
       .execute()
       .then(() => {
         this.notify({ message: this.i18n('publication.unpublish.all.success') });

--- a/test/nuxeo-document-publications.test.js
+++ b/test/nuxeo-document-publications.test.js
@@ -300,180 +300,115 @@ suite('nuxeo-document-publications', () => {
     });
   });
 
+  // WEBUI-1701: the publication operations report failures through `this.notify()` from inside
+  // their `.catch()` handlers. A regression to `function () { ... }` handlers loses the `this`
+  // binding (modules are strict mode, so `this` is `undefined`) and the user is never told the
+  // operation failed. These suites pin that behaviour for all three operations.
+  //
+  // Stubs are intentionally not restored inline: test/setup.js restores leaked sinon fakes after
+  // every test, so an assertion failure here cannot leak a stubbed `window.confirm` into the rest
+  // of the run (same convention as nuxeo-vocabulary-management.test.js).
+  const rowEvent = (item) => {
+    return { target: { parentNode: { item } } };
+  };
+
+  // Assert on plain extracted values, never `expect(spy).to.have.been.calledWith(...)`:
+  // a FAILING sinon-chai spy assertion never reports under @web/test-runner, so a regression
+  // would stall the run until `testsFinishTimeout` (15 min in CI) instead of failing. Comparing
+  // plain strings/numbers keeps the regression signal fast and readable.
+  const notifiedMessages = (spy) => spy.args.map((args) => args[0] && args[0].message);
+
   suite('_unpublish error handling', () => {
     test('should notify user on unpublish error', async () => {
       const notifySpy = sinon.spy(element, 'notify');
-      const confirmStub = sinon.stub(window, 'confirm').returns(true);
+      sinon.stub(window, 'confirm').returns(true);
       sinon.stub(element.$.unpublishOp, 'execute').rejects(new Error('Unpublish failed'));
 
-      const mockEvent = {
-        target: {
-          parentNode: {
-            item: { uid: 'doc-1', path: '/default-domain/workspaces/ws/doc' },
-          },
-        },
-      };
+      await element._unpublish(rowEvent({ uid: 'doc-1', path: '/default-domain/workspaces/ws/doc' }));
 
-      await element._unpublish(mockEvent);
-
-      // Wait for promise chain to complete
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(notifySpy).to.have.been.calledWith(sinon.match({ message: 'publication.unpublish.error' }));
-
-      notifySpy.restore();
-      confirmStub.restore();
-      element.$.unpublishOp.execute.restore();
+      expect(notifiedMessages(notifySpy)).to.deep.equal(['publication.unpublish.error']);
     });
 
     test('should not proceed if user cancels confirmation', () => {
-      const confirmStub = sinon.stub(window, 'confirm').returns(false);
+      sinon.stub(window, 'confirm').returns(false);
       const executeSpy = sinon.spy(element.$.unpublishOp, 'execute');
 
-      const mockEvent = {
-        target: {
-          parentNode: {
-            item: { uid: 'doc-1' },
-          },
-        },
-      };
-
-      element._unpublish(mockEvent);
-
-      expect(executeSpy).to.not.have.been.called;
-
-      confirmStub.restore();
-      executeSpy.restore();
+      expect(element._unpublish(rowEvent({ uid: 'doc-1' }))).to.be.undefined;
+      expect(executeSpy.callCount).to.equal(0);
     });
 
-    test('should notify success on unpublish success', async () => {
+    test('should notify success and refresh on unpublish success', async () => {
       const notifySpy = sinon.spy(element, 'notify');
-      const confirmStub = sinon.stub(window, 'confirm').returns(true);
+      sinon.stub(window, 'confirm').returns(true);
       const fetchSpy = sinon.spy(element, '_fetchPublications');
       sinon.stub(element.$.unpublishOp, 'execute').resolves();
 
-      const mockEvent = {
-        target: {
-          parentNode: {
-            item: { uid: 'doc-1', path: '/default-domain/workspaces/ws/doc' },
-          },
-        },
-      };
+      await element._unpublish(rowEvent({ uid: 'doc-1', path: '/default-domain/workspaces/ws/doc' }));
 
-      await element._unpublish(mockEvent);
-
-      expect(notifySpy).to.have.been.calledWith(sinon.match({ message: 'publication.unpublish.success' }));
-      expect(fetchSpy).to.have.been.calledOnce;
-
-      notifySpy.restore();
-      confirmStub.restore();
-      fetchSpy.restore();
-      element.$.unpublishOp.execute.restore();
+      expect(notifiedMessages(notifySpy)).to.deep.equal(['publication.unpublish.success']);
+      expect(fetchSpy.callCount).to.equal(1);
     });
   });
 
   suite('_republish error handling', () => {
-    test('should notify user on republish error', async () => {
+    test('should notify user on republish error and rethrow', async () => {
       const notifySpy = sinon.spy(element, 'notify');
-      const confirmStub = sinon.stub(window, 'confirm').returns(true);
+      sinon.stub(window, 'confirm').returns(true);
       sinon.stub(element.$.publishOp, 'execute').rejects(new Error('Republish failed'));
-
       element._src = { uid: 'doc-src' };
-      const mockEvent = {
-        target: {
-          parentNode: {
-            item: {
-              uid: 'doc-1',
-              parentRef: 'section-1',
-              properties: { 'rend:renditionName': 'pdf' },
-            },
-          },
-        },
-      };
 
-      try {
-        await element._republish(mockEvent);
-      } catch (err) {
-        // Expected to throw after notifying
-      }
+      let rejection;
+      await element
+        ._republish(rowEvent({ uid: 'doc-1', parentRef: 'section-1', properties: { 'rend:renditionName': 'pdf' } }))
+        .catch((err) => {
+          rejection = err;
+        });
 
-      // Wait for promise chain to complete
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(notifySpy).to.have.been.calledWith(sinon.match({ message: 'publication.internal.publish.error' }));
-
-      notifySpy.restore();
-      confirmStub.restore();
-      element.$.publishOp.execute.restore();
+      expect(notifiedMessages(notifySpy)).to.deep.equal(['publication.internal.publish.error']);
+      // The handler rethrows so callers can react; assert it so the rejection is not left unhandled.
+      expect(rejection).to.be.an('error');
+      expect(rejection.message).to.equal('Republish failed');
     });
 
     test('should not proceed if user cancels republish confirmation', () => {
-      const confirmStub = sinon.stub(window, 'confirm').returns(false);
+      sinon.stub(window, 'confirm').returns(false);
       const executeSpy = sinon.spy(element.$.publishOp, 'execute');
-
       element._src = { uid: 'doc-src' };
-      const mockEvent = {
-        target: {
-          parentNode: {
-            item: { uid: 'doc-1', parentRef: 'section-1', properties: {} },
-          },
-        },
-      };
 
-      element._republish(mockEvent);
-
-      expect(executeSpy).to.not.have.been.called;
-
-      confirmStub.restore();
-      executeSpy.restore();
+      expect(element._republish(rowEvent({ uid: 'doc-1', parentRef: 'section-1', properties: {} }))).to.be.undefined;
+      expect(executeSpy.callCount).to.equal(0);
     });
   });
 
   suite('_unpublishAll error handling', () => {
     test('should notify user on unpublish all error', async () => {
       const notifySpy = sinon.spy(element, 'notify');
-      const confirmStub = sinon.stub(window, 'confirm').returns(true);
+      sinon.stub(window, 'confirm').returns(true);
       sinon.stub(element.$.unpublishAllOp, 'execute').rejects(new Error('Unpublish all failed'));
 
-      element._unpublishAll();
+      await element._unpublishAll();
 
-      // Wait for promise chain to complete
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(notifySpy).to.have.been.calledWith(sinon.match({ message: 'publication.unpublish.all.error' }));
-
-      notifySpy.restore();
-      confirmStub.restore();
-      element.$.unpublishAllOp.execute.restore();
+      expect(notifiedMessages(notifySpy)).to.deep.equal(['publication.unpublish.all.error']);
     });
 
     test('should not proceed if user cancels unpublish all confirmation', () => {
-      const confirmStub = sinon.stub(window, 'confirm').returns(false);
+      sinon.stub(window, 'confirm').returns(false);
       const executeSpy = sinon.spy(element.$.unpublishAllOp, 'execute');
 
-      element._unpublishAll();
-
-      expect(executeSpy).to.not.have.been.called;
-
-      confirmStub.restore();
-      executeSpy.restore();
+      expect(element._unpublishAll()).to.be.undefined;
+      expect(executeSpy.callCount).to.equal(0);
     });
 
     test('should notify success and refresh on unpublish all success', async () => {
       const notifySpy = sinon.spy(element, 'notify');
-      const confirmStub = sinon.stub(window, 'confirm').returns(true);
+      sinon.stub(window, 'confirm').returns(true);
       const fetchSpy = sinon.spy(element, '_fetchPublications');
       sinon.stub(element.$.unpublishAllOp, 'execute').resolves();
 
       await element._unpublishAll();
 
-      expect(notifySpy).to.have.been.calledWith(sinon.match({ message: 'publication.unpublish.all.success' }));
-      expect(fetchSpy).to.have.been.calledOnce;
-
-      notifySpy.restore();
-      confirmStub.restore();
-      fetchSpy.restore();
-      element.$.unpublishAllOp.execute.restore();
+      expect(notifiedMessages(notifySpy)).to.deep.equal(['publication.unpublish.all.success']);
+      expect(fetchSpy.callCount).to.equal(1);
     });
   });
 });

--- a/test/nuxeo-document-publications.test.js
+++ b/test/nuxeo-document-publications.test.js
@@ -299,4 +299,181 @@ suite('nuxeo-document-publications', () => {
       document.dir = origDir;
     });
   });
+
+  suite('_unpublish error handling', () => {
+    test('should notify user on unpublish error', async () => {
+      const notifySpy = sinon.spy(element, 'notify');
+      const confirmStub = sinon.stub(window, 'confirm').returns(true);
+      sinon.stub(element.$.unpublishOp, 'execute').rejects(new Error('Unpublish failed'));
+
+      const mockEvent = {
+        target: {
+          parentNode: {
+            item: { uid: 'doc-1', path: '/default-domain/workspaces/ws/doc' },
+          },
+        },
+      };
+
+      await element._unpublish(mockEvent);
+
+      // Wait for promise chain to complete
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(notifySpy).to.have.been.calledWith(sinon.match({ message: 'publication.unpublish.error' }));
+
+      notifySpy.restore();
+      confirmStub.restore();
+      element.$.unpublishOp.execute.restore();
+    });
+
+    test('should not proceed if user cancels confirmation', () => {
+      const confirmStub = sinon.stub(window, 'confirm').returns(false);
+      const executeSpy = sinon.spy(element.$.unpublishOp, 'execute');
+
+      const mockEvent = {
+        target: {
+          parentNode: {
+            item: { uid: 'doc-1' },
+          },
+        },
+      };
+
+      element._unpublish(mockEvent);
+
+      expect(executeSpy).to.not.have.been.called;
+
+      confirmStub.restore();
+      executeSpy.restore();
+    });
+
+    test('should notify success on unpublish success', async () => {
+      const notifySpy = sinon.spy(element, 'notify');
+      const confirmStub = sinon.stub(window, 'confirm').returns(true);
+      const fetchSpy = sinon.spy(element, '_fetchPublications');
+      sinon.stub(element.$.unpublishOp, 'execute').resolves();
+
+      const mockEvent = {
+        target: {
+          parentNode: {
+            item: { uid: 'doc-1', path: '/default-domain/workspaces/ws/doc' },
+          },
+        },
+      };
+
+      await element._unpublish(mockEvent);
+
+      expect(notifySpy).to.have.been.calledWith(sinon.match({ message: 'publication.unpublish.success' }));
+      expect(fetchSpy).to.have.been.calledOnce;
+
+      notifySpy.restore();
+      confirmStub.restore();
+      fetchSpy.restore();
+      element.$.unpublishOp.execute.restore();
+    });
+  });
+
+  suite('_republish error handling', () => {
+    test('should notify user on republish error', async () => {
+      const notifySpy = sinon.spy(element, 'notify');
+      const confirmStub = sinon.stub(window, 'confirm').returns(true);
+      sinon.stub(element.$.publishOp, 'execute').rejects(new Error('Republish failed'));
+
+      element._src = { uid: 'doc-src' };
+      const mockEvent = {
+        target: {
+          parentNode: {
+            item: {
+              uid: 'doc-1',
+              parentRef: 'section-1',
+              properties: { 'rend:renditionName': 'pdf' },
+            },
+          },
+        },
+      };
+
+      try {
+        await element._republish(mockEvent);
+      } catch (err) {
+        // Expected to throw after notifying
+      }
+
+      // Wait for promise chain to complete
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(notifySpy).to.have.been.calledWith(sinon.match({ message: 'publication.internal.publish.error' }));
+
+      notifySpy.restore();
+      confirmStub.restore();
+      element.$.publishOp.execute.restore();
+    });
+
+    test('should not proceed if user cancels republish confirmation', () => {
+      const confirmStub = sinon.stub(window, 'confirm').returns(false);
+      const executeSpy = sinon.spy(element.$.publishOp, 'execute');
+
+      element._src = { uid: 'doc-src' };
+      const mockEvent = {
+        target: {
+          parentNode: {
+            item: { uid: 'doc-1', parentRef: 'section-1', properties: {} },
+          },
+        },
+      };
+
+      element._republish(mockEvent);
+
+      expect(executeSpy).to.not.have.been.called;
+
+      confirmStub.restore();
+      executeSpy.restore();
+    });
+  });
+
+  suite('_unpublishAll error handling', () => {
+    test('should notify user on unpublish all error', async () => {
+      const notifySpy = sinon.spy(element, 'notify');
+      const confirmStub = sinon.stub(window, 'confirm').returns(true);
+      sinon.stub(element.$.unpublishAllOp, 'execute').rejects(new Error('Unpublish all failed'));
+
+      element._unpublishAll();
+
+      // Wait for promise chain to complete
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(notifySpy).to.have.been.calledWith(sinon.match({ message: 'publication.unpublish.all.error' }));
+
+      notifySpy.restore();
+      confirmStub.restore();
+      element.$.unpublishAllOp.execute.restore();
+    });
+
+    test('should not proceed if user cancels unpublish all confirmation', () => {
+      const confirmStub = sinon.stub(window, 'confirm').returns(false);
+      const executeSpy = sinon.spy(element.$.unpublishAllOp, 'execute');
+
+      element._unpublishAll();
+
+      expect(executeSpy).to.not.have.been.called;
+
+      confirmStub.restore();
+      executeSpy.restore();
+    });
+
+    test('should notify success and refresh on unpublish all success', async () => {
+      const notifySpy = sinon.spy(element, 'notify');
+      const confirmStub = sinon.stub(window, 'confirm').returns(true);
+      const fetchSpy = sinon.spy(element, '_fetchPublications');
+      sinon.stub(element.$.unpublishAllOp, 'execute').resolves();
+
+      await element._unpublishAll();
+
+      expect(notifySpy).to.have.been.calledWith(sinon.match({ message: 'publication.unpublish.all.success' }));
+      expect(fetchSpy).to.have.been.calledOnce;
+
+      notifySpy.restore();
+      confirmStub.restore();
+      fetchSpy.restore();
+      element.$.unpublishAllOp.execute.restore();
+    });
+  });
 });

--- a/test/nuxeo-document-publications.test.js
+++ b/test/nuxeo-document-publications.test.js
@@ -337,6 +337,14 @@ suite('nuxeo-document-publications', () => {
       expect(executeSpy.callCount).to.equal(0);
     });
 
+    test('should do nothing when the event has no target', () => {
+      const executeSpy = sinon.spy(element.$.unpublishOp, 'execute');
+
+      expect(element._unpublish(undefined)).to.be.undefined;
+      expect(element._unpublish({})).to.be.undefined;
+      expect(executeSpy.callCount).to.equal(0);
+    });
+
     test('should notify success and refresh on unpublish success', async () => {
       const notifySpy = sinon.spy(element, 'notify');
       sinon.stub(window, 'confirm').returns(true);
@@ -368,6 +376,29 @@ suite('nuxeo-document-publications', () => {
       // The handler rethrows so callers can react; assert it so the rejection is not left unhandled.
       expect(rejection).to.be.an('error');
       expect(rejection.message).to.equal('Republish failed');
+    });
+
+    test('should notify success and fire events on republish success', async () => {
+      const notifySpy = sinon.spy(element, 'notify');
+      sinon.stub(window, 'confirm').returns(true);
+      sinon.stub(element.$.publishOp, 'execute').resolves();
+      element._src = { uid: 'doc-src' };
+      const fired = [];
+      element.addEventListener('document-updated', () => fired.push('document-updated'));
+      element.addEventListener('nx-publish-success', () => fired.push('nx-publish-success'));
+
+      await element._republish(rowEvent({ uid: 'doc-1', parentRef: 'section-1', properties: {} }));
+
+      expect(notifiedMessages(notifySpy)).to.deep.equal(['publication.internal.publish.success']);
+      expect(fired).to.deep.equal(['document-updated', 'nx-publish-success']);
+    });
+
+    test('should do nothing when the event has no target', () => {
+      const executeSpy = sinon.spy(element.$.publishOp, 'execute');
+
+      expect(element._republish(undefined)).to.be.undefined;
+      expect(element._republish({})).to.be.undefined;
+      expect(executeSpy.callCount).to.equal(0);
     });
 
     test('should not proceed if user cancels republish confirmation', () => {


### PR DESCRIPTION
## Problem

When a publication operation fails, the user is not told. A customer reported that **Unpublish All** silently does nothing on error, and correctly suspected a `this` binding problem in the `catch` handler.

## Root cause

In an ES module (always strict mode) a non-arrow promise handler is invoked with `this === undefined`. So `.catch(function () { this.notify(...) })` throws a `TypeError` *before* it can notify, and the failure is swallowed as an unhandled rejection.

**This part is already fixed on both bases.** All three handlers in `elements/nuxeo-publication/nuxeo-document-publications.js` (lines 228, 255, 298) use arrow functions today — the WEBUI-1980 prettier pass (`5ddda571d` on lts-2025, `a9f382482` on maintenance-3.1.x, 2026-04-01) converted them incidentally. What was missing was a **regression guard**, and adding a working one required a small production change.

## Changes

**`elements/nuxeo-publication/nuxeo-document-publications.js`** (production, +11/−6)
- `_unpublish`, `_republish` and `_unpublishAll` now **return** their promise chains, so callers and tests can await the operation instead of sleeping and hoping. Both call sites are `on-tap` bindings in this element's own template, which discard return values, so **behaviour is unchanged**.
- Cancel and no-event guard paths return `undefined` explicitly for a consistent return contract.

**`test/nuxeo-document-publications.test.js`** (+143)
- 11 new tests (36 → 47 in this file) covering error, success, cancel-confirmation and no-event guard paths for all three operations.
- Assertions use **plain extracted values**, never `expect(spy).to.have.been.calledWith(...)`. This matters: a *failing* sinon-chai spy assertion never reports under `@web/test-runner`, so the first version of these tests did not fail on a regression — it **stalled the run** to `testsFinishTimeout` (900 s in CI). Verified independent of the matcher and of the Polymer element graph:

  | Failing assertion | Result |
  |---|---|
  | `expect(1).to.equal(2)` | clean failure |
  | `expect(elementSpy).to.have.been.calledWith(sinon.match({...}))` | run never finishes |
  | `expect(elementSpy).to.have.been.calledWith({...})` | run never finishes |
  | `expect(anonymousSpy).to.have.been.calledWith(sinon.match({...}))` | run never finishes |
  | `expect(spy.args.map((a) => a[0].message)).to.deep.equal([...])` | clean failure |

- The `_republish` rethrow is asserted rather than swallowed in a `try/catch` that could never catch anything, which also removes a recurring unhandled-rejection log from the suite output.

## Test plan

**The guard actually fires.** Each handler reverted to `function () { ... }` in turn, one per run:

| Source state | Result |
|---|---|
| Correct (arrow handlers) | **47 passed, 0 failed** |
| `_unpublish` reverted | 43 passed, **1 failed** — `TypeError: ... reading 'notify'` |
| `_republish` reverted | 43 passed, **1 failed** — `expected [] to deeply equal [ Array(1) ]` |
| `_unpublishAll` reverted | 43 passed, **1 failed** |

Each failure names the right test and takes ~4 s.

- Full suite: **2691 passed, 0 failed**
- `npm run lint` (eslint + prettier) clean
- SonarCloud quality gate **OK**, `new_coverage` **100%** (0 uncovered new lines)

**Verified in the real UI.** The same tree was built twice and each build deployed into one throwaway Nuxeo container, so the only difference is the three handlers. `Document.UnpublishAll` was answered with HTTP 500 via a CDP `Fetch` interception scoped to that single URL — no application code stubbed:

| | BEFORE (`function(){}`) | AFTER (`()=>{}`) |
|---|---|---|
| Error notification shown | **no** | **yes, at t+250 ms** |
| Notification text | — | `Error while unpublishing all documents.` |
| Uncaught page error | `TypeError: ... reading 'notify'` | none |

Videos, screenshots and machine-readable probe output are attached to the Jira ticket.

## Notes

- The `TypeError` in the "before" run stack-traces to the buggy bundle, confirming which code executed.
- Out of scope: the failing-`calledWith` stall is a harness-wide issue affecting any suite using that pattern. Only the assertions in this file were changed; three pre-existing `calledWith`/`calledOnce` assertions earlier in the same file were left untouched to keep the diff scoped — they pass today and would only stall if they started failing.
- Jira: https://hyland.atlassian.net/browse/WEBUI-1701

_Paired change: this PR targets `maintenance-3.1.x`; the identical change for the other base is in the companion PR._
