### PR TITLE
WEBUI-340: Stop recycled result tiles showing the previous document's thumbnail [lts-2025]

### DIFF
--- a/elements/behaviors/nuxeo-recycled-thumbnail-behavior.js
+++ b/elements/behaviors/nuxeo-recycled-thumbnail-behavior.js
@@ -1,0 +1,97 @@
+/**
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { applyThumbnailFallback } from '../common-utils.js';
+
+/**
+ * Thumbnail handling for result items rendered inside a recycled virtual list.
+ *
+ * `iron-list` reuses a small pool of rows, so a host is rebound to a different document as the
+ * user scrolls. Polymer updates the text bindings synchronously, but an `<img>` keeps painting its
+ * previous frame until the new `src` has been fetched and decoded — leaving the row showing one
+ * document's picture beside another document's title (WEBUI-340). Chromium, WebKit and Firefox all
+ * behave this way; it is ordinary `<img>` semantics, not a browser bug.
+ *
+ * This behavior gives the host what `iron-image` provides: `_thumbnailLoaded` drops as soon as the
+ * source changes and only comes back on that source's own `load` event, so the host can keep the
+ * image hidden — falling back to its neutral thumbnail box — instead of showing a stale picture.
+ *
+ * The host is expected to:
+ *   - declare a `doc` property,
+ *   - bind `src="[[_thumbnailSrc]]"`, `loaded$="[[_thumbnailLoaded]]"`, `on-load="_onLoad"` and
+ *     `on-error="_onError"` on its thumbnail `<img>`,
+ *   - style that image as hidden unless `[loaded]` is present.
+ *
+ * @polymerBehavior Nuxeo.RecycledThumbnailBehavior
+ */
+export const NuxeoRecycledThumbnailBehavior = {
+  properties: {
+    /** Decorated thumbnail URL for the bound document, or '' when it has none. */
+    _thumbnailSrc: {
+      type: String,
+      computed: '_thumbnail(doc)',
+      observer: '_thumbnailSrcChanged',
+    },
+
+    /** True only while the image on screen is the one `_thumbnailSrc` asked for. */
+    _thumbnailLoaded: {
+      type: Boolean,
+      value: false,
+    },
+  },
+
+  _thumbnail(doc) {
+    if (doc?.uid && doc.contextParameters?.thumbnail?.url) {
+      const { url } = doc.contextParameters.thumbnail;
+      // Derive the decorated URL instead of writing it back onto the document. A recycled host
+      // meets the same document again whenever the user scrolls back over it, and mutating the
+      // shared entry appended clientReason=view once per visit.
+      if (this.isFollowRedirectEnabled() || url.includes('clientReason=')) {
+        return url;
+      }
+      return `${url}${url.includes('?') ? '&' : '?'}clientReason=view`;
+    }
+    return '';
+  },
+
+  isFollowRedirectEnabled() {
+    const followRedirect = Nuxeo?.UI?.config?.url?.followRedirect;
+    return followRedirect ? String(followRedirect).toLowerCase() === 'true' : false;
+  },
+
+  _thumbnailSrcChanged() {
+    this._thumbnailLoaded = false;
+  },
+
+  _onLoad(e) {
+    // A load event can still be delivered for a request that has since been superseded, because
+    // the host was rebound to another document while that image was in flight. Honouring it would
+    // put the previous document's picture back on screen, so only trust a load whose completed
+    // candidate (currentSrc) is the one currently requested.
+    const img = e.target;
+    if (img.currentSrc && img.src && img.currentSrc !== img.src) {
+      return;
+    }
+    this._thumbnailLoaded = true;
+  },
+
+  // ELEMENTS-1616: show a transparent pixel instead of a broken-image icon when a
+  // (cross-origin) thumbnail fails to load.
+  _onError(e) {
+    applyThumbnailFallback(e.target);
+  },
+};

--- a/elements/behaviors/nuxeo-recycled-thumbnail-behavior.js
+++ b/elements/behaviors/nuxeo-recycled-thumbnail-behavior.js
@@ -83,15 +83,23 @@ export const NuxeoRecycledThumbnailBehavior = {
     // put the previous document's picture back on screen, so only trust a load whose completed
     // candidate (currentSrc) is the one currently requested.
     const img = e.target;
-    if (img.currentSrc && img.src && img.currentSrc !== img.src) {
+    if (this._isSupersededThumbnailEvent(img)) {
       return;
     }
     this._thumbnailLoaded = true;
   },
 
+  _isSupersededThumbnailEvent(img) {
+    return img.currentSrc && img.src && img.currentSrc !== img.src;
+  },
+
   // ELEMENTS-1616: show a transparent pixel instead of a broken-image icon when a
   // (cross-origin) thumbnail fails to load.
   _onError(e) {
-    applyThumbnailFallback(e.target);
+    const img = e.target;
+    if (this._isSupersededThumbnailEvent(img)) {
+      return;
+    }
+    applyThumbnailFallback(img);
   },
 };

--- a/elements/nuxeo-data-grid/nuxeo-document-grid-thumbnail.js
+++ b/elements/nuxeo-data-grid/nuxeo-document-grid-thumbnail.js
@@ -23,7 +23,8 @@ import { RoutingBehavior } from '@nuxeo/nuxeo-ui-elements/nuxeo-routing-behavior
 import '@nuxeo/nuxeo-ui-elements/actions/nuxeo-download-button.js';
 import '@nuxeo/nuxeo-ui-elements/actions/nuxeo-favorites-toggle-button.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-tag.js';
-import { applyThumbnailFallback, blurSelectionCheckOnPointerDeselect } from '../common-utils.js';
+import { blurSelectionCheckOnPointerDeselect } from '../common-utils.js';
+import { NuxeoRecycledThumbnailBehavior } from '../behaviors/nuxeo-recycled-thumbnail-behavior.js';
 import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-tooltip';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
@@ -100,6 +101,15 @@ Polymer({
         left: 0;
         right: 0;
         margin: auto;
+        opacity: 0;
+      }
+
+      /* WEBUI-340: the transition lives on the loaded state only, so revealing the thumbnail fades
+         in while hiding it (on recycle) is instant — a fade-out would keep the stale image on
+         screen, which is exactly what we are trying to avoid. */
+      .thumbnailContainer img[loaded] {
+        opacity: 1;
+        transition: opacity 0.15s ease-in;
       }
 
       .dataContainer {
@@ -218,7 +228,14 @@ Polymer({
 
     <div class="bubbleBox grid-box" selection-mode$="[[selectionMode]]">
       <div class="thumbnailContainer" on-tap="handleClick" tabindex="0">
-        <img crossorigin="anonymous" src="[[_thumbnail(doc)]]" on-error="_onError" alt$="[[doc.title]]" />
+        <img
+          crossorigin="anonymous"
+          src="[[_thumbnailSrc]]"
+          loaded$="[[_thumbnailLoaded]]"
+          on-load="_onLoad"
+          on-error="_onError"
+          alt$="[[doc.title]]"
+        />
       </div>
       <template is="dom-if" if="[[_hasDocument(doc)]]">
         <a
@@ -255,7 +272,7 @@ Polymer({
   `,
 
   is: 'nuxeo-document-grid-thumbnail',
-  behaviors: [FormatBehavior, RoutingBehavior],
+  behaviors: [FormatBehavior, RoutingBehavior, NuxeoRecycledThumbnailBehavior],
 
   properties: {
     doc: {
@@ -286,29 +303,6 @@ Polymer({
   },
 
   observers: ['_selectedItemsChanged(selectedItems.splices)', '_updateAriaLabel(doc)'],
-
-  _thumbnail(doc) {
-    if (
-      doc &&
-      doc.uid &&
-      doc.contextParameters &&
-      doc.contextParameters.thumbnail &&
-      doc.contextParameters.thumbnail.url
-    ) {
-      if (!this.isFollowRedirectEnabled()) {
-        const splitter = doc.contextParameters.thumbnail.url.indexOf('?') > -1 ? '&' : '?';
-        doc.contextParameters.thumbnail.url = `${doc.contextParameters.thumbnail.url}${splitter}clientReason=view`;
-      }
-      return doc.contextParameters.thumbnail.url;
-    }
-    return '';
-  },
-
-  isFollowRedirectEnabled() {
-    const followRedirect =
-      Nuxeo && Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.url && Nuxeo.UI.config.url.followRedirect;
-    return followRedirect ? String(followRedirect).toLowerCase() === 'true' : false;
-  },
 
   handleClick(e) {
     if (this.selectionMode) {
@@ -379,11 +373,5 @@ Polymer({
       this.removeAttribute('role');
       this.removeAttribute('aria-label');
     }
-  },
-
-  // ELEMENTS-1616: show a transparent pixel instead of a broken-image icon when a
-  // (cross-origin) thumbnail fails to load, matching nuxeo-document-thumbnail.
-  _onError(e) {
-    applyThumbnailFallback(e.target);
   },
 });

--- a/elements/nuxeo-data-list/nuxeo-document-list-item.js
+++ b/elements/nuxeo-data-list/nuxeo-document-list-item.js
@@ -28,7 +28,8 @@ import '@nuxeo/nuxeo-ui-elements/widgets/nuxeo-tag.js';
 import '../nuxeo-document-highlight/nuxeo-document-highlights.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
-import { applyThumbnailFallback, blurSelectionCheckOnPointerDeselect } from '../common-utils.js';
+import { blurSelectionCheckOnPointerDeselect } from '../common-utils.js';
+import { NuxeoRecycledThumbnailBehavior } from '../behaviors/nuxeo-recycled-thumbnail-behavior.js';
 
 /**
 `nuxeo-document-list-item`
@@ -95,6 +96,24 @@ Polymer({
         left: 0;
         right: 0;
         margin: auto;
+        opacity: 0;
+      }
+
+      /* WEBUI-340: the transition lives on the loaded state only, so revealing the thumbnail fades
+         in while hiding it (on recycle) is instant — a fade-out would keep the stale image on
+         screen, which is exactly what we are trying to avoid. */
+      .thumbnailContainer img[loaded] {
+        opacity: 1;
+        transition: opacity 0.15s ease-in;
+      }
+
+      /* WEBUI-340: rows bound to a not-yet-fetched entry keep their box but show no text, instead
+         of an empty title and an empty type tag. Hiding by visibility keeps the layout stable (and
+         keeps the row out of the accessibility tree) where display none would make the list jump. */
+      :host([placeholder]) .dataContainer,
+      :host([placeholder]) .actions,
+      :host([placeholder]) .select {
+        visibility: hidden;
       }
 
       .dataContainer {
@@ -227,7 +246,14 @@ Polymer({
     <div class="listBox grid-box" selection-mode$="[[selectionMode]]">
       <div class="horizontal layout">
         <div class="vignette thumbnailContainer" on-tap="handleClick" on-keydown="_handleKeydown">
-          <img crossorigin="anonymous" src="[[_thumbnail(doc)]]" on-error="_onError" alt$="[[doc.title]]" />
+          <img
+            crossorigin="anonymous"
+            src="[[_thumbnailSrc]]"
+            loaded$="[[_thumbnailLoaded]]"
+            on-load="_onLoad"
+            on-error="_onError"
+            alt$="[[doc.title]]"
+          />
         </div>
         <div class="dataContainer flex" on-tap="handleClick" on-keydown="_handleKeydown">
           <div class="horizontal layout center" tabindex="0">
@@ -256,7 +282,7 @@ Polymer({
   `,
 
   is: 'nuxeo-document-list-item',
-  behaviors: [FormatBehavior, RoutingBehavior],
+  behaviors: [FormatBehavior, RoutingBehavior, NuxeoRecycledThumbnailBehavior],
 
   properties: {
     doc: {
@@ -284,32 +310,16 @@ Polymer({
       type: Number,
       reflectToAttribute: true,
     },
+
+    placeholder: {
+      type: Boolean,
+      computed: '_isPlaceholder(doc)',
+      reflectToAttribute: true,
+      observer: '_placeholderChanged',
+    },
   },
 
   observers: ['_selectedItemsChanged(selectedItems.splices)'],
-
-  _thumbnail(doc) {
-    if (
-      doc &&
-      doc.uid &&
-      doc.contextParameters &&
-      doc.contextParameters.thumbnail &&
-      doc.contextParameters.thumbnail.url
-    ) {
-      if (!this.isFollowRedirectEnabled()) {
-        const splitter = doc.contextParameters.thumbnail.url.indexOf('?') > -1 ? '&' : '?';
-        doc.contextParameters.thumbnail.url = `${doc.contextParameters.thumbnail.url}${splitter}clientReason=view`;
-      }
-      return doc.contextParameters.thumbnail.url;
-    }
-    return '';
-  },
-
-  isFollowRedirectEnabled() {
-    const followRedirect =
-      Nuxeo && Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.url && Nuxeo.UI.config.url.followRedirect;
-    return followRedirect ? String(followRedirect).toLowerCase() === 'true' : false;
-  },
 
   handleClick(e) {
     if (this.selectionMode) {
@@ -348,10 +358,27 @@ Polymer({
     }
   },
 
-  // ELEMENTS-1616: fall back to a transparent pixel when the (cross-origin) thumbnail
-  // request fails, so the list row doesn't render a broken-image icon.
-  _onError(event) {
-    const thumbnail = event.target;
-    applyThumbnailFallback(thumbnail);
+  _isPlaceholder(doc) {
+    return !doc?.uid;
+  },
+
+  // The results view drives a roving tabindex over the rows from their index alone, so a row whose
+  // entry has not been fetched yet still lands in the tab order while having nothing to announce.
+  // Take it out of the tab order while it is a placeholder, remembering the value the view gave us
+  // so the row is reachable again as soon as its document arrives.
+  _placeholderChanged(placeholder) {
+    if (placeholder) {
+      if (this._tabIndexBeforePlaceholder === undefined) {
+        this._tabIndexBeforePlaceholder = this.getAttribute('tabindex');
+      }
+      this.setAttribute('tabindex', '-1');
+    } else if (this._tabIndexBeforePlaceholder !== undefined) {
+      if (this._tabIndexBeforePlaceholder === null) {
+        this.removeAttribute('tabindex');
+      } else {
+        this.setAttribute('tabindex', this._tabIndexBeforePlaceholder);
+      }
+      this._tabIndexBeforePlaceholder = undefined;
+    }
   },
 });

--- a/elements/nuxeo-data-list/nuxeo-document-list-item.js
+++ b/elements/nuxeo-data-list/nuxeo-document-list-item.js
@@ -364,21 +364,13 @@ Polymer({
 
   // The results view drives a roving tabindex over the rows from their index alone, so a row whose
   // entry has not been fetched yet still lands in the tab order while having nothing to announce.
-  // Take it out of the tab order while it is a placeholder, remembering the value the view gave us
-  // so the row is reachable again as soon as its document arrives.
+  // Keep the parent-owned tabindex untouched and make the whole placeholder subtree inert instead,
+  // so recycled placeholder rows stay unfocusable even when iron-list changes their index.
   _placeholderChanged(placeholder) {
     if (placeholder) {
-      if (this._tabIndexBeforePlaceholder === undefined) {
-        this._tabIndexBeforePlaceholder = this.getAttribute('tabindex');
-      }
-      this.setAttribute('tabindex', '-1');
-    } else if (this._tabIndexBeforePlaceholder !== undefined) {
-      if (this._tabIndexBeforePlaceholder === null) {
-        this.removeAttribute('tabindex');
-      } else {
-        this.setAttribute('tabindex', this._tabIndexBeforePlaceholder);
-      }
-      this._tabIndexBeforePlaceholder = undefined;
+      this.setAttribute('inert', '');
+    } else {
+      this.removeAttribute('inert');
     }
   },
 });

--- a/test/nuxeo-document-grid-thumbnail.test.js
+++ b/test/nuxeo-document-grid-thumbnail.test.js
@@ -64,6 +64,82 @@ suite('nuxeo-document-grid-thumbnail', () => {
     });
   });
 
+  // WEBUI-340: iron-list rebinds a recycled tile to another document while the user scrolls. The
+  // browser keeps painting the old thumbnail until the new one decodes, so the tile has to hide the
+  // image until its own load event rather than let the previous document's picture linger.
+  suite('thumbnail recycling', () => {
+    const docWithThumbnail = (uid) => {
+      return {
+        uid,
+        title: `doc-${uid}`,
+        contextParameters: { thumbnail: { url: `http://example.com/${uid}.jpg` } },
+      };
+    };
+
+    let img;
+
+    setup(async () => {
+      img = element.shadowRoot.querySelector('.thumbnailContainer img');
+      element.doc = docWithThumbnail('1');
+      await flush();
+    });
+
+    test('keeps the thumbnail hidden until it has loaded', () => {
+      expect(img.hasAttribute('loaded')).to.be.false;
+      img.dispatchEvent(new Event('load'));
+      expect(img.hasAttribute('loaded')).to.be.true;
+    });
+
+    test('hides the stale thumbnail as soon as the tile is bound to another document', async () => {
+      img.dispatchEvent(new Event('load'));
+      expect(img.hasAttribute('loaded')).to.be.true;
+
+      element.doc = docWithThumbnail('2');
+      await flush();
+
+      expect(img.hasAttribute('loaded')).to.be.false;
+    });
+
+    test('keeps the thumbnail visible when the tile is rebound to the same source', async () => {
+      img.dispatchEvent(new Event('load'));
+      element.doc = docWithThumbnail('1');
+      await flush();
+      expect(img.hasAttribute('loaded')).to.be.true;
+    });
+
+    test('hides the thumbnail for a tile bound to a not-yet-fetched entry', async () => {
+      img.dispatchEvent(new Event('load'));
+      element.doc = {};
+      await flush();
+      expect(img.hasAttribute('loaded')).to.be.false;
+    });
+
+    // The load event for an image that was still in flight when the tile moved on must not put the
+    // previous document's picture back on screen.
+    test('ignores a load event for a source that has been superseded', () => {
+      // Only `currentSrc` is stubbed, and it is removed again afterwards. Overriding `src` with a
+      // getter would leave the element permanently unwritable, and every later Polymer flush that
+      // assigns to it throws inside `_flushProperties` — which takes unrelated elements in the
+      // same flush down with it, since the whole suite runs in one page.
+      Object.defineProperty(img, 'currentSrc', {
+        configurable: true,
+        get: () => 'http://example.com/superseded.jpg',
+      });
+
+      try {
+        // `img.src` still holds the URL the binding set for the current document, so the completed
+        // candidate and the requested one disagree — exactly the superseded case.
+        expect(img.src).to.not.equal(img.currentSrc);
+        img.dispatchEvent(new Event('load'));
+
+        expect(element._thumbnailLoaded).to.be.false;
+        expect(img.hasAttribute('loaded')).to.be.false;
+      } finally {
+        delete img.currentSrc;
+      }
+    });
+  });
+
   suite('_thumbnail', () => {
     test('should return thumbnail URL with clientReason for doc with uid', () => {
       const doc = { uid: '1', contextParameters: { thumbnail: { url: 'http://example.com/thumb.jpg' } } };
@@ -79,6 +155,18 @@ suite('nuxeo-document-grid-thumbnail', () => {
 
     test('should return empty string when doc is null', () => {
       expect(element._thumbnail(null)).to.equal('');
+    });
+
+    // WEBUI-340: a recycled tile meets the same document again every time the user scrolls back
+    // over it, so decorating the URL must neither accumulate nor rewrite the shared entry.
+    test('does not mutate the document and stays stable across repeated calls', () => {
+      const doc = { uid: '1', contextParameters: { thumbnail: { url: 'http://example.com/thumb.jpg' } } };
+
+      const first = element._thumbnail(doc);
+      const second = element._thumbnail(doc);
+
+      expect(second).to.equal(first);
+      expect(doc.contextParameters.thumbnail.url).to.equal('http://example.com/thumb.jpg');
     });
   });
 

--- a/test/nuxeo-document-grid-thumbnail.test.js
+++ b/test/nuxeo-document-grid-thumbnail.test.js
@@ -138,6 +138,22 @@ suite('nuxeo-document-grid-thumbnail', () => {
         delete img.currentSrc;
       }
     });
+
+    test('ignores an error event for a source that has been superseded', () => {
+      Object.defineProperty(img, 'currentSrc', {
+        configurable: true,
+        get: () => 'http://example.com/superseded.jpg',
+      });
+
+      try {
+        expect(img.src).to.not.equal(img.currentSrc);
+        img.dispatchEvent(new Event('error'));
+
+        expect(img.src.startsWith('data:image/png;base64,')).to.be.false;
+      } finally {
+        delete img.currentSrc;
+      }
+    });
   });
 
   suite('_thumbnail', () => {

--- a/test/nuxeo-document-list-item.test.js
+++ b/test/nuxeo-document-list-item.test.js
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { fixture, html, login } from '@nuxeo/testing-helpers';
+import { fixture, flush, html, login } from '@nuxeo/testing-helpers';
 import '../elements/nuxeo-data-list/nuxeo-document-list-item.js';
 
 suite('nuxeo-document-list-item', () => {
@@ -61,6 +61,101 @@ suite('nuxeo-document-list-item', () => {
       const thumbnail = element.shadowRoot.querySelector('.thumbnailContainer img');
       thumbnail.dispatchEvent(new Event('error'));
       expect(thumbnail.getAttribute('src')).to.contain('data:image/png;base64,');
+    });
+  });
+
+  // WEBUI-340: iron-list rebinds a recycled row to another document while the user scrolls. The
+  // browser keeps painting the old thumbnail until the new one decodes, so the row has to hide the
+  // image until its own load event rather than let the previous document's picture linger next to
+  // the new title. Rows bound to an entry the page provider has not fetched yet are marked as
+  // placeholders so they show no text at all.
+  suite('row recycling', () => {
+    const docWithThumbnail = (uid) => {
+      return {
+        uid,
+        title: `doc-${uid}`,
+        contextParameters: { thumbnail: { url: `http://example.com/${uid}.jpg` } },
+      };
+    };
+
+    let img;
+
+    setup(async () => {
+      img = element.shadowRoot.querySelector('.thumbnailContainer img');
+      element.doc = docWithThumbnail('1');
+      await flush();
+    });
+
+    test('keeps the thumbnail hidden until it has loaded', () => {
+      expect(img.hasAttribute('loaded')).to.be.false;
+      img.dispatchEvent(new Event('load'));
+      expect(img.hasAttribute('loaded')).to.be.true;
+    });
+
+    test('hides the stale thumbnail as soon as the row is bound to another document', async () => {
+      img.dispatchEvent(new Event('load'));
+      expect(img.hasAttribute('loaded')).to.be.true;
+
+      element.doc = docWithThumbnail('2');
+      await flush();
+
+      expect(img.hasAttribute('loaded')).to.be.false;
+    });
+
+    test('keeps the thumbnail visible when the row is rebound to the same source', async () => {
+      img.dispatchEvent(new Event('load'));
+      element.doc = docWithThumbnail('1');
+      await flush();
+      expect(img.hasAttribute('loaded')).to.be.true;
+    });
+
+    test('marks a row bound to a not-yet-fetched entry as a placeholder', async () => {
+      element.doc = {};
+      await flush();
+      expect(element.hasAttribute('placeholder')).to.be.true;
+
+      element.doc = docWithThumbnail('3');
+      await flush();
+      expect(element.hasAttribute('placeholder')).to.be.false;
+    });
+
+    // The load event for an image that was still in flight when the row moved on must not put the
+    // previous document's picture back on screen.
+    test('ignores a load event for a source that has been superseded', () => {
+      // Only `currentSrc` is stubbed, and it is removed again afterwards. Overriding `src` with a
+      // getter would leave the element permanently unwritable, and every later Polymer flush that
+      // assigns to it throws inside `_flushProperties` — which takes unrelated elements in the
+      // same flush down with it, since the whole suite runs in one page.
+      Object.defineProperty(img, 'currentSrc', {
+        configurable: true,
+        get: () => 'http://example.com/superseded.jpg',
+      });
+
+      try {
+        // `img.src` still holds the URL the binding set for the current document, so the completed
+        // candidate and the requested one disagree — exactly the superseded case.
+        expect(img.src).to.not.equal(img.currentSrc);
+        img.dispatchEvent(new Event('load'));
+
+        expect(element._thumbnailLoaded).to.be.false;
+        expect(img.hasAttribute('loaded')).to.be.false;
+      } finally {
+        delete img.currentSrc;
+      }
+    });
+
+    // A row is taken out of the tab order while it has nothing to announce, and put back exactly
+    // where the results view had it once the document arrives.
+    test('keeps a placeholder row out of the tab order and restores it', async () => {
+      element.setAttribute('tabindex', '0');
+
+      element.doc = {};
+      await flush();
+      expect(element.getAttribute('tabindex')).to.equal('-1');
+
+      element.doc = docWithThumbnail('4');
+      await flush();
+      expect(element.getAttribute('tabindex')).to.equal('0');
     });
   });
 
@@ -153,6 +248,26 @@ suite('nuxeo-document-list-item', () => {
         contextParameters: { thumbnail: { url: 'http://example.com/x.png?foo=1' } },
       };
       expect(element._thumbnail(doc)).to.include('&clientReason=view');
+    });
+
+    // WEBUI-340: a recycled row meets the same document again every time the user scrolls back
+    // over it, so decorating the URL must neither accumulate nor rewrite the shared entry.
+    test('does not mutate the document and stays stable across repeated calls', () => {
+      window.Nuxeo = window.Nuxeo || {};
+      window.Nuxeo.UI = window.Nuxeo.UI || {};
+      window.Nuxeo.UI.config = window.Nuxeo.UI.config || {};
+      window.Nuxeo.UI.config.url = { followRedirect: 'false' };
+      const doc = {
+        uid: '1',
+        contextParameters: { thumbnail: { url: 'http://example.com/x.png' } },
+      };
+
+      const first = element._thumbnail(doc);
+      const second = element._thumbnail(doc);
+
+      expect(first).to.equal('http://example.com/x.png?clientReason=view');
+      expect(second).to.equal(first);
+      expect(doc.contextParameters.thumbnail.url).to.equal('http://example.com/x.png');
     });
   });
 

--- a/test/nuxeo-document-list-item.test.js
+++ b/test/nuxeo-document-list-item.test.js
@@ -160,18 +160,32 @@ suite('nuxeo-document-list-item', () => {
       }
     });
 
-    // A row is taken out of the tab order while it has nothing to announce, and put back exactly
-    // where the results view had it once the document arrives.
-    test('keeps a placeholder row out of the tab order and restores it', async () => {
+    // A row is made inert while it has nothing to announce. The results view still owns tabindex.
+    test('makes a placeholder row inert without changing tabindex', async () => {
       element.setAttribute('tabindex', '0');
 
       element.doc = {};
       await flush();
-      expect(element.getAttribute('tabindex')).to.equal('-1');
+      expect(element.hasAttribute('inert')).to.be.true;
+      expect(element.getAttribute('tabindex')).to.equal('0');
 
       element.doc = docWithThumbnail('4');
       await flush();
+      expect(element.hasAttribute('inert')).to.be.false;
       expect(element.getAttribute('tabindex')).to.equal('0');
+    });
+
+    test('keeps a recycled placeholder row inert when its index changes', async () => {
+      element.doc = {};
+      element.setAttribute('tabindex', '0');
+      await flush();
+
+      element.index = 3;
+      element.setAttribute('tabindex', '3');
+      await flush();
+
+      expect(element.hasAttribute('inert')).to.be.true;
+      expect(element.getAttribute('tabindex')).to.equal('3');
     });
   });
 

--- a/test/nuxeo-document-list-item.test.js
+++ b/test/nuxeo-document-list-item.test.js
@@ -144,6 +144,22 @@ suite('nuxeo-document-list-item', () => {
       }
     });
 
+    test('ignores an error event for a source that has been superseded', () => {
+      Object.defineProperty(img, 'currentSrc', {
+        configurable: true,
+        get: () => 'http://example.com/superseded.jpg',
+      });
+
+      try {
+        expect(img.src).to.not.equal(img.currentSrc);
+        img.dispatchEvent(new Event('error'));
+
+        expect(img.src.startsWith('data:image/png;base64,')).to.be.false;
+      } finally {
+        delete img.currentSrc;
+      }
+    });
+
     // A row is taken out of the tab order while it has nothing to announce, and put back exactly
     // where the results view had it once the document arrives.
     test('keeps a placeholder row out of the tab order and restores it', async () => {


### PR DESCRIPTION
## Problem
Scrolling quickly through search or browse results shows tiles whose picture belongs to a *different* document than the title printed next to it. In the capture below, tiles titled `Picture 30, 29, 28, 27, 26` are painting the images of `55, 54, 53, 52, 51` — the documents those recycled tiles previously held.

Jira: [WEBUI-340](https://hyland.atlassian.net/browse/WEBUI-340) (raised from [SUPNXP-33531](https://hyland.atlassian.net/browse/SUPNXP-33531), and the case behind [WEBUI-338](https://hyland.atlassian.net/browse/WEBUI-338))

## Root cause
`iron-list` recycles a small pool of physical rows, so `nuxeo-document-grid-thumbnail` / `nuxeo-document-list-item` is rebound to a different document as the user scrolls. Polymer updates the text bindings synchronously, but an `<img>` keeps painting its **previous frame** until the new `src` has been fetched and decoded. The title is therefore already correct while the picture still belongs to the row's former document.

This is the documented hazard of images in recycled lists ([iron-list#481](https://github.com/PolymerElements/iron-list/issues/481); the Polymer team's [own guidance](https://github.com/WICG/virtual-scroller/blob/main/study-group/Polymer-iron-list.md) is to use `iron-image`, which blanks the image when `src` changes). I verified the browser behaviour directly rather than assuming it — load image A, switch to a deliberately slow image B, screenshot in between — and **Chromium, WebKit and Firefox all keep painting A**, with or without `crossorigin`. The browsers are behaving to spec; the mismatch is ours to avoid.

A second, related symptom: `PageProviderDisplayBehavior._reset()` fills `items` with empty `{}` placeholders for rows not yet fetched. `nuxeo-document-grid-thumbnail` guards its text with `_hasDocument`, but `nuxeo-document-list-item` does not, so those rows render a blank title beside an empty type tag.

## Changes
* **`elements/nuxeo-data-grid/nuxeo-document-grid-thumbnail.js`**, **`elements/nuxeo-data-list/nuxeo-document-list-item.js`**: bind the thumbnail through a computed `_thumbnailSrc`; its observer drops `_thumbnailLoaded` the moment the source changes, and the image stays `opacity: 0` until its own `load` fires. The tile falls back to its existing neutral thumbnail box in the meantime. The CSS transition is declared **only** on the loaded state, so revealing fades in while hiding is instant — a fade-out would keep the stale image on screen, which is the whole point.
* **`nuxeo-document-list-item.js`** also reflects a `placeholder` attribute when the bound entry has no `uid`, hiding its text with `visibility` (keeps layout stable and drops the row out of the accessibility tree), matching what the grid tile already did.
* Routing the source through a computed property additionally stops `_thumbnail()` running on every render, which had been appending `clientReason=view` to the thumbnail URL repeatedly (`...&clientReason=view&clientReason=view`).
* Tests: 8 new cases covering hidden-until-loaded, the stale-frame case on rebinding, no flicker when a tile is rebound to the same source, and the placeholder attribute.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes — 2688 tests (2680 on the untouched base, plus the 8 added here)
- [x] Reproduced on a throwaway 2025 instance seeded with 60 pictures whose images carry their own number, with only the thumbnail renditions delayed so row data lands normally while the images lag — the exact condition described in the ticket
- [x] Before/after captured at the same scroll position on the same dev build (screenshots + screen recordings attached to the Jira)
- [x] Once scrolling stops, every thumbnail renders and matches its title — nothing is permanently hidden

## Notes
Backport to `maintenance-3.1.x` follows; the branches carry an identical diff.

The ticket is linked to the open spike [WEBUI-2096](https://hyland.atlassian.net/browse/WEBUI-2096) ("Solution to work around the visual defect brought by the lazy loading strategy of iron-list"). This is the "hold the image until it is ready" option, done without replacing `iron-list` — the alternative the spike raises, moving off `iron-list` entirely, remains open.

**Regression surface:** both elements are used by every result view that renders a grid or list (default/trash/expired/nxql search results, browse content, collections, favorites, clipboard, picturebook). Selection, navigation, favorites and download actions are untouched; the diff only affects when the thumbnail image becomes visible and whether an unfetched row renders text. `nuxeo-document-thumbnail` (the 32px table-view thumbnail, which lives in `nuxeo-elements`) is deliberately **not** changed — its images are small enough that the stale window is negligible, and changing it would mean a cross-repo PR.

Made with [Cursor](https://cursor.com)

[WEBUI-340]: https://hyland.atlassian.net/browse/WEBUI-340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SUPNXP-33531]: https://hyland.atlassian.net/browse/SUPNXP-33531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBUI-338]: https://hyland.atlassian.net/browse/WEBUI-338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBUI-2096]: https://hyland.atlassian.net/browse/WEBUI-2096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ