### PR TITLE
task: block Cursor co-author trailers that fail CLA checks [lts-2025]

### DIFF
--- a/.cursor/rules/git-cla-commits.mdc
+++ b/.cursor/rules/git-cla-commits.mdc
@@ -16,7 +16,9 @@ alwaysApply: true
 ## Always do this
 
 - Author and commit as the human contributor only, using the email address covered by their signed CLA.
-- Before pushing a PR branch, verify: `gh api repos/nuxeo/nuxeo-elements/pulls/<n>/commits --jq '.[].commit.author.email' | sort -u` (or the web-ui repo) shows only the contributor's email.
+- Before pushing a PR branch, inspect every author, committer, and commit message:
+  `gh api repos/nuxeo/nuxeo-elements/pulls/<n>/commits --jq '.[] | {sha, author: .commit.author.email, committer: .commit.committer.email, message: .commit.message}'`
+  (or the web-ui repo), and verify that no Cursor agent identity or co-author trailer is present.
 - If history is polluted, squash to one clean commit on the PR base, then rewrite with `git commit-tree` and a message file (normal `git commit` from the agent shell may re-inject Cursor co-author trailers).
 
 ## Local guard

--- a/.cursor/rules/git-cla-commits.mdc
+++ b/.cursor/rules/git-cla-commits.mdc
@@ -1,9 +1,9 @@
 ---
-description: Keep git commits CLA-clean for nuxeo/nuxeo-elements and nuxeo/nuxeo-web-ui PRs
+description: Keep git commits CLA-clean for this repository
 alwaysApply: true
 ---
 
-# CLA-safe commits (nuxeo-elements / nuxeo-web-ui)
+# CLA-safe commits
 
 `license/cla` (cla-assistant.io) fails when a PR contains commits or co-authors that are not covered by the contributor's signed CLA.
 
@@ -17,10 +17,11 @@ alwaysApply: true
 
 - Author and commit as the human contributor only, using the email address covered by their signed CLA.
 - Before pushing a PR branch, inspect every author, committer, and commit message:
-  `gh api repos/nuxeo/nuxeo-elements/pulls/<n>/commits --jq '.[] | {sha, author: .commit.author.email, committer: .commit.committer.email, message: .commit.message}'`
-  (or the web-ui repo), and verify that no Cursor agent identity or co-author trailer is present.
+  `gh api repos/<owner>/<repo>/pulls/<n>/commits --jq '.[] | {sha, author: .commit.author.email, committer: .commit.committer.email, message: .commit.message}'`,
+  and verify that no Cursor agent identity or co-author trailer is present.
 - If history is polluted, squash to one clean commit on the PR base, then rewrite with `git commit-tree` and a message file (normal `git commit` from the agent shell may re-inject Cursor co-author trailers).
 
 ## Local guard
 
-Both repos run `scripts/git/commit-msg-cla.sh` via Husky `commit-msg`. Commits with Cursor co-author trailers are rejected before push.
+This repository runs `scripts/git/commit-msg-cla.sh` via Husky `commit-msg`. Commits with Cursor co-author trailers
+are rejected before push.

--- a/.cursor/rules/git-cla-commits.mdc
+++ b/.cursor/rules/git-cla-commits.mdc
@@ -1,0 +1,24 @@
+---
+description: Keep git commits CLA-clean for nuxeo/nuxeo-elements and nuxeo/nuxeo-web-ui PRs
+alwaysApply: true
+---
+
+# CLA-safe commits (nuxeo-elements / nuxeo-web-ui)
+
+`license/cla` (cla-assistant.io) fails when a PR contains commits or co-authors that are not covered by the contributor's signed CLA.
+
+## Never do this
+
+- Do **not** add `Co-authored-by: Cursor <cursoragent@cursor.com>` (or any `cursoragent@` trailer).
+- Do **not** create commits authored/committed as `Cursor Agent <cursoragent@cursor.com>`.
+- Do **not** let cloud agents push commits directly to PR branches.
+
+## Always do this
+
+- Author and commit as the human contributor only, using the email address covered by their signed CLA.
+- Before pushing a PR branch, verify: `gh api repos/nuxeo/nuxeo-elements/pulls/<n>/commits --jq '.[].commit.author.email' | sort -u` (or the web-ui repo) shows only the contributor's email.
+- If history is polluted, squash to one clean commit on the PR base, then rewrite with `git commit-tree` and a message file (normal `git commit` from the agent shell may re-inject Cursor co-author trailers).
+
+## Local guard
+
+Both repos run `scripts/git/commit-msg-cla.sh` via Husky `commit-msg`. Commits with Cursor co-author trailers are rejected before push.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,10 @@ npm test                     # Web Test Runner unit tests — must pass
 - Always run `npm run format` before committing. Pre-commit hooks enforce this.
 - Do NOT commit `.only` in test files — the `no-only-tests` ESLint rule blocks it.
 
+## CLA-safe commits
+
+`license/cla` fails if any commit or `Co-authored-by` trailer names `cursoragent@cursor.com`. Never add `Co-authored-by: Cursor` and never commit as the Cursor agent user. Husky runs `scripts/git/commit-msg-cla.sh` on every commit to block those trailers. If a PR branch is already polluted, squash on the PR base and rewrite with `git commit-tree` + a message file (agent `git commit` may re-inject Cursor trailers).
+
 ## Project Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "build:analyze": "webpack --env production --analyze",
     "lint:eslint": "eslint .",
     "format:eslint": "eslint . --fix",
-    "lint:prettier": "prettier \"**/*.{js,html}\" --list-different || (echo '↑↑ these files are not prettier formatted ↑↑' && exit 1)",
+    "lint:prettier": "prettier \"**/*.{js,html}\" --list-different || (echo '\u2191\u2191 these files are not prettier formatted \u2191\u2191' && exit 1)",
     "format:prettier": "prettier \"**/*.{js,html}\" --write",
     "lint": " npm run lint:eslint && npm run lint:prettier",
     "win-lint": " npm run lint:eslint && npm run lint:prettier",
@@ -216,7 +216,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged",
+      "commit-msg": "scripts/git/commit-msg-cla.sh"
     }
   },
   "lint-staged": {

--- a/scripts/git/commit-msg-cla.sh
+++ b/scripts/git/commit-msg-cla.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Reject commit messages that would fail cla-assistant.io on nuxeo/* PRs.
+set -eu
+
+MSG_FILE=${1:-}
+
+if [ -z "$MSG_FILE" ] || [ ! -f "$MSG_FILE" ]; then
+  echo "commit-msg-cla: missing commit message file" >&2
+  exit 1
+fi
+
+if grep -qiE '^Co-authored-by:.*cursor' "$MSG_FILE"; then
+  echo "commit-msg-cla: remove Co-authored-by: Cursor from the commit message (CLA check)." >&2
+  exit 1
+fi
+
+if grep -qi 'cursoragent@cursor.com' "$MSG_FILE"; then
+  echo "commit-msg-cla: cursoragent@cursor.com is not CLA-covered; use your Hyland email only." >&2
+  exit 1
+fi
+
+exit 0

--- a/scripts/git/commit-msg-cla.sh
+++ b/scripts/git/commit-msg-cla.sh
@@ -2,20 +2,16 @@
 # Reject commit messages that would fail cla-assistant.io on nuxeo/* PRs.
 set -eu
 
-MSG_FILE=${1:-}
+MSG_FILE=${1:-${HUSKY_GIT_PARAMS:-}}
 
 if [ -z "$MSG_FILE" ] || [ ! -f "$MSG_FILE" ]; then
   echo "commit-msg-cla: missing commit message file" >&2
   exit 1
 fi
 
-if grep -qiE '^Co-authored-by:.*cursor' "$MSG_FILE"; then
-  echo "commit-msg-cla: remove Co-authored-by: Cursor from the commit message (CLA check)." >&2
-  exit 1
-fi
-
-if grep -qi 'cursoragent@cursor.com' "$MSG_FILE"; then
-  echo "commit-msg-cla: cursoragent@cursor.com is not CLA-covered; use your Hyland email only." >&2
+if grep -qiE '^Co-authored-by:[[:space:]]*[^<]*<[[:space:]]*cursoragent@cursor\.com[[:space:]]*>[[:space:]]*$' \
+  "$MSG_FILE"; then
+  echo "commit-msg-cla: remove the Cursor agent co-author trailer; its email is not CLA-covered." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Add `scripts/git/commit-msg-cla.sh` Husky hook to reject commits with `Co-authored-by: Cursor` or `cursoragent@cursor.com` trailers that break `license/cla`
- Document CLA-safe commit rules in `AGENTS.md`
- Add `.cursor/rules/git-cla-commits.mdc` so agents stop injecting Cursor co-authors

## Test plan
- [x] Hook rejects a message containing `Co-authored-by: Cursor <cursoragent@cursor.com>`
- [x] Hook allows a normal commit message
- [x] `npm run lint` passes

Made with [Cursor](https://cursor.com)