### PR TITLE
WEBUI-500: Format themes/base.js with Prettier [lts-2025]

### DIFF
--- a/themes/base.js
+++ b/themes/base.js
@@ -161,7 +161,8 @@ const template = html`
         font-style: normal;
         font-weight: 400;
         font-display: swap;
-        src: url('../fonts/Inter-Regular.woff2?v=3.13') format('woff2'),
+        src:
+          url('../fonts/Inter-Regular.woff2?v=3.13') format('woff2'),
           url('../fonts/Inter-Regular.woff?v=3.13') format('woff');
       }
 
@@ -170,7 +171,8 @@ const template = html`
         font-style: normal;
         font-weight: 600;
         font-display: swap;
-        src: url('../fonts/Inter-SemiBold.woff2?v=3.13') format('woff2'),
+        src:
+          url('../fonts/Inter-SemiBold.woff2?v=3.13') format('woff2'),
           url('../fonts/Inter-SemiBold.woff?v=3.13') format('woff');
       }
 
@@ -179,7 +181,8 @@ const template = html`
         font-style: normal;
         font-weight: 700;
         font-display: swap;
-        src: url('../fonts/Inter-Bold.woff2?v=3.13') format('woff2'),
+        src:
+          url('../fonts/Inter-Bold.woff2?v=3.13') format('woff2'),
           url('../fonts/Inter-Bold.woff?v=3.13') format('woff');
       }
 
@@ -699,7 +702,7 @@ const template = html`
         /* layout rules */
         --nuxeo-widget: {
           margin-bottom: 16px;
-        }
+        };
       }
 
       @media (max-width: 1024px) {
@@ -711,7 +714,7 @@ const template = html`
           --nuxeo-dialog: {
             min-width: 0;
             width: 90%;
-          }
+          };
         }
       }
 


### PR DESCRIPTION
## Problem

`lts-2025` is red at its tip. **Lint Web UI** fails with:

```
themes/base.js
↑↑ these files are not prettier formatted ↑↑
Process completed with exit code 1
```

This turns the **Cross repo check** red ([run 33604931990](https://github.com/nuxeo/nuxeo-web-ui/actions/runs/33604931990/job/100166681733)), and it also fails every PR's lint job that merges the branch tip. `maintenance-3.1.x` is broken identically and is fixed by the companion PR below.

Jira: [WEBUI-500](https://hyland.atlassian.net/browse/WEBUI-500)

## Root cause

[feba34b6](https://github.com/nuxeo/nuxeo-web-ui/commit/feba34b60a565713c182cea3f98df971a0de79f4) ("WEBUI-500: Apply accessible text spacing to Create/Import form fields", [#3391](https://github.com/nuxeo/nuxeo-web-ui/pull/3391)) added a four-line CSS comment to the `--nuxeo-label` mixin inside the base theme's ``html` ` `` template.

Prettier formats CSS embedded in `html` tagged templates. Adding that comment changed how Prettier handles the template's `<style>` block, and it now formats the whole block — including three multi-value `src:` `@font-face` declarations and two Polymer mixin closings that it had previously left untouched. Those lines are **older than the WEBUI-500 change** and were never themselves edited; the commit simply changed whether Prettier rewrites them.

The file was not re-run through Prettier before merging, so `prettier --list-different` now reports it. Confirmed by bisecting the file with the pinned Prettier 3.8.3:

| Commit | Result |
|---|---|
| feba34b6 (WEBUI-500) | **fails** |
| 469433d9 (parent) | passes |
| 7c1c4173 | passes |

## Changes

* **`themes/base.js`**: `prettier --write` output, no hand edits. Two kinds of change, both safe:
  * Three `src:` `@font-face` declarations gain a line break inside the declaration value. CSS ignores whitespace there, so the fonts resolve exactly as before.
  * Two mixin closings (`--nuxeo-widget`, `--nuxeo-dialog`) gain a trailing semicolon: `}` becomes `};`. This is already the form used everywhere else in this repo (1485 occurrences), including the identical `--app-header-background-rear-layer` mixin in `elements/nuxeo-app.js`, so it makes these two consistent rather than introducing anything new.

No selector, property, or value is added, removed, or changed. The rendered theme is byte-for-byte equivalent.

## Test plan

- [x] `npm run lint` passes (eslint clean, `prettier --list-different` reports nothing) — this is the exact gate that was failing
- [x] `npm test` passes — 2682 passed, 0 failed
- [x] `prettier --check themes/base.js` is idempotent (re-running produces no further change)
- [ ] Confirm the Cross repo check goes green on the branch tip once merged

## Notes

Backport pair — the same commit is cherry-picked onto `maintenance-3.1.x` in companion PR [#3499](https://github.com/nuxeo/nuxeo-web-ui/pull/3499). `themes/base.js` is byte-identical on both lines, so the two diffs are identical.

Formatting only; no functional change and no product behaviour to re-verify.

Made with [Cursor](https://cursor.com)

[WEBUI-500]: https://hyland.atlassian.net/browse/WEBUI-500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ