### PR TITLE
task: Document avoiding optional chaining in fix-nuxeo-web-ui-bug skill [maintenance-3.1.x]

### DIFF
--- a/.agents/skills/fix-nuxeo-web-ui-bug/SKILL.md
+++ b/.agents/skills/fix-nuxeo-web-ui-bug/SKILL.md
@@ -305,6 +305,9 @@ Tear them down in Phase 10.
   `nuxeo-elements` repo) before editing. **Print the root cause to the user** — a clear,
   explicit statement of what is actually causing the bug (file/function/line and why) — before
   making any change. Then make the **minimal** change in `nuxeo-web-ui`.
+- **When the fix lands in `nuxeo-elements`:** do **not** use optional chaining (`?.`) in
+  `core/`, `ui/`, or `dataviz/` source — Polymer lint/analyze cannot parse it and elements go
+  missing from `analysis.json`. Use explicit `&&` guards instead (see `nuxeo-elements/AGENTS.md`).
 - Keep the diff focused — do not bundle unrelated files. Capture the **after** evidence, including
   the **after video** (Phase 2 recipe) showing the fixed behavior end-to-end.
 - **Extract self-contained/cross-cutting client logic into a Polymer behavior**, don't inline it

--- a/.agents/skills/fix-nuxeo-web-ui-bug/SKILL.md
+++ b/.agents/skills/fix-nuxeo-web-ui-bug/SKILL.md
@@ -305,9 +305,6 @@ Tear them down in Phase 10.
   `nuxeo-elements` repo) before editing. **Print the root cause to the user** — a clear,
   explicit statement of what is actually causing the bug (file/function/line and why) — before
   making any change. Then make the **minimal** change in `nuxeo-web-ui`.
-- **When the fix lands in `nuxeo-elements`:** do **not** use optional chaining (`?.`) in
-  `core/`, `ui/`, or `dataviz/` source — Polymer lint/analyze cannot parse it and elements go
-  missing from `analysis.json`. Use explicit `&&` guards instead (see `nuxeo-elements/AGENTS.md`).
 - Keep the diff focused — do not bundle unrelated files. Capture the **after** evidence, including
   the **after video** (Phase 2 recipe) showing the fixed behavior end-to-end.
 - **Extract self-contained/cross-cutting client logic into a Polymer behavior**, don't inline it

--- a/.cursor/skills/fix-nuxeo-web-ui-bug/SKILL.md
+++ b/.cursor/skills/fix-nuxeo-web-ui-bug/SKILL.md
@@ -305,6 +305,9 @@ Tear them down in Phase 10.
   `nuxeo-elements` repo) before editing. **Print the root cause to the user** — a clear,
   explicit statement of what is actually causing the bug (file/function/line and why) — before
   making any change. Then make the **minimal** change in `nuxeo-web-ui`.
+- **When the fix lands in `nuxeo-elements`:** do **not** use optional chaining (`?.`) in
+  `core/`, `ui/`, or `dataviz/` source — Polymer lint/analyze cannot parse it and elements go
+  missing from `analysis.json`. Use explicit `&&` guards instead (see `nuxeo-elements/AGENTS.md`).
 - Keep the diff focused — do not bundle unrelated files. Capture the **after** evidence, including
   the **after video** (Phase 2 recipe) showing the fixed behavior end-to-end.
 - **Extract self-contained/cross-cutting client logic into a Polymer behavior**, don't inline it


### PR DESCRIPTION
## Summary
- Add guidance to the `fix-nuxeo-web-ui-bug` agent skill (`.cursor/` and `.agents/` copies) so fixes that land in `nuxeo-elements` avoid optional chaining in `core/`, `ui/`, and `dataviz/` source.
- Complements nuxeo/nuxeo-elements#1666 and nuxeo/nuxeo-elements#1667.

## Test plan
- [x] Documentation-only change — no runtime code modified
- [ ] Review Phase 4 bullet in `fix-nuxeo-web-ui-bug/SKILL.md`

Made with [Cursor](https://cursor.com)