### PR TITLE
task: Align search-form unit test with nuxeo-selectivity aria-labelledby [maintenance-3.1.x]

### DIFF
--- a/test/nuxeo-search-form.test.js
+++ b/test/nuxeo-search-form.test.js
@@ -47,7 +47,9 @@ suite('nuxeo-search-form', () => {
       '.selectivity-single-select-input, .selectivity-multiple-input',
     );
     expect(input).to.exist;
-    expect(input.getAttribute('aria-label')).to.equal('Search Filters');
+    expect(input.getAttribute('aria-labelledby')).to.equal('label');
+    expect(input.hasAttribute('aria-label')).to.be.false;
+    expect(visibleLabel.getAttribute('for')).to.equal(input.id);
   });
 
   test('maps saved searches for selectivity data', () => {


### PR DESCRIPTION
## Problem
The Test workflow has been failing on every recent PR (and blocking nuxeo-elements cross-repo checks) with a single unit-test failure in `nuxeo-search-form`. Jira: [WEBUI-489](https://hyland.atlassian.net/browse/WEBUI-489)

## Root cause
The Test workflow installs the latest `@nuxeo` RC packages from nuxeo-elements. A recent `nuxeo-selectivity` accessibility change (ELEMENTS-1611) now binds a visible `label` to the input via `aria-labelledby` instead of `aria-label`. The WEBUI-489 unit test still asserted `aria-label === 'Search Filters'`, so CI fails even though the component behaviour is correct.

## Changes
* **`test/nuxeo-search-form.test.js`**: Assert `aria-labelledby="label"`, no `aria-label`, and `label[for]` pointing at the input — matching the current `nuxeo-selectivity` contract.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (2719 tests)

## Notes
Backport of the `lts-2025` PR; identical diff.

Made with [Cursor](https://cursor.com)

[WEBUI-489]: https://hyland.atlassian.net/browse/WEBUI-489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ