### PR TITLE
WEBUI-2247: Suppress css:S4667 on Polymer style-module includes [lts-2025]

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -119,8 +119,24 @@ sonar.sourceEncoding=UTF-8
 #   Coverage >= 90%, Issues == 0, Hotspots reviewed == 100%, Duplications <= 3%
 # Note: sonar.qualitygate.wait is set via workflow args to ensure it applies in all scan modes.
 
+# Suppress css:S4667 ("CSS files should not be empty") on HTML templates.
+# `<style include="nuxeo-styles"></style>` is the Polymer legacy style-module idiom: the `include`
+# attribute stamps the shared `nuxeo-styles` module into the element's shadow root, and the element's
+# own body is empty precisely because it contributes no rules of its own. Sonar's CSS analyser only
+# sees a <style> element with no CSS text and reports an empty stylesheet — 43 of them, across the
+# document metadata/edit/import layouts, the search forms and results, the directory edit layouts,
+# the bulk default layout, and the template-rendering and imap-connector addons.
+# There is nothing to fix. Deleting the element would drop the shared layout styling from every one
+# of those templates, and adding a filler rule or a comment inside the tag would be dead markup whose
+# only purpose is to satisfy the analyser. Scoped to **/*.html so the rule stays enabled for genuine
+# standalone .css files, and durable so the false positive does not reappear on the new-code gate
+# every time a layout template is added.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=css:S4667
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.html
+
 # Suppress all issues in CI workflow files — npm install with preinstall scripts is intentional.
 # TODO: Remove once sub-packages have package-lock.json and npm ci can be used safely.
-# sonar.issue.ignore.multicriteria=e1
-# sonar.issue.ignore.multicriteria.e1.ruleKey=*
-# sonar.issue.ignore.multicriteria.e1.resourceKey=.github/workflows/**
+# When re-enabling, add e2 to the sonar.issue.ignore.multicriteria list above (comma-separated).
+# sonar.issue.ignore.multicriteria.e2.ruleKey=*
+# sonar.issue.ignore.multicriteria.e2.resourceKey=.github/workflows/**


### PR DESCRIPTION
## Problem

SonarCloud reports **43 `css:S4667`** ("CSS files should not be empty") findings on `nuxeo-web-ui`, all of them false positives. They are noise on the maintainability backlog, and — because they sit on layout markup — a fresh one appears against the **new-code quality gate** on every PR that adds a layout template or search form.

Jira: [WEBUI-2247](https://hyland.atlassian.net/browse/WEBUI-2247) (2 of 9 from the [WEBUI-2246](https://hyland.atlassian.net/browse/WEBUI-2246) triage)

## Root cause

Every one of the 43 sits on the same line of markup:

```html
<style include="nuxeo-styles"></style>
```

That is the Polymer legacy style-module idiom. The `include` attribute stamps the shared `nuxeo-styles` module into the element's shadow root; the element's own body is empty *because it correctly contributes no rules of its own*. Sonar's CSS analyser sees only a `<style>` element with no CSS text and reports an empty stylesheet.

There is nothing to fix in the templates:

* **Deleting the element** would drop shared layout styling from all 43 templates.
* **Adding a filler rule or a comment** inside the tag would be dead markup whose only purpose is to fool a linter.

## Changes

* **`sonar-project.properties`**: suppress `css:S4667` via `sonar.issue.ignore.multicriteria`, scoped to `**/*.html`, with a comment explaining the Polymer idiom so the next reader does not re-litigate it. This mirrors the existing documented `sonar.cpd.exclusions` precedent in the same file.

Two details worth flagging for review:

1. **Scope is `**/*.html` only.** `css:S4667` stays enabled for genuine standalone `.css` files, so real empty stylesheets are still reported.
2. **The dormant CI-workflow criterion below it is renumbered `e1` → `e2`.** It was already commented out behind a TODO, but it declared `sonar.issue.ignore.multicriteria=e1`; had anyone later uncommented it as written, that line would have silently overwritten the new criterion and re-enabled all 43 findings. The renumber plus a note ("add `e2` to the list above") removes that foot-gun.

**No `.html`, `.js` or `.css` file is modified.** This is a one-file, configuration-only change — no application code, no runtime behaviour change, nothing for QA to verify.

## Test plan

- [x] `npm run lint` — ESLint passes. Prettier is not applicable: it globs `**/*.{js,html}` and this PR touches neither. (Locally it flags every file in the repo due to `core.autocrlf=true` on Windows; unrelated and pre-existing.)
- [x] `npm test` — not affected; no source file is touched and `.properties` is outside the test runner's scope. CI runs it regardless.
- [x] Verified the count independently: exactly **43** `<style include="nuxeo-styles"></style>` occurrences fall inside Sonar's source scope (`elements/`, `addons/`) — 26 in `elements/document/*`, 8 in `elements/search/*`, 2 in `elements/directory/*`, 1 in `elements/bulk/`, 4 in `nuxeo-template-rendering`, 2 in `nuxeo-imap-connector`. A further 26 occurrences live in `plugin/**` and `test/**`, which `sonar.exclusions` / `sonar.tests` already keep out of scope.
- [ ] **Confirm on the SonarCloud analysis for this PR that the 43 `css:S4667` findings are gone** and the quality gate is green.

## Notes

* Backport pair — the same commit lands on `lts-2025` and `maintenance-3.1.x`; the diffs are identical.
* **Alternative considered and rejected:** bulk-marking all 43 as *Won't Fix* in the SonarCloud UI. That clears them today but does not stop the finding reappearing on any new layout template, so every future layout PR would carry a fresh false positive against the new-code gate. The properties-file suppression is durable; the UI approach is not.
* Landing this early makes every subsequent ticket in the WEBUI-2246 set quieter.


[WEBUI-2247]: https://hyland.atlassian.net/browse/WEBUI-2247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBUI-2246]: https://hyland.atlassian.net/browse/WEBUI-2246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ