### PR TITLE
WEBUI-1786: Document PR CLA readiness [lts-2025]

### DIFF
--- a/.cursor/rules/pr-cla-readiness.mdc
+++ b/.cursor/rules/pr-cla-readiness.mdc
@@ -5,8 +5,9 @@ alwaysApply: true
 
 # PR CLA Readiness
 
-- Before committing for a PR, verify signing is enabled and the latest commit is
-  verified locally: `git log -1 --format='%G?'` should print `G`.
+- Before committing for a PR, verify signing is enabled.
+- After creating the commit and before pushing, verify the new commit is signed:
+  `git log -1 --format='%G?'` should print `G`.
 - Do not keep unknown agent/bot authors or co-author trailers in final PR commits.
   In particular, remove `Co-authored-by: Cursor <cursoragent@cursor.com>` before
   pushing a PR branch.

--- a/.cursor/rules/pr-cla-readiness.mdc
+++ b/.cursor/rules/pr-cla-readiness.mdc
@@ -1,0 +1,18 @@
+---
+description: Prevent PRs from getting stuck on missing CLA status checks
+alwaysApply: true
+---
+
+# PR CLA Readiness
+
+- Before committing for a PR, verify signing is enabled and the latest commit is
+  verified locally: `git log -1 --format='%G?'` should print `G`.
+- Do not keep unknown agent/bot authors or co-author trailers in final PR commits.
+  In particular, remove `Co-authored-by: Cursor <cursoragent@cursor.com>` before
+  pushing a PR branch.
+- After pushing, verify the PR head commit has a successful `license/cla` status.
+  If GitHub shows `license/cla Expected — Waiting for status to be reported`, push a
+  signed empty retrigger commit first.
+- If the status still does not appear after a retrigger, treat it as a missing legacy
+  status-provider problem and ask a repo maintainer to refresh the required check or
+  CLA app configuration instead of leaving the PR blocked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,16 @@ npm test                     # Web Test Runner unit tests — must pass
 
 ## CLA-safe commits
 
-`license/cla` fails if any commit or `Co-authored-by` trailer names `cursoragent@cursor.com`. Never add `Co-authored-by: Cursor` and never commit as the Cursor agent user. Husky runs `scripts/git/commit-msg-cla.sh` on every commit to block those trailers. If a PR branch is already polluted, squash on the PR base and rewrite with `git commit-tree` + a message file (agent `git commit` may re-inject Cursor trailers).
+`license/cla` fails if any commit or `Co-authored-by` trailer names `cursoragent@cursor.com`. Never add
+`Co-authored-by: Cursor` and never commit as the Cursor agent user. Husky runs
+`scripts/git/commit-msg-cla.sh` on every commit to block those trailers. If a PR branch is already
+polluted, squash on the PR base and rewrite with `git commit-tree` + a message file (agent
+`git commit` may re-inject Cursor trailers).
+
+Before marking a PR ready, verify the current head SHA has a successful `license/cla` status. If
+GitHub shows `license/cla Expected — Waiting for status to be reported`, first push a signed empty
+retrigger commit. If the legacy status provider still does not report, ask a repo maintainer to
+refresh the required check or CLA app configuration instead of leaving the PR blocked.
 
 ## Project Structure
 
@@ -70,6 +79,7 @@ Some elements are `.html` files with `<dom-module>` + inline `<script>` — this
 ### Server Communication
 
 Always use Nuxeo Elements for API calls, never `fetch()`:
+
 - `<nuxeo-operation>` — Automation operations
 - `<nuxeo-resource>` — REST endpoints
 - `<nuxeo-document>` — Document CRUD
@@ -139,8 +149,8 @@ PRs run lint and test workflows automatically.
 
 ## Environment Variables
 
-| Variable | Default | Purpose |
-|---|---|---|
-| `NUXEO_URL` | `/nuxeo` | Server URL in the app |
-| `NUXEO_HOST` | `localhost:8080` | Dev proxy target |
+| Variable         | Default                                                                   | Purpose                                                           |
+| ---------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `NUXEO_URL`      | `/nuxeo`                                                                  | Server URL in the app                                             |
+| `NUXEO_HOST`     | `localhost:8080`                                                          | Dev proxy target                                                  |
 | `NUXEO_PACKAGES` | empty (no addon entry points imported; `nuxeo-spreadsheet` always loaded) | Addon JS entry points to import at runtime via `Nuxeo.UI.bundles` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,10 +28,12 @@ npm test                     # Web Test Runner unit tests — must pass
 polluted, squash on the PR base and rewrite with `git commit-tree` + a message file (agent
 `git commit` may re-inject Cursor trailers).
 
-Before marking a PR ready, verify the current head SHA has a successful `license/cla` status. If
-GitHub shows `license/cla Expected — Waiting for status to be reported`, first push a signed empty
-retrigger commit. If the legacy status provider still does not report, ask a repo maintainer to
-refresh the required check or CLA app configuration instead of leaving the PR blocked.
+After creating a commit and before pushing a PR branch, verify the new commit is signed:
+`git log -1 --format='%G?'` should print `G`. Before marking a PR ready, verify the current head SHA
+has a successful `license/cla` status. If GitHub shows
+`license/cla Expected — Waiting for status to be reported`, first push a signed empty retrigger
+commit. If the legacy status provider still does not report, ask a repo maintainer to refresh the
+required check or CLA app configuration instead of leaving the PR blocked.
 
 ## Project Structure
 


### PR DESCRIPTION
## Problem
PRs can get blocked by the legacy `license/cla` status either because an agent/bot co-author trailer is present or because the expected legacy status never reports. Jira: [WEBUI-1786](https://hyland.atlassian.net/browse/WEBUI-1786)

## Root cause
The repo instructions did not explicitly tell agents to verify signed commits, avoid unknown agent co-authors, or check the `license/cla` status before marking a PR ready.

## Changes
* **`AGENTS.md`**: extend the CLA-safe commit guidance with the missing PR-head status verification and retrigger guidance.
* **`.cursor/rules/pr-cla-readiness.mdc`**: add an always-applied Cursor rule so future agent runs check these steps before PR readiness.

## Test plan
- [x] Formatted changed Markdown files with Prettier
- [x] Verified commit is signed with `git log -1 --format='%G?'`
- [ ] CI checks complete on the PR

## Notes
Backport pair for `maintenance-3.1.x`: https://github.com/nuxeo/nuxeo-web-ui/pull/3516

[WEBUI-1786]: https://hyland.atlassian.net/browse/WEBUI-1786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ