### PR TITLE
WEBUI-2248: Replace legacy JS and DOM APIs with modern equivalents [maintenance-3.1.x]

### DIFF
--- a/addons/amazon-s3-online-storage/index.js
+++ b/addons/amazon-s3-online-storage/index.js
@@ -198,7 +198,7 @@ class S3Provider {
   upload(files, callback) {
     this._ensureBatch().then(() => {
       callback({ type: 'batchStart', batchId: this.batchId });
-      if (new Date().getTime() >= this.extraInfo.expiration) {
+      if (Date.now() >= this.extraInfo.expiration) {
         this._refreshBatchInfo();
       }
 

--- a/addons/nuxeo-csv/elements/nuxeo-document-import-csv.js
+++ b/addons/nuxeo-csv/elements/nuxeo-document-import-csv.js
@@ -560,7 +560,7 @@ Polymer({
   },
 
   _filterImportDocTypes(type) {
-    return window.nuxeo.importBlacklist.indexOf(type.type) === -1;
+    return !window.nuxeo.importBlacklist.includes(type.type);
   },
 
   _observeFiles(changeRecord) {

--- a/addons/nuxeo-drive/elements/nuxeo-drive-download-button.js
+++ b/addons/nuxeo-drive/elements/nuxeo-drive-download-button.js
@@ -214,7 +214,7 @@ class NuxeoDriveDownloadButton extends mixinBehaviors([I18nBehavior], PolymerEle
     const uuidBinary = [];
     allUuidHex.forEach((hexStr) => {
       for (let i = 0; i < hexStr.length; i += 2) {
-        uuidBinary.push(parseInt(hexStr.substr(i, 2), 16));
+        uuidBinary.push(Number.parseInt(hexStr.substr(i, 2), 16));
       }
     });
 

--- a/addons/nuxeo-drive/elements/nuxeo-drive-download-button.js
+++ b/addons/nuxeo-drive/elements/nuxeo-drive-download-button.js
@@ -204,11 +204,11 @@ class NuxeoDriveDownloadButton extends mixinBehaviors([I18nBehavior], PolymerEle
     const segments = firstPart.split('/');
     const scheme = segments[0] === 'https' ? 1 : 0;
     const server = segments.slice(1, -1).join('/');
-    const firstUuid = segments[segments.length - 1].replace(/-/g, '');
+    const firstUuid = segments[segments.length - 1].replaceAll('-', '');
 
     const allUuidHex = [firstUuid];
     for (let i = 1; i < parts.length; i++) {
-      allUuidHex.push(parts[i].trim().replace(/-/g, ''));
+      allUuidHex.push(parts[i].trim().replaceAll('-', ''));
     }
 
     const uuidBinary = [];

--- a/addons/nuxeo-drive/elements/nuxeo-drive-sync-toggle-button.js
+++ b/addons/nuxeo-drive/elements/nuxeo-drive-sync-toggle-button.js
@@ -106,7 +106,7 @@ Polymer({
       return false;
     }
     const excludedDoctypes = ['Domain', 'SectionRoot', 'TemplateRoot', 'WorkspaceRoot', 'Forum', 'Collections'];
-    const isExcluded = excludedDoctypes.indexOf(this.document.type) !== -1;
+    const isExcluded = excludedDoctypes.includes(this.document.type);
     const isContainer = this.hasFacet(this.document, 'Collection') || this.hasFacet(this.document, 'Folderish');
     const isSyncRootCandidate = isContainer && !this.isTrashed(this.document);
     return !isExcluded && isSyncRootCandidate && !this.synchronizationRoot;
@@ -126,12 +126,12 @@ Polymer({
     if (!this.document || !roots) {
       return;
     }
-    this.synchronized = roots.indexOf(this.document.uid) !== -1;
+    this.synchronized = roots.includes(this.document.uid);
 
     // determine synchronization root (closest synchronized ancestor)
     const breadcrumb = this.document.contextParameters.breadcrumb.entries;
     for (let i = breadcrumb.length - 1; i >= 0; i--) {
-      if (roots.indexOf(breadcrumb[i].parentRef) !== -1) {
+      if (roots.includes(breadcrumb[i].parentRef)) {
         this.synchronizationRoot = breadcrumb[i].parentRef;
         return;
       }

--- a/addons/nuxeo-drive/test/nuxeo-drive-sync-toggle-button.test.js
+++ b/addons/nuxeo-drive/test/nuxeo-drive-sync-toggle-button.test.js
@@ -79,4 +79,52 @@ suite('nuxeo-drive-sync-toggle-button', () => {
       expect(element._isAvailable()).to.be.false;
     });
   });
+
+  // Kept last: `_handleRoots` writes the module-level sync-root cache that `_update`
+  // reads, so these tests leave state behind that the suites above must not see.
+  suite('_update', () => {
+    function documentWithBreadcrumb(uid, parentRefs) {
+      const entries = parentRefs.map((parentRef) => {
+        return { parentRef };
+      });
+      return { uid, type: 'Folder', contextParameters: { breadcrumb: { entries } } };
+    }
+
+    function receiveRoots(uids) {
+      const entries = uids.map((uid) => {
+        return { uid };
+      });
+      element._handleRoots({ detail: { response: { entries } } });
+    }
+
+    teardown(() => {
+      receiveRoots([]);
+    });
+
+    test('should mark the document synchronized when it is itself a sync root', () => {
+      element.document = documentWithBreadcrumb('doc-1', ['root']);
+
+      receiveRoots(['doc-1']);
+
+      expect(element.synchronized).to.be.true;
+    });
+
+    test('should resolve the closest synchronized ancestor as the synchronization root', () => {
+      element.document = documentWithBreadcrumb('doc-1', ['root', 'ws-1']);
+
+      receiveRoots(['root', 'ws-1']);
+
+      // The breadcrumb is walked from the closest ancestor outwards, so `ws-1` wins over `root`.
+      expect(element.synchronizationRoot).to.equal('ws-1');
+    });
+
+    test('should clear the synchronization root when no ancestor is synchronized', () => {
+      element.document = documentWithBreadcrumb('doc-2', ['root', 'ws-1']);
+
+      receiveRoots(['unrelated']);
+
+      expect(element.synchronized).to.be.false;
+      expect(element.synchronizationRoot).to.be.null;
+    });
+  });
 });

--- a/addons/nuxeo-platform-3d/elements/nuxeo-3d-transmission-formats.js
+++ b/addons/nuxeo-platform-3d/elements/nuxeo-3d-transmission-formats.js
@@ -179,7 +179,7 @@ Polymer({
     if (value < base) {
       return `${value} ${unit}`;
     }
-    const exp = parseInt(Math.log(value) / Math.log(base), 0);
+    const exp = Number.parseInt(Math.log(value) / Math.log(base), 0);
     const pre = String('kMGTPE'.charAt(exp - 1));
     return `${Math.round((value / base ** exp) * 10) / 10} ${pre}${unit}`;
   },

--- a/addons/nuxeo-platform-3d/elements/nuxeo-3d-viewer.js
+++ b/addons/nuxeo-platform-3d/elements/nuxeo-3d-viewer.js
@@ -320,16 +320,14 @@ Polymer({
     const object = data.scene;
 
     if (data.cameras && data.cameras.length) {
-      for (let i = 0; i < data.cameras.length; i++) {
-        const dataCamera = data.cameras[i];
+      for (const dataCamera of data.cameras) {
         const cameraName = dataCamera.parent.name;
         this.cameras[cameraName] = dataCamera;
       }
     }
 
     if (data.animations && data.animations.length) {
-      for (let i = 0; i < data.animations.length; i++) {
-        const animation = data.animations[i];
+      for (const animation of data.animations) {
         animation.loop = true;
         animation.play();
         this.animations.push(animation);

--- a/addons/nuxeo-spreadsheet/app/app.js
+++ b/addons/nuxeo-spreadsheet/app/app.js
@@ -126,7 +126,7 @@ function run({ baseURL = '/nuxeo', resultColumns, pageProviderName, queryParamet
       for (const k in searchDocument.properties) {
         const v = searchDocument.properties[k];
         // skip empty values
-        if (typeof v.length !== 'undefined' && v.length === 0) {
+        if (v.length !== undefined && v.length === 0) {
           continue;
         }
         namedParameters[k] = typeof v === 'string' ? v : JSON.stringify(v);

--- a/addons/nuxeo-spreadsheet/app/lib/handsontable.patches.js
+++ b/addons/nuxeo-spreadsheet/app/lib/handsontable.patches.js
@@ -7,7 +7,7 @@
  */
 Handsontable.DataMap.prototype.get = function (row, prop) {
   row = Handsontable.hooks.execute(this.instance, 'modifyRow', row);
-  if (typeof prop === 'string' && prop.indexOf('.') > -1) {
+  if (typeof prop === 'string' && prop.includes('.')) {
     const sliced = prop.split('.');
     let out = this.dataSource[row];
     if (!out) {
@@ -50,7 +50,7 @@ Handsontable.DataMap.prototype.get = function (row, prop) {
  */
 Handsontable.DataMap.prototype.set = function (row, prop, value, source) {
   row = Handsontable.hooks.execute(this.instance, 'modifyRow', row, source || 'datamapGet');
-  if (typeof prop === 'string' && prop.indexOf('.') > -1) {
+  if (typeof prop === 'string' && prop.includes('.')) {
     const sliced = prop.split('.');
     let out = this.dataSource[row];
     let i;

--- a/addons/nuxeo-spreadsheet/app/nuxeo/rest/request.js
+++ b/addons/nuxeo-spreadsheet/app/nuxeo/rest/request.js
@@ -44,7 +44,7 @@ class Request {
       .request(path || this.path)
       .repositoryName(undefined)
       .headers(this._headers)
-      .queryParams(Object.assign({}, this._params, params))
+      .queryParams({ ...this._params, ...params })
       [method]();
   }
 }

--- a/addons/nuxeo-spreadsheet/app/nuxeo/rest/schemas.js
+++ b/addons/nuxeo-spreadsheet/app/nuxeo/rest/schemas.js
@@ -30,7 +30,7 @@ class Schemas extends Request {
     return this.execute().then((entries) => {
       for (const entry of entries) {
         const key = entry['@prefix'] || entry.name;
-        if (schemas.indexOf(key) !== -1) {
+        if (schemas.includes(key)) {
           data[key] = { name: entry.name };
         }
       }

--- a/addons/nuxeo-spreadsheet/app/nuxeo/widget.js
+++ b/addons/nuxeo-spreadsheet/app/nuxeo/widget.js
@@ -28,7 +28,7 @@ class Widget {
     this.field = this.widget.fields[0].fieldName;
 
     // Rename data['schema']['property'] to data.schema.property
-    this.field = this.field.replace(/\['/g, '.').replace(/']/g, '');
+    this.field = this.field.replaceAll("['", '.').replaceAll("']", '');
 
     // In a listing, the layout is not usually rendered on the document, but on a PageSelection element,
     // wrapping the  DocumentModel to handle selection information.

--- a/addons/nuxeo-spreadsheet/app/ui/spreadsheet.js
+++ b/addons/nuxeo-spreadsheet/app/ui/spreadsheet.js
@@ -246,8 +246,7 @@ class Spreadsheet {
       return;
     }
     if (change !== null) {
-      for (let i = 0; i < change.length; i++) {
-        let [idx, field, oldV, newV] = change[i];
+      for (let [idx, field, oldV, newV] of change) {
         if (oldV === newV) {
           continue;
         }

--- a/addons/nuxeo-spreadsheet/app/ui/spreadsheet.js
+++ b/addons/nuxeo-spreadsheet/app/ui/spreadsheet.js
@@ -67,8 +67,8 @@ class Spreadsheet {
     // get schemas prefixes from columns
     const schemasPrefixes = [];
     for (const c of columns) {
-      const schema = c.field.indexOf(':') > -1 ? c.field.split(':')[0] : undefined;
-      if (schema && schemasPrefixes.indexOf(schema) === -1) {
+      const schema = c.field.includes(':') ? c.field.split(':')[0] : undefined;
+      if (schema && !schemasPrefixes.includes(schema)) {
         schemasPrefixes.push(schema);
       }
     }
@@ -83,7 +83,7 @@ class Spreadsheet {
 
         // get field definition from schemas map
         let field; // <- explicitly set field as undefined in each iteration
-        if (c.field.indexOf(':') > -1) {
+        if (c.field.includes(':')) {
           const [s, f] = c.field.split(':');
           field = schemas[s].fields[f] || undefined;
           field = typeof field === 'string' ? { type: field } : field;
@@ -168,7 +168,7 @@ class Spreadsheet {
     const cell = {};
     const doc = this.getDataAtRow(row);
     const permissions = doc && doc.contextParameters && doc.contextParameters.permissions;
-    if (permissions && permissions.indexOf('Write') === -1) {
+    if (permissions && !permissions.includes('Write')) {
       cell.readOnly = true;
     }
     return cell;

--- a/addons/nuxeo-spreadsheet/app/utils.js
+++ b/addons/nuxeo-spreadsheet/app/utils.js
@@ -28,7 +28,7 @@ export function parseParams() {
   for (const param of params) {
     // eslint-disable-next-line prefer-const
     let [k, v] = param.split('=');
-    v = v.replace(/\+/g, ' ');
+    v = v.replaceAll('+', ' ');
     parameters[k] = decodeURIComponent(v);
   }
   return parameters;

--- a/addons/nuxeo-spreadsheet/app/utils.js
+++ b/addons/nuxeo-spreadsheet/app/utils.js
@@ -39,7 +39,7 @@ export function b64DecodeUnicode(str) {
   return decodeURIComponent(
     atob(str)
       .split('')
-      .map((c) => `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`)
+      .map((c) => `%${`00${c.codePointAt(0).toString(16)}`.slice(-2)}`)
       .join(''),
   );
 }

--- a/addons/nuxeo-template-rendering/elements/nuxeo-render-template-button.js
+++ b/addons/nuxeo-template-rendering/elements/nuxeo-render-template-button.js
@@ -202,8 +202,7 @@ Polymer({
     if (this.selectedTemplate.properties['tmpl:allowOverride'] && this._templateData) {
       if (this.document.properties['nxts:bindings']) {
         let binding;
-        for (let i = 0; i < this.document.properties['nxts:bindings'].length; i++) {
-          const b = this.document.properties['nxts:bindings'][i];
+        for (const b of this.document.properties['nxts:bindings']) {
           if (b.templateName === this.selectedTemplate.properties['tmpl:templateName']) {
             binding = b;
           }
@@ -331,7 +330,7 @@ Polymer({
           a.href = URL.createObjectURL(blob);
           document.body.appendChild(a);
           a.click();
-          document.body.removeChild(a);
+          a.remove();
           URL.revokeObjectURL(a.href);
         }
       });

--- a/addons/nuxeo-template-rendering/elements/nuxeo-template-param-editor.js
+++ b/addons/nuxeo-template-rendering/elements/nuxeo-template-param-editor.js
@@ -377,7 +377,7 @@ Polymer({
       const change = this._getParamAttribute(param, 'change');
       if (change) {
         if (change === 'deleted') {
-          this.params.querySelector('templateParams').removeChild(param);
+          param.remove();
         }
         this._removeParamAttribute(param, 'change');
       }

--- a/elements/bulk/nuxeo-edit-documents-button.js
+++ b/elements/bulk/nuxeo-edit-documents-button.js
@@ -524,9 +524,8 @@ class NuxeoEditDocumentsButton extends mixinBehaviors([I18nBehavior, FiltersBeha
         const selector = '[role="widget"], nuxeo-data-table[role="table"]';
         const widgets = Array.from(bulkLayout.shadowRoot.querySelectorAll(selector));
         widgets.forEach((widget) => {
-          const { parentNode } = widget;
           const bulkWidget = document.createElement('nuxeo-bulk-widget');
-          parentNode.replaceChild(bulkWidget, widget);
+          widget.replaceWith(bulkWidget);
           bulkWidget.appendChild(widget);
           // get the element that is bound to a property
           const boundElement = this._getBoundElement(widget, bulkLayout.__templateInfo);

--- a/elements/bulk/nuxeo-edit-documents-button.js
+++ b/elements/bulk/nuxeo-edit-documents-button.js
@@ -314,10 +314,7 @@ class NuxeoEditDocumentsButton extends mixinBehaviors([I18nBehavior, FiltersBeha
       // get the bulk widget wrapper element
       const bulkWidget = this._getBulkWidget(boundElement);
       // get the path without the `document.properties.` part, replacing the `.` for `/` (complex fields)
-      const path = boundPath
-        .replace(/^(document\.properties\.)/, '')
-        .split('.')
-        .join('/');
+      const path = boundPath.replace(/^(document\.properties\.)/, '').replaceAll('.', '/');
       if (bulkWidget.updateMode === 'replace') {
         let value = bulkLayout.get(boundPath);
         if (this._shouldStringifyValue(value)) {

--- a/elements/diff/nuxeo-diff-behavior.js
+++ b/elements/diff/nuxeo-diff-behavior.js
@@ -245,7 +245,7 @@ export const DiffBehavior = {
     } else if (this._hasTextDiff(delta)) {
       [value] = delta;
     } else if (this._hasArrayInnerChanges(delta)) {
-      const aKey = Object.keys(delta).filter((key) => key !== '_t')[0];
+      const aKey = Object.keys(delta).find((key) => key !== '_t');
       value = Array.isArray(delta[aKey]) ? delta[aKey][0] : delta[aKey];
     }
     return value;

--- a/elements/diff/nuxeo-diff.js
+++ b/elements/diff/nuxeo-diff.js
@@ -471,8 +471,8 @@ Polymer({
   },
 
   _fetchCommonSchemas(left, right) {
-    const commonSchemas = left.schemas.filter(
-      (schema1) => !!right.schemas.find((schema2) => schema1.name === schema2.name),
+    const commonSchemas = left.schemas.filter((schema1) =>
+      right.schemas.some((schema2) => schema1.name === schema2.name),
     );
     return _fetchSchemas(this.$.schema).then((schemas) => {
       // populate the common schemas with the fields information
@@ -484,14 +484,13 @@ Polymer({
   },
 
   _getCommonProperties(left, right, schema, delta) {
-    return Object.keys(left.properties).filter(
-      (leftPropName) =>
-        !!Object.keys(right.properties).find(
-          (rightPropName) =>
-            leftPropName === rightPropName &&
-            (schema ? leftPropName.startsWith(`${schema.prefix ? schema.prefix : schema.name}:`) : true) &&
-            (delta ? delta[leftPropName] : true),
-        ),
+    return Object.keys(left.properties).filter((leftPropName) =>
+      Object.keys(right.properties).some(
+        (rightPropName) =>
+          leftPropName === rightPropName &&
+          (schema ? leftPropName.startsWith(`${schema.prefix ? schema.prefix : schema.name}:`) : true) &&
+          (delta ? delta[leftPropName] : true),
+      ),
     );
   },
 

--- a/elements/diff/nuxeo-diff.js
+++ b/elements/diff/nuxeo-diff.js
@@ -565,9 +565,8 @@ Polymer({
     } else {
       const deltaObj = Array.isArray(delta) && delta.length > 0 ? delta[0] : delta;
       const properties = parentPath ? Object.keys(deltaObj) : this._getCommonSchemaProperties(schema, false, deltaObj);
-      for (let i = 0; i < properties.length; i++) {
-        const key = properties[i];
-        const subpath = path ? [path, key].join('.') : properties[i];
+      for (const key of properties) {
+        const subpath = path ? [path, key].join('.') : key;
         let type;
         let subSchema;
         if (typeof schema === 'string') {

--- a/elements/directory/l10nxvocabulary/nuxeo-l10nxvocabulary-edit-layout.html
+++ b/elements/directory/l10nxvocabulary/nuxeo-l10nxvocabulary-edit-layout.html
@@ -216,7 +216,7 @@ limitations under the License.
                 return !isNotLeaf && node.root !== true;
               }.bind(this),
             };
-            this.$.tree.open.apply(this.$.tree, ['root']);
+            this.$.tree.open('root');
           }
         }
       },

--- a/elements/document/nuxeo-document-import.js
+++ b/elements/document/nuxeo-document-import.js
@@ -1480,7 +1480,7 @@ Polymer({
   },
 
   _filterImportDocTypes(type) {
-    return window.nuxeo.importBlacklist.indexOf(type.type) === -1;
+    return !window.nuxeo.importBlacklist.includes(type.type);
   },
 
   _computeImportDocTypes() {

--- a/elements/document/nuxeo-document-import.js
+++ b/elements/document/nuxeo-document-import.js
@@ -926,7 +926,7 @@ Polymer({
       this.fire('nx-creation-wizard-hide-tabs');
       // let's select the first file that's not disabled
       const toSelect = this._getAllFiles().findIndex((f) => !f.error);
-      this._selectDoc(toSelect < 0 ? 0 : toSelect);
+      this._selectDoc(Math.max(0, toSelect));
     } else {
       this.stage = 'upload';
       this.customizing = false;
@@ -1305,7 +1305,7 @@ Polymer({
           result['entity-type'] !== 'exception' &&
           result['entity-type'] !== 'validation_report',
       );
-      this._handleSuccess(this._mergeResponses.apply(null, errorFree), !(errorFree.length < results.length));
+      this._handleSuccess(this._mergeResponses.apply(null, errorFree), errorFree.length >= results.length);
       if (errorFree.length < results.length) {
         this.set('_creating', false);
         this.set('_importWithPropertiesError', 'These documents could not be created.');

--- a/elements/document/nuxeo-document-import.js
+++ b/elements/document/nuxeo-document-import.js
@@ -1240,8 +1240,7 @@ Polymer({
 
   _mergeResponses(...args) {
     const response = { 'entity-type': 'Documents', entries: [] };
-    for (let i = 0; i < args.length; i++) {
-      const current = args[i];
+    for (const current of args) {
       if (current && current.entries) {
         response.entries.push(...current.entries);
       } else {
@@ -1387,10 +1386,9 @@ Polymer({
 
   _batchReady(data) {
     data.stopPropagation();
-    this.properties = [];
-    for (let i = 0; i < this.localFiles.length; i++) {
-      this.properties.push({});
-    }
+    this.properties = this.localFiles.map(() => {
+      return {};
+    });
     const div = this.$$('div[name="upload"]');
     if (div) {
       div.focus();

--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -1978,13 +1978,13 @@ Polymer({
         toast.__state = { dismissed: false, aborted: true };
         callback();
         // remove the toast if the action was aborted
-        toast.parentNode.removeChild(toast);
+        toast.remove();
       } else if (e.detail.reason === 'dismiss') {
         const state = toast.__state;
         if (state && state.ended) {
           toast.__state = null;
           // remove the toast if the action has ended
-          toast.parentNode.removeChild(toast);
+          toast.remove();
         } else {
           // do not remove the toast, otherwise it will show up before the end of the task
           toast.__state.dismissed = true;

--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -1402,8 +1402,7 @@ Polymer({
 
       case 'tasks':
         if (this.currentTask) {
-          title.push(this.i18n(this.currentTask.workflowModelName));
-          title.push(this.i18n(this.currentTask.name));
+          title.push(this.i18n(this.currentTask.workflowModelName), this.i18n(this.currentTask.name));
         } else {
           title.push(this.i18n(`app.title.${this.page}`));
         }

--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -1351,8 +1351,8 @@ Polymer({
     this.show('diff');
     const params = [id1, id2];
     // let's keep current context only if it includes the ids already in the params
-    if (this.$.diff.docIds && params.every((el) => this.$.diff.docIds.indexOf(el) > -1)) {
-      const otherIds = this.$.diff.docIds.find((id) => params.indexOf(id) === -1);
+    if (this.$.diff.docIds && params.every((el) => this.$.diff.docIds.includes(el))) {
+      const otherIds = this.$.diff.docIds.find((id) => !params.includes(id));
       this.$.diff.docIds = null;
       this.$.diff.docIds = params.concat(otherIds).filter(Boolean);
     } else {

--- a/elements/nuxeo-audit/nuxeo-audit-search.js
+++ b/elements/nuxeo-audit/nuxeo-audit-search.js
@@ -291,7 +291,7 @@ class AuditSearch extends mixinBehaviors([FormatBehavior, RoutingBehavior], Nuxe
     if (moment(comment, moment.ISO_8601).isValid()) {
       return this.formatDateTime(comment);
     }
-    return clientReason && clientReason.toLowerCase().indexOf('view') > -1
+    return clientReason && clientReason.toLowerCase().includes('view')
       ? `${this.i18n('command.view')}: [${comment}]`
       : comment;
   }

--- a/elements/nuxeo-audit/nuxeo-audit-search.js
+++ b/elements/nuxeo-audit/nuxeo-audit-search.js
@@ -291,9 +291,7 @@ class AuditSearch extends mixinBehaviors([FormatBehavior, RoutingBehavior], Nuxe
     if (moment(comment, moment.ISO_8601).isValid()) {
       return this.formatDateTime(comment);
     }
-    return clientReason && clientReason.toLowerCase().includes('view')
-      ? `${this.i18n('command.view')}: [${comment}]`
-      : comment;
+    return clientReason?.toLowerCase().includes('view') ? `${this.i18n('command.view')}: [${comment}]` : comment;
   }
 }
 

--- a/elements/nuxeo-browser.html
+++ b/elements/nuxeo-browser.html
@@ -186,7 +186,7 @@ limitations under the License.
       },
 
       get _canReadChildren() {
-        return this._enrichers && this._enrichers.permissions.indexOf('ReadChildren') !== -1;
+        return this._enrichers && this._enrichers.permissions.includes('ReadChildren');
       },
 
       _actionContext() {

--- a/elements/nuxeo-browser/nuxeo-breadcrumb.js
+++ b/elements/nuxeo-browser/nuxeo-breadcrumb.js
@@ -190,7 +190,7 @@ import { microTask } from '@polymer/polymer/lib/utils/async.js';
         this.document.contextParameters &&
         this.document.contextParameters.breadcrumb &&
         this.document.contextParameters.breadcrumb.entries;
-      return breadcrumbEntries && breadcrumbEntries.slice(0, breadcrumbEntries.length - 1);
+      return breadcrumbEntries && breadcrumbEntries.slice(0, -1);
     }
 
     get _contentWidth() {
@@ -249,7 +249,7 @@ import { microTask } from '@polymer/polymer/lib/utils/async.js';
           this._contentWidth + this.lastDeletedNodeWidth < this._ancestors.offsetWidth &&
           this.deletedNodes.length > 0
         ) {
-          this._ancestors.insertBefore(this.deletedNodes[this.deletedNodes.length - 1], this._ancestors.childNodes[1]);
+          this._ancestors.insertBefore(this.deletedNodes.at(-1), this._ancestors.childNodes[1]);
           this.deletedNodes.pop();
           if (this.deletedNodes.length === 0) {
             const ellipsisListItem = this.shadowRoot.getElementById('ellipsis').parentElement;

--- a/elements/nuxeo-browser/nuxeo-repositories.js
+++ b/elements/nuxeo-browser/nuxeo-repositories.js
@@ -71,7 +71,9 @@ class Repositories extends mixinBehaviors([I18nBehavior, RoutingBehavior], Nuxeo
         type: Array,
         value() {
           if (Nuxeo.UI.repositories) {
-            return Nuxeo.UI.repositories.map((r) => Object.assign({}, r));
+            return Nuxeo.UI.repositories.map((r) => {
+              return { ...r };
+            });
           }
           return [];
         },

--- a/elements/nuxeo-collections/nuxeo-collection-remove-action.js
+++ b/elements/nuxeo-collections/nuxeo-collection-remove-action.js
@@ -85,7 +85,7 @@ class NuxeoCollectionRemoveAction extends mixinBehaviors([NotifyBehavior, I18nBe
     if (collection && collection.contextParameters && collection.contextParameters.permissions) {
       // NXP-21408: prior to 8.10-HF01 the permissions enricher wouldn't return ReadCanCollect
       // Action will therefore not be available
-      return collection.contextParameters.permissions.indexOf('WriteProperties') < 0;
+      return !collection.contextParameters.permissions.includes('WriteProperties');
     }
     return true;
   }

--- a/elements/nuxeo-collections/nuxeo-collections.js
+++ b/elements/nuxeo-collections/nuxeo-collections.js
@@ -539,7 +539,7 @@ Polymer({
     if (collection && collection.contextParameters && collection.contextParameters.permissions) {
       // NXP-21408: prior to 8.10-HF01 the permissions enricher wouldn't return ReadCanCollect
       // Action will therefore not be available
-      return collection.contextParameters.permissions.indexOf('ReadCanCollect') > -1;
+      return collection.contextParameters.permissions.includes('ReadCanCollect');
     }
     return false;
   },

--- a/elements/nuxeo-data-grid/nuxeo-document-grid-thumbnail.js
+++ b/elements/nuxeo-data-grid/nuxeo-document-grid-thumbnail.js
@@ -296,7 +296,7 @@ Polymer({
       doc.contextParameters.thumbnail.url
     ) {
       if (!this.isFollowRedirectEnabled()) {
-        const splitter = doc.contextParameters.thumbnail.url.indexOf('?') > -1 ? '&' : '?';
+        const splitter = doc.contextParameters.thumbnail.url.includes('?') ? '&' : '?';
         doc.contextParameters.thumbnail.url = `${doc.contextParameters.thumbnail.url}${splitter}clientReason=view`;
       }
       return doc.contextParameters.thumbnail.url;

--- a/elements/nuxeo-data-list/nuxeo-document-list-item.js
+++ b/elements/nuxeo-data-list/nuxeo-document-list-item.js
@@ -297,7 +297,7 @@ Polymer({
       doc.contextParameters.thumbnail.url
     ) {
       if (!this.isFollowRedirectEnabled()) {
-        const splitter = doc.contextParameters.thumbnail.url.indexOf('?') > -1 ? '&' : '?';
+        const splitter = doc.contextParameters.thumbnail.url.includes('?') ? '&' : '?';
         doc.contextParameters.thumbnail.url = `${doc.contextParameters.thumbnail.url}${splitter}clientReason=view`;
       }
       return doc.contextParameters.thumbnail.url;

--- a/elements/nuxeo-document-actions/nuxeo-replace-blob-button.js
+++ b/elements/nuxeo-document-actions/nuxeo-replace-blob-button.js
@@ -223,7 +223,7 @@ Polymer({
       let xpathArray = xpath.split(splitter);
 
       for (let i = 0; i < xpathArray.length; i++) {
-        if (!Number.isNaN(parseInt(xpathArray[i], 10))) {
+        if (!Number.isNaN(Number.parseInt(xpathArray[i], 10))) {
           xpathArray[i] = star;
         }
         transformedArray.push(xpathArray[i]);

--- a/elements/nuxeo-document-bulk-actions/nuxeo-add-to-collection-documents-button.js
+++ b/elements/nuxeo-document-bulk-actions/nuxeo-add-to-collection-documents-button.js
@@ -219,7 +219,7 @@ class NuxeoAddToCollectionDocumentsButton extends mixinBehaviors(
   }
 
   _resultsFilter(entry) {
-    return entry.id && entry.id.indexOf('-999999') === -1;
+    return entry.id && !entry.id.includes('-999999');
   }
 
   _resultAndSelectionFormatter(item) {

--- a/elements/nuxeo-document-bulk-actions/nuxeo-download-documents-button.js
+++ b/elements/nuxeo-document-bulk-actions/nuxeo-download-documents-button.js
@@ -85,9 +85,9 @@ Polymer({
   _params() {
     const params = {};
     if (this.document && (this.hasFacet(this.document, 'Collection') || this.hasFacet(this.document, 'Folderish'))) {
-      params.filename = `${this.document.title}_${new Date().getTime()}.zip`;
+      params.filename = `${this.document.title}_${Date.now()}.zip`;
     } else {
-      params.filename = `${this.i18n('bulkDownload.filename.selection')}-${new Date().getTime()}.zip`;
+      params.filename = `${this.i18n('bulkDownload.filename.selection')}-${Date.now()}.zip`;
     }
     return params;
   },

--- a/elements/nuxeo-document-create-actions/nuxeo-document-create-shortcuts.js
+++ b/elements/nuxeo-document-create-actions/nuxeo-document-create-shortcuts.js
@@ -70,14 +70,14 @@ Polymer({
   _updateShortcuts() {
     const types = this.$.creationStats.lastType(1);
     this.$.creationStats.mostCommonType(2).forEach((type) => {
-      if (types.indexOf(type) < 0) {
+      if (!types.includes(type)) {
         types.push(type);
       }
     });
 
     const shorcuts = [];
     types.forEach((type) => {
-      if (this.subtypes && this.subtypes.indexOf(type) > -1) {
+      if (this.subtypes && this.subtypes.includes(type)) {
         const el = document.createElement('nuxeo-document-create-shortcut');
         el.type = type;
         el.icon = `images/doctypes/${type}.svg`;

--- a/elements/nuxeo-document-create-actions/nuxeo-document-create-shortcuts.js
+++ b/elements/nuxeo-document-create-actions/nuxeo-document-create-shortcuts.js
@@ -91,7 +91,7 @@ Polymer({
 
   _putNodes(parent, ...args) {
     while (parent.firstChild) {
-      parent.removeChild(parent.firstChild);
+      parent.firstChild.remove();
     }
     if (args && args.length > 0) {
       for (const arg of args) {

--- a/elements/nuxeo-document-create-actions/nuxeo-document-create-shortcuts.js
+++ b/elements/nuxeo-document-create-actions/nuxeo-document-create-shortcuts.js
@@ -94,13 +94,13 @@ Polymer({
       parent.removeChild(parent.firstChild);
     }
     if (args && args.length > 0) {
-      for (let i = 0; i < args.length; i++) {
-        if (Array.isArray(args[i])) {
-          for (let j = 0; j < args[i].length; j++) {
-            parent.appendChild(args[i][j]);
+      for (const arg of args) {
+        if (Array.isArray(arg)) {
+          for (const node of arg) {
+            parent.appendChild(node);
           }
         } else {
-          parent.appendChild(args[i]);
+          parent.appendChild(arg);
         }
       }
     }

--- a/elements/nuxeo-document-create-actions/nuxeo-document-create-shortcuts.js
+++ b/elements/nuxeo-document-create-actions/nuxeo-document-create-shortcuts.js
@@ -77,7 +77,7 @@ Polymer({
 
     const shorcuts = [];
     types.forEach((type) => {
-      if (this.subtypes && this.subtypes.includes(type)) {
+      if (this.subtypes?.includes(type)) {
         const el = document.createElement('nuxeo-document-create-shortcut');
         el.type = type;
         el.icon = `images/doctypes/${type}.svg`;

--- a/elements/nuxeo-document-create-button/nuxeo-document-create-button.js
+++ b/elements/nuxeo-document-create-button/nuxeo-document-create-button.js
@@ -171,7 +171,7 @@ Polymer({
         const filteredSubtypes = [];
         if (this._canCreateIn(this.parent)) {
           subtypes.forEach((type) => {
-            if (type.facets.indexOf('HiddenInCreation') === -1) {
+            if (!type.facets.includes('HiddenInCreation')) {
               filteredSubtypes.push(type.id);
             }
           });
@@ -185,7 +185,7 @@ Polymer({
 
   _canCreateIn(document) {
     if (document && document.contextParameters && document.contextParameters.permissions) {
-      return document.contextParameters.permissions.indexOf('AddChildren') > -1;
+      return document.contextParameters.permissions.includes('AddChildren');
     }
     return false;
   },

--- a/elements/nuxeo-document-creation/nuxeo-document-creation-behavior.js
+++ b/elements/nuxeo-document-creation/nuxeo-document-creation-behavior.js
@@ -128,7 +128,7 @@ export const DocumentCreationBehavior = [
         const filteredSubtypes = [];
         if (this._canCreateIn(this.parent)) {
           subtypes.forEach((type) => {
-            if (type.facets.indexOf('HiddenInCreation') === -1) {
+            if (!type.facets.includes('HiddenInCreation')) {
               filteredSubtypes.push(type);
             }
           });
@@ -205,7 +205,7 @@ export const DocumentCreationBehavior = [
 
     _canCreateIn(document) {
       if (document && document.contextParameters && document.contextParameters.permissions) {
-        return document.contextParameters.permissions.indexOf('AddChildren') > -1;
+        return document.contextParameters.permissions.includes('AddChildren');
       }
       return false;
     },

--- a/elements/nuxeo-document-creation/nuxeo-document-creation-behavior.js
+++ b/elements/nuxeo-document-creation/nuxeo-document-creation-behavior.js
@@ -215,11 +215,7 @@ export const DocumentCreationBehavior = [
     },
 
     _isValidType(type) {
-      return (
-        type &&
-        this.subtypes &&
-        this.subtypes.some((t) => t._id === type._id && t.type === type.type && t.icon === type.icon)
-      );
+      return type && this.subtypes?.some((t) => t._id === type._id && t.type === type.type && t.icon === type.icon);
     },
 
     _getTypeLabel(type) {

--- a/elements/nuxeo-document-creation/nuxeo-document-creation-behavior.js
+++ b/elements/nuxeo-document-creation/nuxeo-document-creation-behavior.js
@@ -218,7 +218,7 @@ export const DocumentCreationBehavior = [
       return (
         type &&
         this.subtypes &&
-        this.subtypes.findIndex((t) => t._id === type._id && t.type === type.type && t.icon === type.icon) > -1
+        this.subtypes.some((t) => t._id === type._id && t.type === type.type && t.icon === type.icon)
       );
     },
 

--- a/elements/nuxeo-dropzone/nuxeo-dropzone.js
+++ b/elements/nuxeo-dropzone/nuxeo-dropzone.js
@@ -562,13 +562,9 @@ Polymer({
       value == null ||
       (Array.isArray(value) &&
         value.filter(
-          (file) =>
-            !Object.prototype.hasOwnProperty.call(
-              this.valueKey && file[this.valueKey] != null ? file[this.valueKey] : file,
-              'data',
-            ),
+          (file) => !Object.hasOwn(this.valueKey && file[this.valueKey] != null ? file[this.valueKey] : file, 'data'),
         ).length === 0) ||
-      Object.prototype.hasOwnProperty.call(value, 'data')
+      Object.hasOwn(value, 'data')
     ) {
       if (this.uploading) {
         this.cancelBatch();
@@ -674,14 +670,14 @@ Polymer({
       return false;
     }
     if (this.accept && this.files && this.files.length > 0) {
-      const accepted = this.accept.split(',').map((a) => a.trim().toLowerCase());
+      const accepted = new Set(this.accept.split(',').map((a) => a.trim().toLowerCase()));
 
       const invalidFile = this.files.find((file) => {
         const name = file.name || '';
         const extension = `.${name.split('.').pop().toLowerCase()}`;
         const mime = (file.type || '').toLowerCase();
 
-        return !accepted.includes(extension) && !accepted.includes(mime);
+        return !accepted.has(extension) && !accepted.has(mime);
       });
 
       if (invalidFile) {

--- a/elements/nuxeo-dropzone/nuxeo-dropzone.js
+++ b/elements/nuxeo-dropzone/nuxeo-dropzone.js
@@ -634,7 +634,7 @@ Polymer({
       document.retainedProperties &&
       document.retainedProperties.length > 0
     ) {
-      if (document.retainedProperties.indexOf(this.xpath) !== -1) {
+      if (document.retainedProperties.includes(this.xpath)) {
         return false;
       }
     }

--- a/elements/nuxeo-dropzone/nuxeo-dropzone.js
+++ b/elements/nuxeo-dropzone/nuxeo-dropzone.js
@@ -672,7 +672,7 @@ Polymer({
     if (this.accept && this.files && this.files.length > 0) {
       const accepted = new Set(this.accept.split(',').map((a) => a.trim().toLowerCase()));
 
-      const invalidFile = this.files.find((file) => {
+      const hasInvalidFile = this.files.some((file) => {
         const name = file.name || '';
         const extension = `.${name.split('.').pop().toLowerCase()}`;
         const mime = (file.type || '').toLowerCase();
@@ -680,7 +680,7 @@ Polymer({
         return !accepted.has(extension) && !accepted.has(mime);
       });
 
-      if (invalidFile) {
+      if (hasInvalidFile) {
         this._errorMessage = this.i18n('dropzone.invalid.file', this.accept);
         return false;
       }

--- a/elements/nuxeo-grid/nuxeo-grid.js
+++ b/elements/nuxeo-grid/nuxeo-grid.js
@@ -185,10 +185,11 @@ function buildGridStyle(grid, validate = true) {
 :host {
   display: grid;
   grid-template-columns: ${
-    cGrid.templateColumns || (cGrid.columns && cGrid.columns > 1 ? Array(cGrid.columns).fill('1fr').join(' ') : 'auto')
+    cGrid.templateColumns ||
+    (cGrid.columns && cGrid.columns > 1 ? new Array(cGrid.columns).fill('1fr').join(' ') : 'auto')
   };
   grid-template-rows: ${
-    cGrid.templateRows || (cGrid.rows && cGrid.rows > 1 ? Array(cGrid.rows).fill('auto').join(' ') : 'auto')
+    cGrid.templateRows || (cGrid.rows && cGrid.rows > 1 ? new Array(cGrid.rows).fill('auto').join(' ') : 'auto')
   };
   ${cGrid.gap ? `grid-gap: ${cGrid.gap}` : ''};
   ${cGrid.columnGap ? `grid-column-gap: ${cGrid.columnGap};` : ''}

--- a/elements/nuxeo-home.html
+++ b/elements/nuxeo-home.html
@@ -453,7 +453,7 @@ limitations under the License.
           provider.query = `SELECT * FROM Document WHERE ecm:uuid IN (${ids}) AND ecm:isTrashed = 0`;
           provider.fetch().then((result) => {
             docs.forEach((doc) => {
-              if (result.entries.findIndex((entry) => entry.uid === doc.uid) === -1) {
+              if (!result.entries.some((entry) => entry.uid === doc.uid)) {
                 storage.remove(doc);
               }
             });

--- a/elements/nuxeo-keys/nuxeo-keys.js
+++ b/elements/nuxeo-keys/nuxeo-keys.js
@@ -123,7 +123,7 @@ Polymer({
         validKey = 'space';
       } else if (/^escape$/.test(lKey)) {
         validKey = 'esc';
-      } else if (/^arrow/.test(lKey)) {
+      } else if (lKey.startsWith('arrow')) {
         validKey = lKey.replace('arrow', '');
       } else if (lKey === 'multiply') {
         validKey = '*';

--- a/elements/nuxeo-results/nuxeo-results.js
+++ b/elements/nuxeo-results/nuxeo-results.js
@@ -1443,7 +1443,7 @@ Polymer({
     try {
       const prefsMap = await this._getAllGlobalPreferencesOnce();
 
-      if (!Object.prototype.hasOwnProperty.call(prefsMap, providerName)) {
+      if (!Object.hasOwn(prefsMap, providerName)) {
         const empty = {};
         __globalPrefsCache.set(cacheKey, empty);
         this.globalPrefs = empty;

--- a/elements/nuxeo-sardine.js
+++ b/elements/nuxeo-sardine.js
@@ -207,7 +207,7 @@ Polymer({
     let y2 = this._lastPointerEvent.y;
     x2 = x2 + w > window.innerWidth ? window.innerWidth - w : x2;
     y2 = y2 + h > window.innerHeight ? window.innerHeight - h : y2;
-    const dist = Math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2);
+    const dist = Math.hypot(x1 - x2, y1 - y2);
     if (dist < 32) {
       if (this._unknownLocation) {
         this.feeling =
@@ -251,8 +251,8 @@ Polymer({
   },
 
   _lerp(value1, value2, amount) {
-    amount = amount < 0 ? 0 : amount;
-    amount = amount > 1 ? 1 : amount;
+    amount = Math.max(0, amount);
+    amount = Math.min(1, amount);
     return value1 + (value2 - value1) * amount;
   },
 });

--- a/elements/nuxeo-suggester/nuxeo-suggester.js
+++ b/elements/nuxeo-suggester/nuxeo-suggester.js
@@ -484,7 +484,7 @@ Polymer({
   },
 
   _sanitizeSearchTerm(term) {
-    return (term || '').replace(/"/g, encodeURIComponent('"')).trim();
+    return (term || '').replaceAll('"', encodeURIComponent('"')).trim();
   },
 
   _canShowResults() {

--- a/elements/nuxeo-tasks/nuxeo-tasks-list.js
+++ b/elements/nuxeo-tasks/nuxeo-tasks-list.js
@@ -212,7 +212,7 @@ Polymer({
   selectTask(index, task, { offset, pageSize }) {
     let fetch;
     const tasks = this.$.list.items;
-    if (tasks.find((item) => item.id === task.id)) {
+    if (tasks.some((item) => item.id === task.id)) {
       fetch = Promise.resolve();
     } else {
       fetch = this.fetch(offset, pageSize);

--- a/elements/nuxeo-tasks/nuxeo-tasks-list.js
+++ b/elements/nuxeo-tasks/nuxeo-tasks-list.js
@@ -235,9 +235,9 @@ Polymer({
     }
     const tasks = this.$.list.items;
     if (newVal && tasks) {
-      for (let i = 0; i < tasks.length; i++) {
-        if (tasks[i].id === newVal.id) {
-          this.$.list.selectItem(tasks[i]);
+      for (const task of tasks) {
+        if (task.id === newVal.id) {
+          this.$.list.selectItem(task);
           break;
         }
       }

--- a/elements/nuxeo-user-authorized-apps.html
+++ b/elements/nuxeo-user-authorized-apps.html
@@ -102,8 +102,8 @@ limitations under the License.
           this.tokens = response.entries;
           if (this.tokens.length > 0) {
             this.$.clients.get().then((innerResponse) => {
-              this.clients = innerResponse.entries.filter(
-                (client) => this.tokens.findIndex((token) => token.clientId === client.id) > -1,
+              this.clients = innerResponse.entries.filter((client) =>
+                this.tokens.some((token) => token.clientId === client.id),
               );
             });
           } else {

--- a/elements/nuxeo-user-cloud-services.html
+++ b/elements/nuxeo-user-cloud-services.html
@@ -89,7 +89,7 @@ limitations under the License.
       },
 
       _showConnectTo() {
-        return this.providers && this.providers.length > 0 && this.providers.some((provider) => provider.isEnabled);
+        return this.providers && this.providers.some((provider) => provider.isEnabled);
       },
 
       _connectTo(e) {

--- a/elements/nuxeo-workflow-graph/nuxeo-workflow-graph.js
+++ b/elements/nuxeo-workflow-graph/nuxeo-workflow-graph.js
@@ -378,8 +378,7 @@ Polymer({
       element.style.left = `${node.x}px`;
       element.style.top = `${node.y}px`;
 
-      element.classList.add('workflow_node');
-      element.classList.add(this._nodeClass(node));
+      element.classList.add('workflow_node', this._nodeClass(node));
       if (node.state === 'suspended') {
         element.classList.add('workflow_node_suspended');
       }

--- a/elements/nuxeo-workflow-graph/nuxeo-workflow-graph.js
+++ b/elements/nuxeo-workflow-graph/nuxeo-workflow-graph.js
@@ -368,7 +368,7 @@ Polymer({
 
     // clear when re-rendering
     while (this.$.container.firstChild) {
-      this.$.container.removeChild(this.$.container.firstChild);
+      this.$.container.firstChild.remove();
     }
     this._jsPlumbInstance.reset();
 

--- a/elements/performance.js
+++ b/elements/performance.js
@@ -59,7 +59,7 @@ export const Performance = {
     // returns “phone”, “tablet”, or “desktop”
     ua = (ua || this.getUserAgent()).toLowerCase();
     const find = function (str) {
-      return ua.indexOf(str) !== -1;
+      return ua.includes(str);
     };
 
     // windows

--- a/elements/performance.js
+++ b/elements/performance.js
@@ -140,7 +140,7 @@ export const Performance = {
   },
 
   getLongTasks() {
-    if (typeof window.__lt === 'undefined') {
+    if (window.__lt === undefined) {
       return null;
     }
     return window.__lt.e.map((longTask) => {
@@ -202,7 +202,7 @@ export const Performance = {
   },
 
   report(options) {
-    if (typeof options === 'undefined') {
+    if (options === undefined) {
       options = {};
     }
     const result = {

--- a/elements/routing.js
+++ b/elements/routing.js
@@ -241,7 +241,7 @@ app.router = {
   },
 
   tasks(id) {
-    return `/tasks${typeof id === 'undefined' ? '' : `/${id}`}`;
+    return `/tasks${id === undefined ? '' : `/${id}`}`;
   },
 
   administration(tab) {

--- a/elements/search/default/nuxeo-default-search-results.html
+++ b/elements/search/default/nuxeo-default-search-results.html
@@ -267,7 +267,7 @@ limitations under the License.
         if (!elem) return;
 
         const tag = elem.tagName.toLowerCase();
-        const currentIndex = parseInt(elem.getAttribute('index'), 10);
+        const currentIndex = Number.parseInt(elem.getAttribute('index'), 10);
         const total = (this.nxProvider && this.nxProvider.resultsCount) || 0;
         let newIndex = currentIndex;
 

--- a/elements/search/nuxeo-saved-search-actions.js
+++ b/elements/search/nuxeo-saved-search-actions.js
@@ -171,6 +171,6 @@ Polymer({
   },
 
   _hasPermissions() {
-    return this.searchDoc ? this.searchDoc.contextParameters.permissions.indexOf('WriteProperties') > -1 : false;
+    return this.searchDoc ? this.searchDoc.contextParameters.permissions.includes('WriteProperties') : false;
   },
 });

--- a/elements/search/nuxeo-search-form.js
+++ b/elements/search/nuxeo-search-form.js
@@ -875,7 +875,7 @@ Polymer({
     const search = this._searches[idx];
     const clonedParams = JSON.parse(JSON.stringify(search.params));
     this.params = this._mutateParams(clonedParams, true);
-    this.searchTerm = this.params && this.params.ecm_fulltext ? this.params.ecm_fulltext.replace(/\*/g, '') : '';
+    this.searchTerm = this.params && this.params.ecm_fulltext ? this.params.ecm_fulltext.replaceAll('*', '') : '';
 
     // Ensure form stays synced
     if (this.form) {

--- a/elements/workflow/nuxeo-document-task.js
+++ b/elements/workflow/nuxeo-document-task.js
@@ -347,7 +347,7 @@ Polymer({
   },
 
   _hasActorType(actors, type) {
-    return actors && Array.isArray(actors) && actors.findIndex((actor) => actor['entity-type'] === type) >= 0;
+    return actors && Array.isArray(actors) && actors.some((actor) => actor['entity-type'] === type);
   },
 
   _getActorsByType(actors, type) {

--- a/test/nuxeo-app.test.js
+++ b/test/nuxeo-app.test.js
@@ -2002,6 +2002,52 @@ suite('nuxeo-app', () => {
       append.restore();
     });
 
+    suite('_newToast MDCSnackbar:closed handling', () => {
+      function closedToast(id, callback, state) {
+        const toast = app._newToast(id, callback);
+        document.body.appendChild(toast);
+        if (state !== undefined) {
+          toast.__state = state;
+        }
+        return toast;
+      }
+
+      function close(toast, reason) {
+        toast.dispatchEvent(new CustomEvent('MDCSnackbar:closed', { detail: { reason } }));
+      }
+
+      test('detaches the toast and runs the callback when the action aborts the command', () => {
+        const callback = sinon.spy();
+        const toast = closedToast('snack_abort', callback);
+
+        close(toast, 'action');
+
+        expect(callback).to.have.been.calledOnce;
+        expect(toast.__state).to.deep.equal({ dismissed: false, aborted: true });
+        expect(toast.parentNode).to.be.null;
+      });
+
+      test('detaches the toast when it is dismissed after the command has ended', () => {
+        const toast = closedToast('snack_ended', undefined, { ended: true });
+
+        close(toast, 'dismiss');
+
+        expect(toast.__state).to.be.null;
+        expect(toast.parentNode).to.be.null;
+      });
+
+      test('keeps the toast attached when dismissed while the command is still running', () => {
+        // Removing it here would make the snackbar reappear before the task finishes.
+        const toast = closedToast('snack_running', undefined, { ended: false });
+
+        close(toast, 'dismiss');
+
+        expect(toast.__state.dismissed).to.be.true;
+        expect(toast.parentNode).to.equal(document.body);
+        toast.remove();
+      });
+    });
+
     test('_notify shows message on command toast', () => {
       const show = sinon.spy();
       const toast = {

--- a/test/nuxeo-document-create-shortcuts.test.js
+++ b/test/nuxeo-document-create-shortcuts.test.js
@@ -67,4 +67,18 @@ suite('nuxeo-document-create-shortcuts', () => {
     el._putNodes(parent);
     expect(parent.children.length).to.equal(0);
   });
+
+  test('_putNodes appends a node passed outside an array and detaches the previous children', () => {
+    const parent = document.createElement('div');
+    const stale = document.createElement('i');
+    parent.appendChild(stale);
+    const solo = document.createElement('span');
+    solo.id = 'solo';
+
+    el._putNodes(parent, solo);
+
+    expect(parent.children.length).to.equal(1);
+    expect(parent.querySelector('#solo')).to.exist;
+    expect(stale.parentNode).to.be.null;
+  });
 });

--- a/test/nuxeo-document-creation-behavior.test.js
+++ b/test/nuxeo-document-creation-behavior.test.js
@@ -109,6 +109,57 @@ suite('DocumentCreationBehavior', () => {
     });
   });
 
+  suite('_parentChanged', () => {
+    function parentWith(permissions, subtypes) {
+      return {
+        path: '/default-domain/workspaces',
+        contextParameters: { permissions, subtypes },
+        isTrashed: false,
+      };
+    }
+
+    function subtypesSetTo() {
+      return ctx.set.getCalls().find((call) => call.args[0] === 'subtypes');
+    }
+
+    test('should drop subtypes flagged HiddenInCreation and keep the rest sorted by id', () => {
+      ctx.parent = parentWith(
+        ['AddChildren'],
+        [
+          { type: 'Picture', facets: ['Commentable'] },
+          { type: 'Note', facets: ['HiddenInCreation'] },
+          { type: 'File', facets: [] },
+        ],
+      );
+
+      ctx._parentChanged();
+
+      expect(subtypesSetTo().args[1].map((type) => type.type)).to.deep.equal(['File', 'Picture']);
+    });
+
+    test('should keep every subtype when none is hidden in creation', () => {
+      ctx.parent = parentWith(
+        ['AddChildren'],
+        [
+          { type: 'File', facets: [] },
+          { type: 'Picture', facets: ['Commentable'] },
+        ],
+      );
+
+      ctx._parentChanged();
+
+      expect(subtypesSetTo().args[1].map((type) => type.type)).to.deep.equal(['File', 'Picture']);
+    });
+
+    test('should set no subtypes when the parent cannot be created in', () => {
+      ctx.parent = parentWith(['Read'], [{ type: 'File', facets: [] }]);
+
+      ctx._parentChanged();
+
+      expect(subtypesSetTo().args[1]).to.deep.equal([]);
+    });
+  });
+
   suite('_getTypeLabel', () => {
     test('should return formatted doc type when type is valid', () => {
       const type = { _id: '1', type: 'File', id: 'file', icon: 'file-icon' };

--- a/test/nuxeo-repositories.test.js
+++ b/test/nuxeo-repositories.test.js
@@ -43,6 +43,43 @@ suite('nuxeo-repositories', () => {
     });
   });
 
+  suite('repositories default value', () => {
+    let saved;
+
+    setup(() => {
+      saved = Nuxeo.UI.repositories;
+    });
+
+    teardown(() => {
+      Nuxeo.UI.repositories = saved;
+    });
+
+    test('should copy the known repositories rather than alias them', async () => {
+      const source = [
+        { name: 'default', isDefault: true },
+        { name: 'other', isDefault: false },
+      ];
+      Nuxeo.UI.repositories = source;
+
+      const el = await fixture(html`<nuxeo-repositories></nuxeo-repositories>`);
+
+      expect(el.repositories).to.deep.equal(source);
+      // Each entry must be its own object, so editing the element's copy cannot
+      // write back into the shared Nuxeo.UI state.
+      expect(el.repositories[0]).to.not.equal(source[0]);
+      el.repositories[0].name = 'mutated';
+      expect(source[0].name).to.equal('default');
+    });
+
+    test('should fall back to an empty list when no repositories are known', async () => {
+      Nuxeo.UI.repositories = undefined;
+
+      const el = await fixture(html`<nuxeo-repositories></nuxeo-repositories>`);
+
+      expect(el.repositories).to.deep.equal([]);
+    });
+  });
+
   suite('_updateSelected', () => {
     test('should use repository name from connection', () => {
       element.$.nx.repositoryName = 'myrepo';


### PR DESCRIPTION
## Problem

SonarCloud reports 96 open MAINTAINABILITY findings across 24 rules in `nuxeo-web-ui` and its addons (~426 min of debt), all of the same class: a legacy JS/DOM idiom where a modern built-in exists. This is part 3 of 9 of the maintainability triage in WEBUI-2246, and the direct counterpart to WEBUI-2228 on the reliability side.

Jira: [WEBUI-2248](https://hyland.atlassian.net/browse/WEBUI-2248)

## Root cause

Not a defect — accumulated idiom drift. The code predates `Array#includes`, `String#replaceAll`, `Object.hasOwn`, `ChildNode#remove`, `for-of` and friends, so existence checks are written as `indexOf(x) !== -1`, global replacements as `replace(/x/g, y)`, DOM detachment as `parent.removeChild(node)`, and iteration as index-counted `for` loops.

## Changes

No behavioural change is intended anywhere. Commits are grouped **by rule**, in the order the ticket asks for, so each one can be verified as a single recognisable transformation rather than 96 unrelated hunks.

| Commit | Rules | Findings | Substitution |
| --- | --- | --- | --- |
| 1 | `S7773` `S7741` `S7759` `S6653` `S7766` `S1940` + 13 long-tail rules | 34 | Pure substitutions with no semantic edge case |
| 2 | `S7765` | 30 | `.indexOf(x)` vs `-1` → `.includes(x)` |
| 3 | `S7754` | 8 | `.find` / `.findIndex` used as a boolean → `.some` |
| 4 | `S7781` | 8 | `.replace(/x/g, y)` → `.replaceAll(x, y)` |
| 5 | `S4138` | 10 | index-counted `for` → `for-of` |
| 6 | `S7762` | 6 | `parent.removeChild(node)` → `node.remove()` |
| 7 | `S6582` | 3 | optional chaining — see below |
| 8 | — | — | unit tests for the rewritten lines |

Each commit message documents the per-site reasoning. The four rules the ticket flagged as having real edge cases were checked individually rather than swept:

* **`S7765`** — all 30 sites are pure existence checks (`=== -1`, `!== -1`, `> -1`, `< 0`). None used `> 0`, which is a *different* predicate. No site searches for a numeric value, so the `NaN` difference between `includes` (SameValueZero) and `indexOf` (strict equality) is unobservable.
* **`S7754`** — converted only where the element/index is never consumed. Two sites were already `!!...find(...)`, i.e. hand-rolled `some`. `nuxeo-dropzone`'s `invalidFile` was only read as `if (invalidFile)`, so it becomes `hasInvalidFile`.
* **`S7781`** — every regex genuinely carried `g`, so nothing relied on replacing only the first occurrence and **no site needed a Won't Fix**. Confirmed each pattern is a literal (the `\+` / `\*` escapes existed only because they are regex metacharacters) and that no replacement contains `$`, which `replaceAll` would treat as a substitution pattern. The non-global anchored `replace(/^(document\.properties\.)/, '')` in `nuxeo-edit-documents-button.js` is deliberately left as a regex.
* **`S4138`** — every loop body was read in full to confirm the index is only used to read the current element. Loops that legitimately use their index (the `addedCount` splice handler and the local/remote file walk in `nuxeo-document-import.js`, which offsets `i` across two arrays) were not flagged by Sonar and are left as index loops. No `for-in` was involved, so the inherited-keys/string-keys caveat does not apply.
* **`S7762`** — none of the 6 sites uses `removeChild`'s return value; all are statement-position calls. The only other difference is that `removeChild` throws `NotFoundError` when the node is not a direct child, so the change is observable *only* on paths that currently throw. Two `nuxeo-app.js` toast sites additionally threw a `TypeError` when `parentNode` was already `null`; `toast.remove()` is a no-op there, which is what the handlers intend.

### Commit 7 — three findings this cleanup created

Collapsing the comparisons above turned three guards into exactly the shape `S6582` looks for: `a && a.b(...) <compared>` became a bare `a && a.b(...)`, i.e. an optional chain written longhand. Sonar reported these as **new** issues on this PR, so they are fixed here rather than left as new debt on a debt-reduction ticket. All three are consumed for truthiness only, so the `a && a.b()` → `a?.b()` difference for falsy-but-not-nullish `a` is not observable — the `''` case in `nuxeo-audit-search` yields `false` instead of `''`, same branch.

### Scope

Per acceptance criterion 4, **no file under `addons/nuxeo-platform-3d/loaders/**` or `controls/**` is touched** (verified against the diff; both are also eslint-ignored). No `package.json` / `package-lock.json` churn.

## Test plan

- [x] `npm run lint` passes on both bases (eslint + prettier)
- [x] `npm test` passes — **2731 tests, 0 failures** on `lts-2025`
- [x] Verified programmatically that no legacy pattern remains for `S7765`, `S7754`, `S7781`, `S4138` or `S7762` in any flagged file
- [x] Both base branches carry **byte-identical** changed lines (57 files, +312/−137)
- [x] All commits signed

### On the baseline

Both branches were validated against a freshly installed dependency tree (`npm ci`) in an isolated per-ticket clone, and compared against the **untouched base commit in the same clone**:

| | base | this branch |
| --- | --- | --- |
| `lts-2025` | 2718 passed, 1 failed | **2731 passed, 0 failed** |
| `maintenance-3.1.x` | 2718 passed, 1 failed | **2730 passed, 1 failed** |

The one failure, `nuxeo-search-form > gives the saved searches dropdown an always visible label (WEBUI-489)`, is **pre-existing** — it fails identically on both untouched bases. It asserts an `aria-labelledby`-derived label needing a `nuxeo-selectivity` newer than the released `@nuxeo/nuxeo-ui-elements` these branches resolve to, i.e. the upstream test-alignment commit landed ahead of the element release. It is order-sensitive: it passed on the `lts-2025` branch run and failed on the `maintenance-3.1.x` one, with byte-identical code.

`nuxeo-app > toast screen reader announcements > _announce clears the region first...` also failed once **on each base** and passed on re-run of the base — a flake, not a regression.

### Coverage

The Sonar gate initially failed on `new_coverage` (84.5% vs 90%), not on any smell: a refactor-only PR inherits the coverage of the lines it rewrites. Commit 8 adds tests for the rewritten lines **where the substitution could actually change behaviour**, so the coverage that closes the gate is also the coverage that protects the change:

* `nuxeo-app` — both `MDCSnackbar:closed` branches that now call `toast.remove()`, including the case where the toast must *not* be detached (dismissed while the command is still running, where removal would make the snackbar reappear mid-task).
* `nuxeo-document-create-shortcuts` — `_putNodes` with a non-array node, asserting the `firstChild.remove()` drain loop really detaches the old children.
* `nuxeo-drive-sync-toggle-button` — `_update`, covering both `roots.includes(...)` conversions and the closest-ancestor walk.
* `nuxeo-document-creation-behavior` — `_parentChanged` filtering on `!facets.includes('HiddenInCreation')`.
* `nuxeo-repositories` — that the default entries are *copies*, which is the real contract of `Object.assign({}, r)` → `{ ...r }` and something `deep.equal` alone would miss.

Changed-line coverage: **85.1% → 92.6%** locally (75/81 covered). The remaining uncovered changed lines are in files with no lcov record at all (inline `<script>` in HTML layouts, `routing.js`) plus `nuxeo-breadcrumb._resize` and `nuxeo-workflow-graph._updateGraph` — the latter two need a laid-out overlay and a live jsPlumb instance respectively, and stubbing jsPlumb hard enough to enter `_updateGraph` would assert the stub rather than the element.

### Worth a manual look

`nuxeo-dropzone` and `nuxeo-document-create-actions` carry 5 findings each and are the two interaction-heavy elements in scope:

1. **Dropzone** — drop a file whose extension/MIME is outside `accept` and confirm the `dropzone.invalid.file` error still appears (`accepted` is now a `Set`, and the check is now `some` rather than `find`); then drop a valid file and confirm upload still works. Also check a retained/legal-hold document still blocks editing the retained blob.
2. **Create shortcuts** — open the document-create dialog and confirm the recently-used type shortcuts still render.
3. **Toasts** — trigger a toast with an action (e.g. a bulk operation), then both abort it and let it complete; confirm the toast is removed in each case and no stale toast is left behind.
4. **Diff** — compare two document versions and confirm common schemas/properties still resolve.
5. **Workflow graph** — open a workflow's graph view and confirm nodes render with correct styling and re-render cleanly on revisit (not covered by unit tests, see above).

## Notes

* Backport of #3518 (lts-2025). The two branches are byte-identical.
* Nothing was marked Won't Fix: all 96 findings are addressed in code.
* Overlapping files called out in the ticket (`nuxeo-document-import.js`, `elements/diff/*`, the spreadsheet files) also appear in WEBUI-2246 and the error-handling ticket, so those should be sequenced after this lands rather than worked in parallel.


[WEBUI-2248]: https://hyland.atlassian.net/browse/WEBUI-2248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ