### PR TITLE
WEBUI-2240: scope service worker JS caching to same-origin [lts-2025]

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -87,7 +87,7 @@ workbox.routing.registerRoute(
    boots from cache, and a cross-upgrade `?ts` change guarantees a fresh fetch.
 ================================ */
 workbox.routing.registerRoute(
-  ({ url }) => url.pathname.endsWith('/main.bundle.js'),
+  ({ url }) => url.origin === self.location.origin && url.pathname.endsWith('/main.bundle.js'),
   new workbox.strategies.NetworkFirst({
     cacheName: JS_CACHE,
     fetchOptions: { cache: 'no-cache', credentials: 'same-origin' },
@@ -106,10 +106,13 @@ workbox.routing.registerRoute(
 
 /* ================================
    JS files (versioned via ts)
+   Same-origin only: intercepting cross-origin scripts would rebuild the request in
+   CORS mode and break external `<script src>` loads (WEBUI-2240). CSP governs which
+   external scripts may execute — not the service worker.
 ================================ */
 if (TS) {
   workbox.routing.registerRoute(
-    ({ url }) => url.pathname.endsWith('.js'),
+    ({ url }) => url.origin === self.location.origin && url.pathname.endsWith('.js'),
     new workbox.strategies.NetworkFirst({
       cacheName: JS_CACHE,
       plugins: [


### PR DESCRIPTION
## Problem
External JavaScript resources fail to load and throw a CORS error in the browser console / Network tab. When an external `<script src="https://.../script.js">` is added to a Web UI page (e.g. `nuxeo-home.html`) and the page is reloaded, the request is blocked: `No 'Access-Control-Allow-Origin' header is present on the requested resource`, and the service worker reports it failed to fetch with no cached fallback. Jira: [WEBUI-2240](https://hyland.atlassian.net/browse/WEBUI-2240)

## Root cause
In `sw.js`, the generic JS caching route matched **every** `.js` request regardless of origin (`url.pathname.endsWith('.js')`) and its `requestWillFetch` plugin rebuilt the request with `credentials: 'same-origin'`. Reconstructing the `Request` forces the browser out of the default opaque `no-cors` mode into CORS mode, so a cross-origin script whose server sends no `Access-Control-Allow-Origin` header is blocked. A plain `<script src>` cross-origin normally loads fine in `no-cors` mode — the service worker interception is what broke it. The other routes are already origin-scoped (HTML → `/nuxeo/ui/`, API → `/nuxeo/api/`); only the JS route was missing the guard.

## Changes
* **`sw.js`**: restrict both the entry-bundle route (`main.bundle.js`) and the generic `.js` route to same-origin requests (`url.origin === self.location.origin && …`). Cross-origin scripts are no longer intercepted and load natively (`no-cors`) again. Same-origin app JS caching, `?ts` versioning and offline fallback are unchanged. The service worker is a caching layer, not a security boundary — CSP remains the control governing which external scripts may execute.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (no unit tests exercise the service worker routes)
- [ ] With an external `<script src>` added to a UI page, reload and confirm the script loads with no CORS error and the service worker no longer intercepts it
- [ ] Confirm same-origin app boot, addon chunk loading, and soft reload still work (entry bundle + chunks still `?ts`-versioned)

## Notes
Backport pair: this PR targets `lts-2025`; a sibling PR targets `maintenance-3.1.x` (LTS-2023) with the identical change. Edge case: a deployment that offloads the app's own webpack chunks to a different-origin CDN would stop receiving service-worker `?ts` cache-busting, but WEBUI-2061's content-hashed chunk filenames already handle upgrade cache-busting, so this is not a practical regression.

[WEBUI-2240]: https://hyland.atlassian.net/browse/WEBUI-2240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ