### PR TITLE
WEBUI-2250: Clear low-risk Sonar complexity and readability findings

### DIFF
--- a/addons/nuxeo-spreadsheet/app/lib/select2-editor.js
+++ b/addons/nuxeo-spreadsheet/app/lib/select2-editor.js
@@ -40,13 +40,12 @@ Select2Editor.prototype.createElements = function () {
 
   this.instance.rootElement[0].appendChild(this.TEXTAREA_PARENT);
 
-  const that = this;
   Handsontable.hooks.add('afterRender', () => {
     // TODO(nfgs) - was that.instance.registerTimeout
-    that.instance._registerTimeout(
+    this.instance._registerTimeout(
       'refresh_editor_dimensions',
       () => {
-        that.refreshDimensions();
+        this.refreshDimensions();
       },
       0,
     );
@@ -54,8 +53,7 @@ Select2Editor.prototype.createElements = function () {
 };
 
 const onBeforeKeyDown = function onBeforeKeyDown(event) {
-  const instance = this;
-  const that = instance.getActiveEditor();
+  const that = this.getActiveEditor();
 
   const keyCodes = Handsontable.helper.keyCode;
   const ctrlDown = (event.ctrlKey || event.metaKey) && !event.altKey; // catch CTRL but not right ALT (which in some systems triggers ALT+CTRL)

--- a/elements/diff/nuxeo-diff-behavior.js
+++ b/elements/diff/nuxeo-diff-behavior.js
@@ -256,9 +256,11 @@ export const DiffBehavior = {
   },
 
   _isSimple(delta, originalValue) {
-    return delta
-      ? this._isSimpleDelta(delta)
-      : !this._isObject(Array.isArray(originalValue) && originalValue.length > 0 ? originalValue[0] : originalValue);
+    if (delta) {
+      return this._isSimpleDelta(delta);
+    }
+    const value = Array.isArray(originalValue) && originalValue.length > 0 ? originalValue[0] : originalValue;
+    return !this._isObject(value);
   },
 
   _getAllKeys(delta, originalValue, showAll) {

--- a/elements/diff/nuxeo-diff.js
+++ b/elements/diff/nuxeo-diff.js
@@ -484,12 +484,14 @@ Polymer({
   },
 
   _getCommonProperties(left, right, schema, delta) {
+    // `schema` does not change across the iteration, so the prefix is resolved once up front.
+    const schemaPrefix = schema ? `${schema.prefix || schema.name}:` : null;
     return Object.keys(left.properties).filter(
       (leftPropName) =>
         !!Object.keys(right.properties).find(
           (rightPropName) =>
             leftPropName === rightPropName &&
-            (schema ? leftPropName.startsWith(`${schema.prefix ? schema.prefix : schema.name}:`) : true) &&
+            (schemaPrefix ? leftPropName.startsWith(schemaPrefix) : true) &&
             (delta ? delta[leftPropName] : true),
         ),
     );

--- a/elements/nuxeo-admin/nuxeo-analytics.js
+++ b/elements/nuxeo-admin/nuxeo-analytics.js
@@ -26,6 +26,16 @@ import '../nuxeo-app/nuxeo-page.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
+// Moves tabindex onto the given tab item so only it is tabbable, then focuses it.
+function updateFocus(item) {
+  if (!item) return;
+  Array.from(item.parentElement.children).forEach((child) => {
+    child.setAttribute('tabindex', '-1');
+  });
+  item.setAttribute('tabindex', '0');
+  item.focus();
+}
+
 /**
 `nuxeo-analytics`
 @group Nuxeo UI
@@ -73,15 +83,6 @@ Polymer({
   ready() {
     if (super.ready) super.ready();
     const listbox = this.$$('paper-listbox');
-
-    function updateFocus(item) {
-      if (!item) return;
-      Array.from(item.parentElement.children).forEach((child) => {
-        child.setAttribute('tabindex', '-1');
-      });
-      item.setAttribute('tabindex', '0');
-      item.focus();
-    }
 
     listbox.addEventListener('click', (e) => {
       const item = e.target.closest('[name]');

--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -1380,58 +1380,74 @@ Polymer({
     this.$.diff.docIds = e.detail.documents.map((doc) => doc.uid);
   },
 
+  _browseTitle() {
+    const title = [];
+    if (this.currentDocument && this.currentDocument.title) {
+      // The repository root has no dc:title, so the server returns its uid as the title.
+      // Mirror the breadcrumb/clipboard behavior and show the localized root label instead
+      // of a raw UUID, so the browser tab title stays meaningful and consistent for
+      // screen-reader users navigating between tabs (WEBUI-1876).
+      title.push(this.currentDocument.type === 'Root' ? this.i18n('browse.root') : this.currentDocument.title);
+      if (this.currentDocument.type === 'Collections') {
+        title.push(this.i18n('app.title.collections'));
+      } else if (this.hasFacet(this.currentDocument, 'Collection')) {
+        title.push(
+          this.currentDocument.type === 'Favorites'
+            ? this.i18n('app.title.favorites')
+            : this.i18n('app.title.collection'),
+        );
+      }
+    }
+    return title;
+  },
+
+  _searchTitle() {
+    const title = [];
+    if (this.searchForm) {
+      if (this.searchForm.selectedSearch && this.searchForm.selectedSearch.title) {
+        title.push(this.searchForm.selectedSearch.title);
+      } else if (this.searchForm.searchName) {
+        title.push(this.i18n(`app.title.search.${this.searchForm.searchName}`));
+      }
+    }
+    title.push(this.i18n('app.title.search'));
+    return title;
+  },
+
+  _tasksTitle() {
+    if (this.currentTask) {
+      return [this.i18n(this.currentTask.workflowModelName), this.i18n(this.currentTask.name)];
+    }
+    return [this.i18n(`app.title.${this.page}`)];
+  },
+
+  _adminTitle() {
+    const title = [];
+    if (this.selectedAdminTab) {
+      title.push(this.i18n(`app.title.admin.${this.selectedAdminTab}`));
+    }
+    title.push(this.i18n(`app.title.${this.page}`));
+    return title;
+  },
+
   _updateTitle() {
     if (!this.page) return;
-    const title = [];
+    let title;
     switch (this.page) {
       case 'browse':
-        if (this.currentDocument && this.currentDocument.title) {
-          // The repository root has no dc:title, so the server returns its uid as the title.
-          // Mirror the breadcrumb/clipboard behavior and show the localized root label instead
-          // of a raw UUID, so the browser tab title stays meaningful and consistent for
-          // screen-reader users navigating between tabs (WEBUI-1876).
-          title.push(this.currentDocument.type === 'Root' ? this.i18n('browse.root') : this.currentDocument.title);
-          if (this.currentDocument.type === 'Collections') {
-            title.push(this.i18n('app.title.collections'));
-          } else if (this.hasFacet(this.currentDocument, 'Collection')) {
-            if (this.currentDocument.type === 'Favorites') {
-              title.push(this.i18n('app.title.favorites'));
-            } else {
-              title.push(this.i18n('app.title.collection'));
-            }
-          }
-        }
+        title = this._browseTitle();
         break;
-
       case 'search':
-        if (this.searchForm) {
-          if (this.searchForm.selectedSearch && this.searchForm.selectedSearch.title) {
-            title.push(this.searchForm.selectedSearch.title);
-          } else if (this.searchForm.searchName) {
-            title.push(this.i18n(`app.title.search.${this.searchForm.searchName}`));
-          }
-        }
-        title.push(this.i18n('app.title.search'));
+        title = this._searchTitle();
         break;
-
       case 'tasks':
-        if (this.currentTask) {
-          title.push(this.i18n(this.currentTask.workflowModelName));
-          title.push(this.i18n(this.currentTask.name));
-        } else {
-          title.push(this.i18n(`app.title.${this.page}`));
-        }
+        title = this._tasksTitle();
         break;
-
       case 'admin':
-        if (this.selectedAdminTab) {
-          title.push(this.i18n(`app.title.admin.${this.selectedAdminTab}`));
-        }
-        title.push(this.i18n(`app.title.${this.page}`));
+        title = this._adminTitle();
         break;
-
       default:
-        title.push(this.i18n(`app.title.${this.page}`));
+        title = [this.i18n(`app.title.${this.page}`)];
     }
     title.push(this.productName);
     document.title = title.join(' - ');

--- a/elements/nuxeo-grid/nuxeo-grid.js
+++ b/elements/nuxeo-grid/nuxeo-grid.js
@@ -175,18 +175,26 @@ function buildDeclaration(property, value) {
 }
 
 /**
- * Builds a `grid-column` / `grid-row` shorthand from a start line and a span, either of which may
- * be absent: a line alone places the item, a span alone leaves placement to the grid's auto flow.
+ * Builds a `grid-column` / `grid-row` shorthand from a start line and a span.
+ *
+ * `line` is interpolated even when it is absent, which reproduces the output of the previous
+ * implementation byte-for-byte. A span with no start line therefore still yields an invalid
+ * declaration (`grid-column: undefinedspan 3;`) that browsers discard. That is a real defect, but
+ * correcting it here would change rendering, so it is tracked separately in WEBUI-2289 and left
+ * untouched by this refactor.
  */
 function buildGridLine(property, line, span) {
-  const parts = [];
-  if (line) {
-    parts.push(line);
+  if (!line && !span) {
+    return '';
   }
+  let value = `${line}`;
   if (span) {
-    parts.push(`span ${span}`);
+    if (line) {
+      value += ' / ';
+    }
+    value += `span ${span}`;
   }
-  return buildDeclaration(property, parts.join(' / '));
+  return `${property}: ${value};`;
 }
 
 function buildGridStyle(grid, validate = true) {

--- a/elements/nuxeo-grid/nuxeo-grid.js
+++ b/elements/nuxeo-grid/nuxeo-grid.js
@@ -389,7 +389,6 @@ class Grid extends Nuxeo.Element {
   connectedCallback() {
     super.connectedCallback();
     this._updateGrid();
-    const targetNode = this;
     const config = { attributes: true, childList: true, subtree: true };
     this.__observer = new MutationObserver((mutationList) => {
       if (
@@ -405,7 +404,7 @@ class Grid extends Nuxeo.Element {
         this._updateGrid();
       }
     });
-    this.__observer.observe(targetNode, config);
+    this.__observer.observe(this, config);
   }
 
   disconnectedCallback() {

--- a/elements/nuxeo-grid/nuxeo-grid.js
+++ b/elements/nuxeo-grid/nuxeo-grid.js
@@ -170,6 +170,25 @@ ${css.replace(/^(.+)$/gm, '  $1') /* apply indentation */}
 `);
 }
 
+function buildDeclaration(property, value) {
+  return value ? `${property}: ${value};` : '';
+}
+
+/**
+ * Builds a `grid-column` / `grid-row` shorthand from a start line and a span, either of which may
+ * be absent: a line alone places the item, a span alone leaves placement to the grid's auto flow.
+ */
+function buildGridLine(property, line, span) {
+  const parts = [];
+  if (line) {
+    parts.push(line);
+  }
+  if (span) {
+    parts.push(`span ${span}`);
+  }
+  return buildDeclaration(property, parts.join(' / '));
+}
+
 function buildGridStyle(grid, validate = true) {
   const cGrid = {};
   cGrid.templateColumns = validateValue(grid.templateColumns, /^(\d+fr|\d+px|auto)$/, validate, 'template-columns');
@@ -214,20 +233,10 @@ function buidChildStyle(child, validate = true) {
   }
   const css = `
 ::slotted([${Child.ATTRS.CHILDID}="${cChild.id}"]) {
-  ${
-    cChild.column || cChild.columnspan
-      ? `grid-column: ${cChild.column}${
-          cChild.columnspan ? `${cChild.column ? ' / ' : ''}span ${cChild.columnspan}` : ''
-        };`
-      : ''
-  }
-  ${
-    cChild.row || cChild.rowspan
-      ? `grid-row: ${cChild.row}${cChild.rowspan ? `${cChild.row ? ' / ' : ''}span ${cChild.rowspan}` : ''};`
-      : ''
-  }
-  ${cChild.align ? `align-self: ${cChild.align};` : ''}
-  ${cChild.justify ? `justify-self: ${cChild.justify};` : ''}
+  ${buildGridLine('grid-column', cChild.column, cChild.columnspan)}
+  ${buildGridLine('grid-row', cChild.row, cChild.rowspan)}
+  ${buildDeclaration('align-self', cChild.align)}
+  ${buildDeclaration('justify-self', cChild.justify)}
 }
 `;
   return removeEmptyLines(css);
@@ -384,15 +393,11 @@ class Grid extends Nuxeo.Element {
     const config = { attributes: true, childList: true, subtree: true };
     this.__observer = new MutationObserver((mutationList) => {
       if (
-        mutationList.some((mutation) => {
-          if (
+        mutationList.some(
+          (mutation) =>
             mutation.target === this ||
-            (mutation.type === 'attributes' && Object.values(Child.ATTRS).includes(mutation.attributeName))
-          ) {
-            return true;
-          }
-          return false;
-        })
+            (mutation.type === 'attributes' && Object.values(Child.ATTRS).includes(mutation.attributeName)),
+        )
       ) {
         // refresh the grid when there is a mutation in:
         // - the grid, for any type of mutation

--- a/elements/routing.js
+++ b/elements/routing.js
@@ -210,20 +210,21 @@ app.router = {
   useHashbang: true,
 
   browse(path, subPage) {
-    return `/browse${
-      path
-        ? path
-            .split('/')
-            .map((n) => encodeURIComponent(n))
-            .join('/')
-        : ''
-    }${subPage ? `?p=${encodeURIComponent(subPage)}` : ''}`;
+    const encodedPath = path
+      ? path
+          .split('/')
+          .map((n) => encodeURIComponent(n))
+          .join('/')
+      : '';
+    const query = subPage ? `?p=${encodeURIComponent(subPage)}` : '';
+    return `/browse${encodedPath}${query}`;
   },
 
   document(idOrPath, subPage) {
     const isId = idOrPath && !idOrPath.startsWith('/');
     if (isId) {
-      return `/doc/${idOrPath}${subPage ? `?p=${encodeURIComponent(subPage)}` : ''}`;
+      const query = subPage ? `?p=${encodeURIComponent(subPage)}` : '';
+      return `/doc/${idOrPath}${query}`;
     }
     return app.router.browse(idOrPath, subPage);
   },
@@ -241,7 +242,8 @@ app.router = {
   },
 
   tasks(id) {
-    return `/tasks${typeof id === 'undefined' ? '' : `/${id}`}`;
+    const suffix = id === undefined ? '' : `/${id}`;
+    return `/tasks${suffix}`;
   },
 
   administration(tab) {

--- a/elements/search/nuxeo-search-form.js
+++ b/elements/search/nuxeo-search-form.js
@@ -48,6 +48,21 @@ import { ensureSearchResultTooltipStyles } from './nuxeo-search-result-tooltip-s
 
 ensureSearchResultTooltipStyles();
 
+// Walks the parent chain of a vocabulary entry and reconstructs the full hierarchical path string.
+// Handles properties.parent as a string id, an object with .id, or an object with .properties.id.
+function toHierarchicalPath(entry) {
+  let output = entry.id;
+  let current = entry;
+  while (current && current.properties && current.properties.parent) {
+    const parent = current.properties.parent;
+    const parentId = typeof parent === 'string' ? parent : (parent.id ?? parent?.properties?.id);
+    if (!parentId) break;
+    output = `${parentId}`.concat('/', `${output}`);
+    current = typeof parent === 'string' ? null : parent;
+  }
+  return output;
+}
+
 /**
  `nuxeo-search-form`
  @group Nuxeo UI
@@ -587,21 +602,6 @@ Polymer({
     paramMutator: {
       type: Function,
       value() {
-        // Walks the parent chain of a vocabulary entry and reconstructs the full hierarchical path string.
-        // Handles properties.parent as a string id, an object with .id, or an object with .properties.id.
-        function toHierarchicalPath(entry) {
-          let output = entry.id;
-          let current = entry;
-          while (current && current.properties && current.properties.parent) {
-            const parent = current.properties.parent;
-            const parentId = typeof parent === 'string' ? parent : (parent.id ?? parent?.properties?.id);
-            if (!parentId) break;
-            output = `${parentId}`.concat('/', `${output}`);
-            current = typeof parent === 'string' ? null : parent;
-          }
-          return output;
-        }
-
         return function (params, modifyPayload = false) {
           const result = {};
           if (params) {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -119,8 +119,37 @@ sonar.sourceEncoding=UTF-8
 #   Coverage >= 90%, Issues == 0, Hotspots reviewed == 100%, Duplications <= 3%
 # Note: sonar.qualitygate.wait is set via workflow args to ensure it applies in all scan modes.
 
+# Suppress javascript:S3776 ("Cognitive Complexity of functions should not be too high") on the
+# two spreadsheet modules that are coupled to a third-party library at import time. See WEBUI-2250
+# for the decision this implements. Between them these two paths account for four of the project's
+# S3776 findings: editors/directory.js (35) and spreadsheet.js (38, 21, 19).
+#
+# These are the same paths already listed in sonar.coverage.exclusions above, and for the same
+# structural reason: nuxeo-spreadsheet/app/ui/editors/ extend Select2Editor and ui/spreadsheet.js
+# owns the jQuery/Handsontable container. Neither can be instantiated under the unit-test harness
+# without first standing up the vendor globals, so a refactor there cannot be backed by a test
+# proving it behaviour-preserving — and Sonar's estimate for the heaviest function is 28min,
+# against a constructor whose correctness gates the widget type of every spreadsheet column.
+#
+# Restructuring untestable code to lower a metric trades real regression risk for no functional
+# gain, so the complexity is recorded and accepted here rather than refactored. The findings in
+# code that unit tests *do* cover were refactored instead, in this same change — and one of them was
+# masking a real defect (an absent grid line interpolated into a `grid-column` shorthand).
+#
+# Scoped to these two paths and to S3776 alone, deliberately narrower than raising the threshold
+# in the shared quality profile, which would lower the bar for new complexity everywhere. The cost
+# accepted here is that new complexity inside these two paths will not be flagged either.
+#
+# Numbering starts at e2: e1 is reserved for the css:S4667 entry in the in-review WEBUI-2247
+# branch, so the two changes merge without renumbering whichever lands second.
+sonar.issue.ignore.multicriteria=e2,e3
+sonar.issue.ignore.multicriteria.e2.ruleKey=javascript:S3776
+sonar.issue.ignore.multicriteria.e2.resourceKey=addons/nuxeo-spreadsheet/app/ui/editors/**
+sonar.issue.ignore.multicriteria.e3.ruleKey=javascript:S3776
+sonar.issue.ignore.multicriteria.e3.resourceKey=addons/nuxeo-spreadsheet/app/ui/spreadsheet.js
+
 # Suppress all issues in CI workflow files — npm install with preinstall scripts is intentional.
 # TODO: Remove once sub-packages have package-lock.json and npm ci can be used safely.
-# sonar.issue.ignore.multicriteria=e1
-# sonar.issue.ignore.multicriteria.e1.ruleKey=*
-# sonar.issue.ignore.multicriteria.e1.resourceKey=.github/workflows/**
+# When re-enabling, add e4 to the sonar.issue.ignore.multicriteria list above (comma-separated).
+# sonar.issue.ignore.multicriteria.e4.ruleKey=*
+# sonar.issue.ignore.multicriteria.e4.resourceKey=.github/workflows/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -143,53 +143,56 @@ sonar.sourceEncoding=UTF-8
 #
 # Numbering starts at e2: e1 is reserved for the css:S4667 entry in the in-review WEBUI-2247
 # branch, so the two changes merge without renumbering whichever lands second.
-sonar.issue.ignore.multicriteria=e2,e3,e4,e5,e6,e7,e8,e9
+sonar.issue.ignore.multicriteria=e2,e3,e4,e5,e6,e7,e8
 sonar.issue.ignore.multicriteria.e2.ruleKey=javascript:S3776
 sonar.issue.ignore.multicriteria.e2.resourceKey=addons/nuxeo-spreadsheet/app/ui/editors/**
 sonar.issue.ignore.multicriteria.e3.ruleKey=javascript:S3776
 sonar.issue.ignore.multicriteria.e3.resourceKey=addons/nuxeo-spreadsheet/app/ui/spreadsheet.js
 
-# e4-e9 below close the readability findings that cannot be fixed without changing behaviour.
-# Every other finding in WEBUI-2250's scope was fixed in code; these twelve are the residue, and
-# each group is suppressed for a specific structural reason rather than because it was expensive.
+# e4-e8 below close the readability findings that cannot be fixed without changing behaviour.
+#
+# WEBUI-2250's 43 findings are disposed of three ways, and this file is the audit trail for two of
+# them. 18 were fixed in code (in this change). 14 are suppressed here: the 4 S3776 above plus the
+# 10 covered by e4-e8. The remaining 11 S3776 are left open on purpose — see the note after e8.
+# Each group below is suppressed for a specific structural reason, not because it was expensive.
 #
 # e4 - javascript:S2004, two functions nested more than five levels deep in the AWS SDK upload
 # lifecycle. Flattening them means restructuring the multipart-upload callback chain, which cannot
 # be exercised under the unit-test harness (the addon index.js barrels are coverage-excluded), so
 # there is no way to prove a refactor behaviour-preserving.
 #
-# e5, e6 - javascript:S7740, `self = this` aliases that are load-bearing rather than stylistic.
-# In nuxeo-document-import._processFilesWithMetadata the alias is captured by a non-arrow IIFE that
-# drives the batched import promises, so removing it means converting the IIFE and re-reasoning
-# about `this` binding across the batch. The lib/ aliases sit in code that patches the Handsontable
-# prototype at import time. The third-party alias in nuxeo-grid was stylistic and was removed.
+# e5 - javascript:S7740, the one `self = this` alias that is load-bearing rather than stylistic. In
+# nuxeo-document-import._processFilesWithMetadata it is captured by a non-arrow IIFE that drives the
+# batched import promises, so removing it means converting the IIFE and re-reasoning about `this`
+# binding across the batch. The three stylistic aliases were removed instead of suppressed: one in
+# nuxeo-grid, and two in spreadsheet lib/select2-editor.js whose only readers were arrow functions
+# (which already inherit the same lexical `this`) or the very next line in the same scope.
 #
-# e7 - javascript:S1788, `execute(method = 'get', path, params = {})`. Satisfying the rule requires
+# e6 - javascript:S1788, `execute(method = 'get', path, params = {})`. Satisfying the rule requires
 # reordering positional parameters, which is a breaking signature change for every caller. The
 # defaulted-parameter-first shape is deliberate here.
 #
-# e8 - javascript:S1121, lazy-init getters of the form `return (x._labels = x._labels || {})` over
+# e7 - javascript:S1121, lazy-init getters of the form `return (x._labels = x._labels || {})` over
 # Handsontable's getCellMeta. Splitting the assignment changes how many times that external getter
 # is invoked, and its side effects are the vendor's, not ours. Also covers app/utils.js, which no
 # test imports - it appears nowhere in lcov.info, so edited lines there would land at 0% coverage
 # and fail the 90% new-code gate.
 #
-# e9 - javascript:S4624, a nested template literal in the same uninstrumented app/utils.js, out of
+# e8 - javascript:S4624, a nested template literal in the same uninstrumented app/utils.js, out of
 # scope for the same coverage reason. The three nested literals in elements/routing.js were fixed.
 sonar.issue.ignore.multicriteria.e4.ruleKey=javascript:S2004
 sonar.issue.ignore.multicriteria.e4.resourceKey=addons/amazon-s3-online-storage/index.js
 sonar.issue.ignore.multicriteria.e5.ruleKey=javascript:S7740
-sonar.issue.ignore.multicriteria.e5.resourceKey=addons/nuxeo-spreadsheet/app/lib/**
-sonar.issue.ignore.multicriteria.e6.ruleKey=javascript:S7740
-sonar.issue.ignore.multicriteria.e6.resourceKey=elements/document/nuxeo-document-import.js
-sonar.issue.ignore.multicriteria.e7.ruleKey=javascript:S1788
-sonar.issue.ignore.multicriteria.e7.resourceKey=addons/nuxeo-spreadsheet/app/nuxeo/rest/request.js
-sonar.issue.ignore.multicriteria.e8.ruleKey=javascript:S1121
-sonar.issue.ignore.multicriteria.e8.resourceKey=addons/nuxeo-spreadsheet/app/**
-sonar.issue.ignore.multicriteria.e9.ruleKey=javascript:S4624
-sonar.issue.ignore.multicriteria.e9.resourceKey=addons/nuxeo-spreadsheet/app/utils.js
+sonar.issue.ignore.multicriteria.e5.resourceKey=elements/document/nuxeo-document-import.js
+sonar.issue.ignore.multicriteria.e6.ruleKey=javascript:S1788
+sonar.issue.ignore.multicriteria.e6.resourceKey=addons/nuxeo-spreadsheet/app/nuxeo/rest/request.js
+sonar.issue.ignore.multicriteria.e7.ruleKey=javascript:S1121
+sonar.issue.ignore.multicriteria.e7.resourceKey=addons/nuxeo-spreadsheet/app/**
+sonar.issue.ignore.multicriteria.e8.ruleKey=javascript:S4624
+sonar.issue.ignore.multicriteria.e8.resourceKey=addons/nuxeo-spreadsheet/app/utils.js
 
-# The eleven remaining javascript:S3776 findings are deliberately left OPEN, not suppressed:
+# The eleven remaining javascript:S3776 findings — the third disposition — are deliberately left
+# OPEN, neither fixed nor suppressed:
 # nuxeo-app.js (x2), nuxeo-diff-behavior.js (x2), nuxeo-edit-documents-button.js (x2), nuxeo-diff.js,
 # nuxeo-document-tree.js, nuxeo-sardine.js, nuxeo-document-import.js and nuxeo-render-template-button.js.
 # Suppressing them would stop flagging genuinely new complexity in the application shell and the two
@@ -198,6 +201,6 @@ sonar.issue.ignore.multicriteria.e9.resourceKey=addons/nuxeo-spreadsheet/app/uti
 
 # Suppress all issues in CI workflow files — npm install with preinstall scripts is intentional.
 # TODO: Remove once sub-packages have package-lock.json and npm ci can be used safely.
-# When re-enabling, add e10 to the sonar.issue.ignore.multicriteria list above (comma-separated).
-# sonar.issue.ignore.multicriteria.e10.ruleKey=*
-# sonar.issue.ignore.multicriteria.e10.resourceKey=.github/workflows/**
+# When re-enabling, add e9 to the sonar.issue.ignore.multicriteria list above (comma-separated).
+# sonar.issue.ignore.multicriteria.e9.ruleKey=*
+# sonar.issue.ignore.multicriteria.e9.resourceKey=.github/workflows/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -121,10 +121,12 @@ sonar.sourceEncoding=UTF-8
 
 # Suppress javascript:S3776 ("Cognitive Complexity of functions should not be too high") on the
 # two spreadsheet modules that are coupled to a third-party library at import time. See WEBUI-2250
-# for the decision this implements. Between them these two paths account for four of the project's
-# S3776 findings: editors/directory.js (35) and spreadsheet.js (38, 21, 19).
+# for the decision this implements. Between them these two files account for four of the project's
+# S3776 findings: ui/editors/directory.js (35) and ui/spreadsheet.js (38, 21, 19). Each criterion
+# names the one file that carries the findings rather than a directory glob, so a new S3776 in a
+# sibling editor such as editors/document.js or editors/user.js is still reported.
 #
-# These are the same paths already listed in sonar.coverage.exclusions above, and for the same
+# Both files already fall under sonar.coverage.exclusions above, and for the same
 # structural reason: nuxeo-spreadsheet/app/ui/editors/ extend Select2Editor and ui/spreadsheet.js
 # owns the jQuery/Handsontable container. Neither can be instantiated under the unit-test harness
 # without first standing up the vendor globals, so a refactor there cannot be backed by a test
@@ -133,27 +135,29 @@ sonar.sourceEncoding=UTF-8
 #
 # Restructuring untestable code to lower a metric trades real regression risk for no functional
 # gain, so the complexity is recorded and accepted here rather than refactored. The findings in
-# code that unit tests *do* cover were refactored instead, in this same change — and one of them was
-# masking a real defect (an absent grid line interpolated into a `grid-column` shorthand).
+# code that unit tests *do* cover were refactored instead, in this same change. One of those
+# refactors surfaced a real defect — an absent grid line interpolated into a `grid-column`
+# shorthand — which is deliberately left uncorrected here and tracked in WEBUI-2289, so this change
+# carries no behavioural impact of its own.
 #
-# Scoped to these two paths, deliberately narrower than raising the threshold in the shared quality
+# Scoped to these two files, deliberately narrower than raising the threshold in the shared quality
 # profile, which would lower the bar for new complexity everywhere. The cost accepted here is that
-# new complexity inside these two paths will not be flagged either. Every suppression in this file
-# names one rule and one path; none disables a rule repository-wide.
+# new complexity inside these two files will not be flagged either. Every suppression in this file
+# names one rule and one file; none uses a directory glob and none disables a rule repository-wide.
 #
 # Numbering starts at e2: e1 is reserved for the css:S4667 entry in the in-review WEBUI-2247
 # branch, so the two changes merge without renumbering whichever lands second.
-sonar.issue.ignore.multicriteria=e2,e3,e4,e5,e6,e7,e8
+sonar.issue.ignore.multicriteria=e2,e3,e4,e5,e6,e7,e8,e9,e10,e11
 sonar.issue.ignore.multicriteria.e2.ruleKey=javascript:S3776
-sonar.issue.ignore.multicriteria.e2.resourceKey=addons/nuxeo-spreadsheet/app/ui/editors/**
+sonar.issue.ignore.multicriteria.e2.resourceKey=addons/nuxeo-spreadsheet/app/ui/editors/directory.js
 sonar.issue.ignore.multicriteria.e3.ruleKey=javascript:S3776
 sonar.issue.ignore.multicriteria.e3.resourceKey=addons/nuxeo-spreadsheet/app/ui/spreadsheet.js
 
-# e4-e8 below close the readability findings that cannot be fixed without changing behaviour.
+# e4-e11 below close the readability findings that cannot be fixed without changing behaviour.
 #
 # WEBUI-2250's 43 findings are disposed of three ways, and this file is the audit trail for two of
 # them. 18 were fixed in code (in this change). 14 are suppressed here: the 4 S3776 above plus the
-# 10 covered by e4-e8. The remaining 11 S3776 are left open on purpose — see the note after e8.
+# 10 covered by e4-e11. The remaining 11 S3776 are left open on purpose — see the note after e11.
 # Each group below is suppressed for a specific structural reason, not because it was expensive.
 #
 # e4 - javascript:S2004, two functions nested more than five levels deep in the AWS SDK upload
@@ -172,14 +176,19 @@ sonar.issue.ignore.multicriteria.e3.resourceKey=addons/nuxeo-spreadsheet/app/ui/
 # reordering positional parameters, which is a breaking signature change for every caller. The
 # defaulted-parameter-first shape is deliberate here.
 #
-# e7 - javascript:S1121, lazy-init getters of the form `return (x._labels = x._labels || {})` over
-# Handsontable's getCellMeta. Splitting the assignment changes how many times that external getter
-# is invoked, and its side effects are the vendor's, not ours. Also covers app/utils.js, which no
-# test imports - it appears nowhere in lcov.info, so edited lines there would land at 0% coverage
-# and fail the 90% new-code gate.
+# e7, e8, e9 - javascript:S1121, lazy-init getters of the form `return (x._labels = x._labels || {})`
+# over Handsontable's getCellMeta, in editors/document.js (121), editors/user.js (176) and
+# editors/directory.js (210). Splitting the assignment changes how many times that external getter
+# is invoked, and its side effects are the vendor's, not ours. One entry per file rather than an
+# editors/** glob, so the same pattern appearing in a new editor is still reported.
 #
-# e8 - javascript:S4624, a nested template literal in the same uninstrumented app/utils.js, out of
-# scope for the same coverage reason. The three nested literals in elements/routing.js were fixed.
+# e10 - javascript:S1121 twice more (57, 70) in app/utils.js, which no test imports - it appears
+# nowhere in lcov.info, so edited lines there would land at 0% coverage and fail the 90% new-code
+# gate.
+#
+# e11 - javascript:S4624, a nested template literal (42) in the same uninstrumented app/utils.js,
+# out of scope for the same coverage reason. The three nested literals in elements/routing.js were
+# fixed.
 sonar.issue.ignore.multicriteria.e4.ruleKey=javascript:S2004
 sonar.issue.ignore.multicriteria.e4.resourceKey=addons/amazon-s3-online-storage/index.js
 sonar.issue.ignore.multicriteria.e5.ruleKey=javascript:S7740
@@ -187,9 +196,15 @@ sonar.issue.ignore.multicriteria.e5.resourceKey=elements/document/nuxeo-document
 sonar.issue.ignore.multicriteria.e6.ruleKey=javascript:S1788
 sonar.issue.ignore.multicriteria.e6.resourceKey=addons/nuxeo-spreadsheet/app/nuxeo/rest/request.js
 sonar.issue.ignore.multicriteria.e7.ruleKey=javascript:S1121
-sonar.issue.ignore.multicriteria.e7.resourceKey=addons/nuxeo-spreadsheet/app/**
-sonar.issue.ignore.multicriteria.e8.ruleKey=javascript:S4624
-sonar.issue.ignore.multicriteria.e8.resourceKey=addons/nuxeo-spreadsheet/app/utils.js
+sonar.issue.ignore.multicriteria.e7.resourceKey=addons/nuxeo-spreadsheet/app/ui/editors/document.js
+sonar.issue.ignore.multicriteria.e8.ruleKey=javascript:S1121
+sonar.issue.ignore.multicriteria.e8.resourceKey=addons/nuxeo-spreadsheet/app/ui/editors/user.js
+sonar.issue.ignore.multicriteria.e9.ruleKey=javascript:S1121
+sonar.issue.ignore.multicriteria.e9.resourceKey=addons/nuxeo-spreadsheet/app/ui/editors/directory.js
+sonar.issue.ignore.multicriteria.e10.ruleKey=javascript:S1121
+sonar.issue.ignore.multicriteria.e10.resourceKey=addons/nuxeo-spreadsheet/app/utils.js
+sonar.issue.ignore.multicriteria.e11.ruleKey=javascript:S4624
+sonar.issue.ignore.multicriteria.e11.resourceKey=addons/nuxeo-spreadsheet/app/utils.js
 
 # The eleven remaining javascript:S3776 findings — the third disposition — are deliberately left
 # OPEN, neither fixed nor suppressed:
@@ -201,6 +216,6 @@ sonar.issue.ignore.multicriteria.e8.resourceKey=addons/nuxeo-spreadsheet/app/uti
 
 # Suppress all issues in CI workflow files — npm install with preinstall scripts is intentional.
 # TODO: Remove once sub-packages have package-lock.json and npm ci can be used safely.
-# When re-enabling, add e9 to the sonar.issue.ignore.multicriteria list above (comma-separated).
-# sonar.issue.ignore.multicriteria.e9.ruleKey=*
-# sonar.issue.ignore.multicriteria.e9.resourceKey=.github/workflows/**
+# When re-enabling, add e12 to the sonar.issue.ignore.multicriteria list above (comma-separated).
+# sonar.issue.ignore.multicriteria.e12.ruleKey=*
+# sonar.issue.ignore.multicriteria.e12.resourceKey=.github/workflows/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -136,20 +136,68 @@ sonar.sourceEncoding=UTF-8
 # code that unit tests *do* cover were refactored instead, in this same change — and one of them was
 # masking a real defect (an absent grid line interpolated into a `grid-column` shorthand).
 #
-# Scoped to these two paths and to S3776 alone, deliberately narrower than raising the threshold
-# in the shared quality profile, which would lower the bar for new complexity everywhere. The cost
-# accepted here is that new complexity inside these two paths will not be flagged either.
+# Scoped to these two paths, deliberately narrower than raising the threshold in the shared quality
+# profile, which would lower the bar for new complexity everywhere. The cost accepted here is that
+# new complexity inside these two paths will not be flagged either. Every suppression in this file
+# names one rule and one path; none disables a rule repository-wide.
 #
 # Numbering starts at e2: e1 is reserved for the css:S4667 entry in the in-review WEBUI-2247
 # branch, so the two changes merge without renumbering whichever lands second.
-sonar.issue.ignore.multicriteria=e2,e3
+sonar.issue.ignore.multicriteria=e2,e3,e4,e5,e6,e7,e8,e9
 sonar.issue.ignore.multicriteria.e2.ruleKey=javascript:S3776
 sonar.issue.ignore.multicriteria.e2.resourceKey=addons/nuxeo-spreadsheet/app/ui/editors/**
 sonar.issue.ignore.multicriteria.e3.ruleKey=javascript:S3776
 sonar.issue.ignore.multicriteria.e3.resourceKey=addons/nuxeo-spreadsheet/app/ui/spreadsheet.js
 
+# e4-e9 below close the readability findings that cannot be fixed without changing behaviour.
+# Every other finding in WEBUI-2250's scope was fixed in code; these twelve are the residue, and
+# each group is suppressed for a specific structural reason rather than because it was expensive.
+#
+# e4 - javascript:S2004, two functions nested more than five levels deep in the AWS SDK upload
+# lifecycle. Flattening them means restructuring the multipart-upload callback chain, which cannot
+# be exercised under the unit-test harness (the addon index.js barrels are coverage-excluded), so
+# there is no way to prove a refactor behaviour-preserving.
+#
+# e5, e6 - javascript:S7740, `self = this` aliases that are load-bearing rather than stylistic.
+# In nuxeo-document-import._processFilesWithMetadata the alias is captured by a non-arrow IIFE that
+# drives the batched import promises, so removing it means converting the IIFE and re-reasoning
+# about `this` binding across the batch. The lib/ aliases sit in code that patches the Handsontable
+# prototype at import time. The third-party alias in nuxeo-grid was stylistic and was removed.
+#
+# e7 - javascript:S1788, `execute(method = 'get', path, params = {})`. Satisfying the rule requires
+# reordering positional parameters, which is a breaking signature change for every caller. The
+# defaulted-parameter-first shape is deliberate here.
+#
+# e8 - javascript:S1121, lazy-init getters of the form `return (x._labels = x._labels || {})` over
+# Handsontable's getCellMeta. Splitting the assignment changes how many times that external getter
+# is invoked, and its side effects are the vendor's, not ours. Also covers app/utils.js, which no
+# test imports - it appears nowhere in lcov.info, so edited lines there would land at 0% coverage
+# and fail the 90% new-code gate.
+#
+# e9 - javascript:S4624, a nested template literal in the same uninstrumented app/utils.js, out of
+# scope for the same coverage reason. The three nested literals in elements/routing.js were fixed.
+sonar.issue.ignore.multicriteria.e4.ruleKey=javascript:S2004
+sonar.issue.ignore.multicriteria.e4.resourceKey=addons/amazon-s3-online-storage/index.js
+sonar.issue.ignore.multicriteria.e5.ruleKey=javascript:S7740
+sonar.issue.ignore.multicriteria.e5.resourceKey=addons/nuxeo-spreadsheet/app/lib/**
+sonar.issue.ignore.multicriteria.e6.ruleKey=javascript:S7740
+sonar.issue.ignore.multicriteria.e6.resourceKey=elements/document/nuxeo-document-import.js
+sonar.issue.ignore.multicriteria.e7.ruleKey=javascript:S1788
+sonar.issue.ignore.multicriteria.e7.resourceKey=addons/nuxeo-spreadsheet/app/nuxeo/rest/request.js
+sonar.issue.ignore.multicriteria.e8.ruleKey=javascript:S1121
+sonar.issue.ignore.multicriteria.e8.resourceKey=addons/nuxeo-spreadsheet/app/**
+sonar.issue.ignore.multicriteria.e9.ruleKey=javascript:S4624
+sonar.issue.ignore.multicriteria.e9.resourceKey=addons/nuxeo-spreadsheet/app/utils.js
+
+# The eleven remaining javascript:S3776 findings are deliberately left OPEN, not suppressed:
+# nuxeo-app.js (x2), nuxeo-diff-behavior.js (x2), nuxeo-edit-documents-button.js (x2), nuxeo-diff.js,
+# nuxeo-document-tree.js, nuxeo-sardine.js, nuxeo-document-import.js and nuxeo-render-template-button.js.
+# Suppressing them would stop flagging genuinely new complexity in the application shell and the two
+# most intricate elements in the codebase. Per WEBUI-2250 they ride along with WEBUI-2248/WEBUI-2251,
+# whichever next touches those files.
+
 # Suppress all issues in CI workflow files — npm install with preinstall scripts is intentional.
 # TODO: Remove once sub-packages have package-lock.json and npm ci can be used safely.
-# When re-enabling, add e4 to the sonar.issue.ignore.multicriteria list above (comma-separated).
-# sonar.issue.ignore.multicriteria.e4.ruleKey=*
-# sonar.issue.ignore.multicriteria.e4.resourceKey=.github/workflows/**
+# When re-enabling, add e10 to the sonar.issue.ignore.multicriteria list above (comma-separated).
+# sonar.issue.ignore.multicriteria.e10.ruleKey=*
+# sonar.issue.ignore.multicriteria.e10.resourceKey=.github/workflows/**

--- a/test/nuxeo-grid.test.js
+++ b/test/nuxeo-grid.test.js
@@ -191,6 +191,26 @@ suite('nuxeo-grid', () => {
       expectNoValidationWarning();
     });
 
+    test('Should place a span without a start line instead of emitting an invalid value', async () => {
+      grid.columns = 0;
+      grid.rows = 0;
+      grid.gap = '16px';
+
+      const [top, main] = grid.querySelectorAll('*');
+      top.setAttribute('data-column-span', '3');
+      main.setAttribute('data-row-span', '2');
+
+      await flush();
+      const style = getStyle(grid);
+      // A span with no explicit start line is valid CSS on its own — the grid auto-places the
+      // item and stretches it across `span n` tracks. Previously the absent line was interpolated
+      // into the shorthand, producing `grid-column: undefinedspan 3;`, which browsers discard.
+      expect(style).to.include('grid-column: span 3;');
+      expect(style).to.include('grid-row: span 2;');
+      expect(style).to.not.include('undefined');
+      expectNoValidationWarning();
+    });
+
     test('Should generate proper style when align and justify properties are set', async () => {
       grid.columns = 0;
       grid.rows = 0;

--- a/test/nuxeo-grid.test.js
+++ b/test/nuxeo-grid.test.js
@@ -191,26 +191,6 @@ suite('nuxeo-grid', () => {
       expectNoValidationWarning();
     });
 
-    test('Should place a span without a start line instead of emitting an invalid value', async () => {
-      grid.columns = 0;
-      grid.rows = 0;
-      grid.gap = '16px';
-
-      const [top, main] = grid.querySelectorAll('*');
-      top.setAttribute('data-column-span', '3');
-      main.setAttribute('data-row-span', '2');
-
-      await flush();
-      const style = getStyle(grid);
-      // A span with no explicit start line is valid CSS on its own — the grid auto-places the
-      // item and stretches it across `span n` tracks. Previously the absent line was interpolated
-      // into the shorthand, producing `grid-column: undefinedspan 3;`, which browsers discard.
-      expect(style).to.include('grid-column: span 3;');
-      expect(style).to.include('grid-row: span 2;');
-      expect(style).to.not.include('undefined');
-      expectNoValidationWarning();
-    });
-
     test('Should generate proper style when align and justify properties are set', async () => {
       grid.columns = 0;
       grid.rows = 0;


### PR DESCRIPTION
## Problem

SonarCloud reports 43 complexity and readability findings across `lts-2025` and `maintenance-3.1.x`. WEBUI-2250 asked for a decision on them — fix, Won't Fix, or raise the profile threshold — rather than a blanket refactor, because mechanically restructuring code to satisfy a metric is a good way to introduce regressions for no user-visible benefit.

This PR implements that decision across the ticket's full scope. **All 43 findings are accounted for: 18 fixed in code, 14 closed by scoped configuration, 11 deliberately left open.**

## Disposition of all 43

| Rule | Total | Fixed | Suppressed | Left open |
| --- | --- | --- | --- | --- |
| `S3776` cognitive complexity | 17 | 2 | 4 | **11** |
| `S3358` nested ternary | 6 | 6 | – | – |
| `S4624` nested template literal | 5 | 4 | 1 | – |
| `S1121` assignment in sub-expression | 5 | – | 5 | – |
| `S7740` `self = this` | 4 | 3 | 1 | – |
| `S7721` function scope | 2 | 2 | – | – |
| `S2004` deep function nesting | 2 | – | 2 | – |
| `S1126` boolean if-then-else | 1 | 1 | – | – |
| `S1788` default parameter order | 1 | – | 1 | – |

Every site was verified against the SonarCloud API for `lts-2025` before being acted on, and every candidate fix was additionally checked against `coverage/lcov.info` to confirm the lines it touches are actually exercised, or that the file is coverage-excluded so the gate cannot be moved.

One extra finding outside the 43 was fixed in passing: `S7741` in `routing.js`, a `typeof id === 'undefined'` open since 2019 that sat on a line this change already moves.

## Behavioural impact

This is a Sonar cleanup, not a client requirement, so nothing here changes at runtime. **Every change is behaviour-preserving. There are no exceptions, and no test assertions were added, removed or modified.** Where equivalence is not obvious from reading the diff, it is backed by an exhaustive input comparison — see the test plan.

### Fixed in code — 18 findings

| File | Findings | Change and why it's inert |
| --- | --- | --- |
| `nuxeo-grid.js` | `S3776`, `S3358` ×4, `S4624`, `S1126`, `S7740` | Extract `buildDeclaration`/`buildGridLine` from `buidChildStyle`, reproducing the previous output byte-for-byte (see below); collapse the MutationObserver predicate (both operands already booleans); drop the single-use `targetNode = this` alias and observe `this` directly |
| `nuxeo-app.js` | `S3776` (complexity 29) | Extract the per-page title builders from `_updateTitle`. Each returns the array the inline code pushed into; every `switch` branch including `default` assigns it. 300 → 290 |
| `routing.js` | `S4624` ×3 (+`S7741`) | Extract the nested template literals in `browse`, `document` and `tasks` into named locals. Pure string concatenation, same expressions in the same order |
| `nuxeo-diff.js` | `S3358` | Hoist the schema prefix out of the filter predicate, using `schema.prefix \|\| schema.name` so the hoisted expression is not itself a nested ternary. Equivalent whenever `prefix` is falsy. 75 → 73 |
| `nuxeo-diff-behavior.js` | `S3358` | `_isSimple` early return. The inner array unwrap is still only evaluated when `delta` is falsy |
| `nuxeo-search-form.js` | `S7721` | Move `toHierarchicalPath` to module scope — it reads nothing but its own argument |
| `nuxeo-analytics.js` | `S7721` | Move `updateFocus` to module scope — it only touches the item passed to it |
| `lib/select2-editor.js` | `S7740` ×2 | Remove two redundant `this` aliases. `createElements`' `that` is read only inside arrow callbacks, which already inherit the same lexical `this`; `onBeforeKeyDown`'s `instance` is read only on the next line in the same scope |

### A latent defect we found and deliberately did **not** fix

`buidChildStyle` builds the `grid-column` / `grid-row` shorthands by interpolating the start line and the span into a single template literal. When a child has a span but no explicit start line — `data-column-span` without `data-column` — the absent line is interpolated as the string `undefined`:

```css
grid-column: undefinedspan 3;   /* also `0span 3` when the line is the number zero */
```

That declaration is invalid, so browsers discard it and the span is silently ignored. A bare `span 3` would be valid CSS and is what the element should emit.

An earlier revision of this PR corrected it while extracting the helper. **That correction has been backed out.** This ticket is explicitly a no-behaviour-change cleanup, and a rendering fix — however small — deserves its own ticket and its own QA cycle rather than riding along inside a maintainability sweep. `buildGridLine` therefore interpolates the line unconditionally and reproduces the malformed output exactly, with a comment on the function recording why.

The defect is now tracked as **WEBUI-2289**, with the reproduction, the empirical evidence and the proposed fix, linked to this ticket.

`buildGridStyle` is likewise untouched: it carries no Sonar findings, so rewriting it would be churn in a change meant to minimise behavioural risk.

### Closed by configuration — 14 findings, `e2`–`e8`

Each entry names one rule and one path; none disables a rule repository-wide. Reasons are recorded inline in `sonar-project.properties`.

* **`S3776` ×4** (`e2`, `e3`) — `nuxeo-spreadsheet/app/ui/editors/**` extends `Select2Editor` and `ui/spreadsheet.js` owns the jQuery/Handsontable container. Both are already coverage-excluded for that reason, so a refactor cannot be backed by a test proving it behaviour-preserving. Covers `editors/directory.js` (35) and `spreadsheet.js` (38, 21, 19).
* **`S2004` ×2** (`e4`) — the AWS SDK multipart-upload callback chain in `amazon-s3-online-storage/index.js`. Flattening it means restructuring the upload lifecycle, which the unit-test harness cannot exercise.
* **`S7740` ×1** (`e5`) — the one alias that is load-bearing rather than stylistic: `nuxeo-document-import._processFilesWithMetadata`'s `self` is captured by a non-arrow IIFE driving the batched import promises. The three stylistic aliases were removed instead.
* **`S1788` ×1** (`e6`) — `execute(method = 'get', path, params = {})`. The rule can only be cleared by reordering positional parameters, which breaks every caller.
* **`S1121` ×5 and `S4624` ×1** (`e7`, `e8`) — lazy-init getters of the form `return (x._labels = x._labels || {})` over Handsontable's `getCellMeta`, where splitting the assignment changes how often that external getter runs. Also covers `app/utils.js`, which **no test imports** — it appears nowhere in `lcov.info`, so edited lines there would land at 0% and fail the 90% new-code gate.

### Deliberately left open — 11 findings

The `S3776` complexity findings in `nuxeo-app.js` (×2), `nuxeo-diff-behavior.js` (×2), `nuxeo-edit-documents-button.js` (×2), `nuxeo-diff.js`, `nuxeo-document-tree.js`, `nuxeo-sardine.js`, `nuxeo-document-import.js` and `nuxeo-render-template-button.js`.

These are genuine restructuring work, not idiom substitution, and suppressing them would stop flagging genuinely new complexity in the application shell and the two most intricate elements in the codebase — a worse trade than carrying the findings. Per the decision on WEBUI-2250 they ride along with WEBUI-2248 / WEBUI-2251, whichever next touches those files.

## Test plan

* `npx eslint` and `npx prettier --list-different` clean on all changed files, on both branches.
* **Exhaustive equivalence check on `nuxeo-grid`.** Both style builders were loaded from the merge-base and from this revision and driven over **20,432 input combinations** — every combination of start line, span, align and justify for `grid-column` and `grid-row`, in both the attribute-backed `Child` shape and the object-literal shape the responsive pass uses, with validation on and off, plus `buildGridStyle` across its own template/track/gap matrix. Result: **0 differences.** The malformed `undefinedspan 3` output is reproduced exactly, confirming the refactor is inert.
* Full unit suite: **2736 passed, 1 failed** — `nuxeo-search-form > gives the saved searches dropdown an always visible label (WEBUI-489)`. This is a pre-existing failure, not caused by this PR: it fails identically on a pristine `origin/lts-2025` checkout with none of these changes present, and the file was also swapped back to its base version independently with the same result. It is an environment-specific selectivity rendering issue.
* **No test file is touched by this PR.** The change set is 8 production files plus `sonar-project.properties`.
* SonarCloud reports **0 open issues** on this PR; new coverage 97.7%, new duplication 0.0%, all ratings A, hotspots 100%.

## Notes

* **No manual verification needed.** Nothing in this PR changes what a user sees. The one candidate for that has been backed out to WEBUI-2289.
* **The suppressions have a real cost:** new issues of those rules inside those paths will not be flagged either. That is much narrower than raising the project-wide threshold, but it is not free and is accepted knowingly.
* **Numbering starts at `e2`.** `e1` is reserved for the `css:S4667` entry on the in-review WEBUI-2247 branch, so whichever lands second merges without renumbering. The commented-out CI-workflow block is renumbered to `e9`.
* **Unrelated but worth someone's attention:** the quality gate does not include an "issues == 0" condition, even though the comment block in `sonar-project.properties` says it does. An earlier revision of this PR went green with two new-code findings present; only `new_coverage`, `new_duplicated_lines_density`, the three ratings and hotspot review are actually enforced.
* An earlier revision also touched `nuxeo-vocabulary-management.js`, `nuxeo-l10nxvocabulary-edit-layout.html` and the four `nuxeo-collection-move-*-action` files on the belief they carried `S1126` findings. They do not — `S1126` occurs exactly once in the project — so those edits were reverted rather than carried as churn.
