### PR TITLE
WEBUI-1119: Drop the trailing separator from the window title when the product name is empty [maintenance-3.1.x]

### DIFF
--- a/elements/nuxeo-app.js
+++ b/elements/nuxeo-app.js
@@ -1433,8 +1433,12 @@ Polymer({
       default:
         title.push(this.i18n(`app.title.${this.page}`));
     }
+    // WEBUI-1119: `org.nuxeo.ecm.product.name` may be configured empty, in which case index.jsp
+    // renders `product-name=""` and that empty attribute overrides the 'Nuxeo' default. Joining a
+    // blank segment left the browser tab title with a dangling " - ", so drop blank segments
+    // instead of appending a separator with nothing after it.
     title.push(this.productName);
-    document.title = title.join(' - ');
+    document.title = title.filter((segment) => segment && String(segment).trim()).join(' - ');
   },
 
   _baseUrlChanged() {

--- a/test/nuxeo-app.test.js
+++ b/test/nuxeo-app.test.js
@@ -1111,6 +1111,40 @@ suite('nuxeo-app', () => {
       expect(document.title).to.include('wf');
       expect(document.title).to.include('step');
     });
+
+    // WEBUI-1119: an empty `org.nuxeo.ecm.product.name` reaches the element as product-name="",
+    // which used to leave the tab title ending with a dangling " - ".
+    test('omits the trailing separator when productName is empty (WEBUI-1119)', () => {
+      app.page = 'home';
+      app.productName = '';
+      app._updateTitle();
+      expect(document.title).to.equal('app.title.home');
+      expect(document.title).to.not.match(/ - $/);
+    });
+
+    test('omits the trailing separator when productName is blank (WEBUI-1119)', () => {
+      app.page = 'home';
+      app.productName = '   ';
+      app._updateTitle();
+      expect(document.title).to.equal('app.title.home');
+    });
+
+    test('still appends productName when it is configured (WEBUI-1119)', () => {
+      app.page = 'home';
+      app.productName = 'Nuxeo';
+      app._updateTitle();
+      expect(document.title).to.equal('app.title.home - Nuxeo');
+    });
+
+    test('joins document and productName without a dangling separator on browse (WEBUI-1119)', () => {
+      sinon.stub(app, 'hasFacet').returns(false);
+      app.page = 'browse';
+      app.currentDocument = { title: 'My Doc', type: 'File' };
+      app.productName = '';
+      app._updateTitle();
+      expect(document.title).to.equal('My Doc');
+      app.hasFacet.restore();
+    });
   });
 
   suite('keyboard shortcuts and wizards', () => {


### PR DESCRIPTION
Backport of #3524 to `maintenance-3.1.x` (same commit, cherry-picked cleanly).

## Problem

When `org.nuxeo.ecm.product.name` is configured with an empty value:

```
org.nuxeo.ecm.product.name=
```

the browser window/tab title ends with a dangling `" - "` (e.g. `Home - `). The hyphen should not be appended when there is no product name to show.

Reported in [WEBUI-1119](https://hyland.atlassian.net/browse/WEBUI-1119) (depends on SUPNXP-45036).

## Root cause

`index.jsp` renders the product name straight onto the element:

```jsp
<nuxeo-app base-url="<%= baseUrl %>"
  product-name="<%= Framework.getProperty(Environment.PRODUCT_NAME) %>" unresolved>
```

With the property configured empty, that emits `product-name=""`. Because the attribute is *present*, Polymer deserializes it and overrides the `'Nuxeo'` default declared in `elements/nuxeo-app.js`:

```js
productName: {
  type: String,
  value: 'Nuxeo',
},
```

`_updateTitle()` then appended that empty value unconditionally before joining the segments:

```js
title.push(this.productName);
document.title = title.join(' - ');
```

`['app.title.home', ''].join(' - ')` yields `"app.title.home - "` — hence the trailing separator.

## Changes

- `elements/nuxeo-app.js` — `_updateTitle()` now filters blank segments out before joining, so the `' - '` separator is only emitted between parts that actually have content. Titles with a configured product name are byte-for-byte unchanged.
- `test/nuxeo-app.test.js` — four unit tests covering the empty product name, a whitespace-only product name, the unchanged configured-product-name case, and the browse page (document title with no product name).

## Test plan

- `npm run lint` — clean.
- Full unit suite on this branch — **2741 passed, 0 failed** (line coverage 81.22%).
- Manual, on an instance with `nuxeo.conf` containing `org.nuxeo.ecm.product.name=`:
  1. Restart Nuxeo and open `/nuxeo/ui/`.
  2. Land on Home, then browse to a document, a saved search, a task and an admin tab.
  3. Before: every tab title ends with `" - "`. After: no trailing separator; segments still separated by `" - "`.
- With `org.nuxeo.ecm.product.name=Nuxeo` (default), titles are unchanged (`My Doc - Nuxeo`).

## Notes

- Fix applies to the client only; `index.jsp` is left alone so no server-side behaviour changes.
- Companion PR on `lts-2025`: #3524.

[WEBUI-1119]: https://hyland.atlassian.net/browse/WEBUI-1119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ