### PR TITLE
WEBUI-1882: Add the document URL to the List view title so right-click offers the link actions [lts-2025]

### DIFF
--- a/elements/nuxeo-data-list/nuxeo-document-list-item.js
+++ b/elements/nuxeo-data-list/nuxeo-document-list-item.js
@@ -238,13 +238,14 @@ Polymer({
           <img crossorigin="anonymous" src="[[_thumbnail(doc)]]" on-error="_onError" alt$="[[doc.title]]" />
         </div>
         <div class="dataContainer flex" on-tap="handleClick" on-keydown="_handleKeydown">
-          <div class="horizontal layout center" tabindex="0">
+          <div class="horizontal layout center">
             <!-- WEBUI-1882: the title holds the document URL so the browser context menu offers
                  "Open Link in New Tab" and "Open Link in New Window", as it already does in the
-                 grid and table views. It stays out of the tab order because the row around it is
-                 already focusable and activates the item; a second tab stop would only repeat
-                 the same title. -->
-            <a class="title flex" href$="[[_documentUrl(doc, urlFor)]]" tabindex="-1" on-keydown="_onTitleKeydown">
+                 grid and table views. Being a real link, it is also the keyboard stop for the row
+                 content, which is why the div around it no longer carries one: a link announces
+                 itself and its menu can be opened with the context menu key, while a plain
+                 focusable div could do neither. -->
+            <a class="title flex" href$="[[_documentUrl(doc, urlFor)]]" on-keydown="_onTitleKeydown">
               <div class="title">[[doc.title]]</div>
             </a>
             <nuxeo-tag>[[formatDocType(doc.type)]]</nuxeo-tag>
@@ -325,13 +326,15 @@ Polymer({
   // The binding also passes urlFor, which this method does not need: it makes the href recompute
   // once the router is known, since urlFor is only resolved from the element when called.
   _documentUrl(doc) {
-    if (!doc || !doc.uid) {
-      return '';
+    if (!doc?.uid) {
+      return undefined;
     }
     try {
-      return this.urlFor(doc) || '';
+      // Anything falsy has to stay undefined, which is what makes Polymer drop the attribute.
+      // An empty string would be serialized into href="", a link back to the current page.
+      return this.urlFor(doc) || undefined;
     } catch {
-      return '';
+      return undefined;
     }
   },
 
@@ -344,7 +347,7 @@ Polymer({
   handleClick(e) {
     // A tap event carries no modifier keys, they belong to the click it was generated from.
     // Direct callers (keyboard handling, tests) pass the original event instead.
-    const source = (e.detail && e.detail.sourceEvent) || e;
+    const source = e.detail?.sourceEvent || e;
     if (!this.selectionMode && (source.ctrlKey || source.shiftKey || source.metaKey || source.button === 1)) {
       // These are the clicks the browser turns into a new tab or window on the title link, so
       // leave them alone. Elsewhere in the row there is no link to follow.
@@ -391,10 +394,10 @@ Polymer({
     }
   },
 
-  // The title link is not in the tab order, but clicking it leaves focus on it, so Enter can
-  // still reach it. Turn the key into a click, the way the row handler does, and cancel its own
-  // action: otherwise the row handler and the browser following the link both activate the item,
-  // which in selection mode toggles it twice and leaves it unchanged.
+  // Enter on the focused title link. Turn the key into a click, the way the row handler does, and
+  // cancel its own action: otherwise the row handler and the browser following the link both
+  // activate the item, which in selection mode toggles it twice and leaves it unchanged. Only
+  // Enter is taken, so Space still reaches the results view and (de)selects the row.
   _onTitleKeydown(e) {
     if (e.key !== 'Enter') {
       return;

--- a/elements/nuxeo-data-list/nuxeo-document-list-item.js
+++ b/elements/nuxeo-data-list/nuxeo-document-list-item.js
@@ -140,6 +140,14 @@ Polymer({
         display: block;
       }
 
+      /* The title is a link, so drop the browser default link colour and underline and keep the
+         row's own colour. The hover and focus rules above are more specific, so they still
+         recolor the title. */
+      a.title {
+        color: inherit;
+        text-decoration: none;
+      }
+
       .listBox .actions {
         display: none;
         background-color: var(--nuxeo-box);
@@ -231,7 +239,12 @@ Polymer({
         </div>
         <div class="dataContainer flex" on-tap="handleClick" on-keydown="_handleKeydown">
           <div class="horizontal layout center" tabindex="0">
-            <a class="title flex">
+            <!-- WEBUI-1882: the title holds the document URL so the browser context menu offers
+                 "Open Link in New Tab" and "Open Link in New Window", as it already does in the
+                 grid and table views. It stays out of the tab order because the row around it is
+                 already focusable and activates the item; a second tab stop would only repeat
+                 the same title. -->
+            <a class="title flex" href$="[[_documentUrl(doc, urlFor)]]" tabindex="-1" on-keydown="_onTitleKeydown">
               <div class="title">[[doc.title]]</div>
             </a>
             <nuxeo-tag>[[formatDocType(doc.type)]]</nuxeo-tag>
@@ -305,6 +318,23 @@ Polymer({
     return '';
   },
 
+  // Resolves the document URL for the title link. Reverse routing throws for an item that is not
+  // a routable document, and the list can hold such an item while it recycles its rows, so fall
+  // back to no href rather than letting the row fail to render. The link is then inert and the
+  // row still opens the document on click, as it always did.
+  // The binding also passes urlFor, which this method does not need: it makes the href recompute
+  // once the router is known, since urlFor is only resolved from the element when called.
+  _documentUrl(doc) {
+    if (!doc || !doc.uid) {
+      return '';
+    }
+    try {
+      return this.urlFor(doc) || '';
+    } catch {
+      return '';
+    }
+  },
+
   isFollowRedirectEnabled() {
     const followRedirect =
       Nuxeo && Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.url && Nuxeo.UI.config.url.followRedirect;
@@ -312,9 +342,22 @@ Polymer({
   },
 
   handleClick(e) {
+    // A tap event carries no modifier keys, they belong to the click it was generated from.
+    // Direct callers (keyboard handling, tests) pass the original event instead.
+    const source = (e.detail && e.detail.sourceEvent) || e;
+    if (!this.selectionMode && (source.ctrlKey || source.shiftKey || source.metaKey || source.button === 1)) {
+      // These are the clicks the browser turns into a new tab or window on the title link, so
+      // leave them alone. Elsewhere in the row there is no link to follow.
+      return;
+    }
+    // The row handles the click itself, so the title link must not navigate on top of it. Polymer
+    // forwards this preventDefault to the click event the tap was generated from.
+    if (typeof e.preventDefault === 'function') {
+      e.preventDefault();
+    }
     if (this.selectionMode) {
       this._toogleSelect(e);
-    } else if (!(e.ctrlKey || e.shiftKey || e.metaKey || e.button === 1)) {
+    } else {
       this.fire('navigate', { item: this.doc, index: this.index });
     }
   },
@@ -346,6 +389,19 @@ Polymer({
         e.currentTarget.click();
       }
     }
+  },
+
+  // The title link is not in the tab order, but clicking it leaves focus on it, so Enter can
+  // still reach it. Turn the key into a click, the way the row handler does, and cancel its own
+  // action: otherwise the row handler and the browser following the link both activate the item,
+  // which in selection mode toggles it twice and leaves it unchanged.
+  _onTitleKeydown(e) {
+    if (e.key !== 'Enter') {
+      return;
+    }
+    e.stopPropagation();
+    e.preventDefault();
+    e.currentTarget.click();
   },
 
   // ELEMENTS-1616: fall back to a transparent pixel when the (cross-origin) thumbnail

--- a/test/nuxeo-document-list-item.test.js
+++ b/test/nuxeo-document-list-item.test.js
@@ -224,7 +224,7 @@ suite('nuxeo-document-list-item', () => {
 
     const title = () => element.shadowRoot.querySelector('a.title');
     const thumbnail = () => element.shadowRoot.querySelector('.thumbnailContainer');
-    const focusableRow = () => element.shadowRoot.querySelector('.dataContainer [tabindex="0"]');
+    const extraRowTabStop = () => element.shadowRoot.querySelector('.dataContainer [tabindex="0"]');
 
     function click(node, init = {}) {
       node.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true, cancelable: true, ...init }));
@@ -259,16 +259,54 @@ suite('nuxeo-document-list-item', () => {
       expect(title().getAttribute('href')).to.equal('/doc/doc-1');
     });
 
-    test('is left without an href when the item is not a routable document', () => {
+    // An href attribute must be absent rather than empty: href="" is a link back to the current
+    // page, so the browser menu would offer to open the search page instead of the document.
+    test('has no href attribute at all when the item is not a routable document', async () => {
       element.urlFor.throws(new Error('cannot resolve route'));
-      expect(element._documentUrl({ uid: 'no-route' })).to.equal('');
-      expect(element._documentUrl({})).to.equal('');
-      expect(element._documentUrl(undefined)).to.equal('');
+      element.doc = { uid: 'not-routable', title: 'No route', type: 'File' };
+      await flush();
+      expect(title().hasAttribute('href'), 'href should be removed, not empty').to.be.false;
     });
 
-    test('stays out of the tab order, the row around it is already focusable', () => {
-      expect(title().tabIndex).to.equal(-1);
-      expect(focusableRow(), 'the row should still have a tab stop').to.exist;
+    test('resolves no URL for an item that cannot be routed', () => {
+      element.urlFor.throws(new Error('cannot resolve route'));
+      expect(element._documentUrl({ uid: 'no-route' })).to.be.undefined;
+      element.urlFor.returns('');
+      expect(element._documentUrl({ uid: 'empty-url' })).to.be.undefined;
+      expect(element._documentUrl({})).to.be.undefined;
+      expect(element._documentUrl(undefined)).to.be.undefined;
+    });
+
+    test('is the keyboard stop for the row content, so its browser menu is reachable', () => {
+      expect(title().tabIndex, 'the link should be in the tab order').to.equal(0);
+      expect(extraRowTabStop(), 'the div around it should not repeat the stop').to.not.exist;
+    });
+
+    test('takes keyboard focus', () => {
+      title().focus();
+      // Some headless environments ignore focus(), and the assertion only means something once
+      // the link is actually focused.
+      if (element.shadowRoot.activeElement !== title()) {
+        return;
+      }
+      expect(element.shadowRoot.activeElement).to.equal(title());
+    });
+
+    // Space is how the results view (de)selects the focused row, so the link must not take it.
+    test('leaves Space to the results view', () => {
+      const event = new KeyboardEvent('keydown', {
+        key: ' ',
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      });
+      let reachedHost = false;
+      element.addEventListener('keydown', () => {
+        reachedHost = true;
+      });
+      title().dispatchEvent(event);
+      expect(reachedHost, 'Space should still bubble out of the element').to.be.true;
+      expect(event.defaultPrevented, 'Space should not be cancelled here').to.be.false;
     });
 
     test('a right-click opens the browser menu without navigating or selecting', () => {
@@ -361,9 +399,15 @@ suite('nuxeo-document-list-item', () => {
         expect(fired.navigate).to.equal(1);
       });
 
-      test('Enter on the focusable row still navigates once', () => {
+      test('Enter handled by the row itself still navigates once', () => {
         const fired = countEvents();
-        pressEnter(focusableRow());
+        pressEnter(element.shadowRoot.querySelector('.dataContainer'));
+        expect(fired.navigate).to.equal(1);
+      });
+
+      test('Enter on the thumbnail still navigates once', () => {
+        const fired = countEvents();
+        pressEnter(thumbnail());
         expect(fired.navigate).to.equal(1);
       });
 

--- a/test/nuxeo-document-list-item.test.js
+++ b/test/nuxeo-document-list-item.test.js
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { fixture, html, login } from '@nuxeo/testing-helpers';
+import { fixture, flush, html, login } from '@nuxeo/testing-helpers';
 import '../elements/nuxeo-data-list/nuxeo-document-list-item.js';
 
 suite('nuxeo-document-list-item', () => {
@@ -190,6 +190,195 @@ suite('nuxeo-document-list-item', () => {
       element.handleClick({ ctrlKey: false, shiftKey: true, metaKey: false, button: 0 });
       expect(element.fire).to.not.have.been.called;
       element.fire.restore();
+    });
+  });
+
+  // The title used to be an anchor with no href, so the browser offered no link actions when
+  // right-clicking it. It is a real link now, and the row has to keep behaving as before on a
+  // plain click, in selection mode and when activated from the keyboard.
+  //
+  // These tests dispatch real mouse and keyboard events so the Polymer tap gesture and the row
+  // handlers run exactly as they do in the browser. A document level guard records whether the
+  // element had already cancelled the link navigation, then cancels it in any case so the test
+  // page never navigates away.
+  suite('title link', () => {
+    let lastClickPrevented;
+
+    const clickGuard = (e) => {
+      lastClickPrevented = e.defaultPrevented;
+      e.preventDefault();
+    };
+
+    setup(async () => {
+      sinon.stub(element, 'urlFor').returns('/doc/doc-1');
+      element.doc = { uid: 'doc-1', title: 'My Document', type: 'File' };
+      element.index = 1;
+      await flush();
+      lastClickPrevented = undefined;
+      document.addEventListener('click', clickGuard);
+    });
+
+    teardown(() => {
+      document.removeEventListener('click', clickGuard);
+    });
+
+    const title = () => element.shadowRoot.querySelector('a.title');
+    const thumbnail = () => element.shadowRoot.querySelector('.thumbnailContainer');
+    const focusableRow = () => element.shadowRoot.querySelector('.dataContainer [tabindex="0"]');
+
+    function click(node, init = {}) {
+      node.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true, cancelable: true, ...init }));
+    }
+
+    function pressEnter(node) {
+      const event = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      });
+      node.dispatchEvent(event);
+      return event;
+    }
+
+    function countEvents() {
+      const fired = { navigate: 0, selected: 0 };
+      element.addEventListener('navigate', () => fired.navigate++);
+      element.addEventListener('selected', () => fired.selected++);
+      return fired;
+    }
+
+    function enterSelectionMode() {
+      element.selectedItems = [{ uid: 'another-doc' }];
+      element._selectedItemsChanged();
+      expect(element.selectionMode, 'selection mode should be on').to.be.true;
+    }
+
+    test('carries the document URL so the browser can offer its own link actions', () => {
+      expect(title(), 'a.title should be rendered').to.exist;
+      expect(title().getAttribute('href')).to.equal('/doc/doc-1');
+    });
+
+    test('is left without an href when the item is not a routable document', () => {
+      element.urlFor.throws(new Error('cannot resolve route'));
+      expect(element._documentUrl({ uid: 'no-route' })).to.equal('');
+      expect(element._documentUrl({})).to.equal('');
+      expect(element._documentUrl(undefined)).to.equal('');
+    });
+
+    test('stays out of the tab order, the row around it is already focusable', () => {
+      expect(title().tabIndex).to.equal(-1);
+      expect(focusableRow(), 'the row should still have a tab stop').to.exist;
+    });
+
+    test('a right-click opens the browser menu without navigating or selecting', () => {
+      const fired = countEvents();
+      const init = { bubbles: true, composed: true, cancelable: true, button: 2, buttons: 2 };
+      title().dispatchEvent(new MouseEvent('mousedown', init));
+      title().dispatchEvent(new MouseEvent('contextmenu', init));
+      expect(fired.navigate, 'should not navigate').to.equal(0);
+      expect(fired.selected, 'should not change the selection').to.equal(0);
+      expect(element.selected).to.be.false;
+    });
+
+    test('a plain click routes in place and the link does not navigate on top of it', () => {
+      const fired = countEvents();
+      click(title());
+      expect(fired.navigate, 'navigate count').to.equal(1);
+      expect(lastClickPrevented, 'link navigation should be cancelled').to.be.true;
+    });
+
+    test('a plain click on the title text behaves the same', () => {
+      const fired = countEvents();
+      click(element.shadowRoot.querySelector('a.title div.title'));
+      expect(fired.navigate).to.equal(1);
+      expect(lastClickPrevented).to.be.true;
+    });
+
+    [
+      { label: 'Ctrl', init: { ctrlKey: true } },
+      { label: 'Meta', init: { metaKey: true } },
+      { label: 'Shift', init: { shiftKey: true } },
+      { label: 'the middle button', init: { button: 1 } },
+    ].forEach(({ label, init }) => {
+      test(`a click with ${label} is left to the browser, which opens a new tab or window`, () => {
+        const fired = countEvents();
+        click(title(), init);
+        expect(fired.navigate, 'should not navigate in place').to.equal(0);
+        expect(lastClickPrevented, 'the click should be left alone').to.be.false;
+      });
+    });
+
+    test('Enter activates the item once and the link does not navigate on top of it', () => {
+      const fired = countEvents();
+      const event = pressEnter(title());
+      expect(fired.navigate, 'navigate count').to.equal(1);
+      expect(event.defaultPrevented, 'the key should not activate the link').to.be.true;
+      expect(lastClickPrevented, 'link navigation should be cancelled').to.be.true;
+    });
+
+    test('other keys on the link are left alone', () => {
+      const fired = countEvents();
+      title().dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, composed: true }));
+      expect(fired.navigate).to.equal(0);
+    });
+
+    suite('in selection mode', () => {
+      test('a click on the title toggles once and does not follow the link', () => {
+        enterSelectionMode();
+        const fired = countEvents();
+        click(title());
+        expect(fired.selected, 'selected count').to.equal(1);
+        expect(element.selected, 'the item should be selected').to.be.true;
+        expect(fired.navigate, 'should not navigate').to.equal(0);
+        expect(lastClickPrevented, 'link navigation should be cancelled').to.be.true;
+      });
+
+      test('a shift-click on the title still extends the selection', () => {
+        enterSelectionMode();
+        let payload;
+        element.addEventListener('selected', (e) => {
+          payload = e.detail;
+        });
+        click(title(), { shiftKey: true });
+        expect(payload).to.deep.equal({ index: 1, shiftKey: true });
+        expect(lastClickPrevented, 'link navigation should be cancelled').to.be.true;
+      });
+
+      test('Enter on the title toggles once', () => {
+        enterSelectionMode();
+        const fired = countEvents();
+        pressEnter(title());
+        expect(fired.selected).to.equal(1);
+      });
+    });
+
+    // The link sits inside the row, so the rest of the row must keep working as it did.
+    suite('rest of the row', () => {
+      test('a click on the thumbnail still navigates', () => {
+        const fired = countEvents();
+        click(thumbnail());
+        expect(fired.navigate).to.equal(1);
+      });
+
+      test('Enter on the focusable row still navigates once', () => {
+        const fired = countEvents();
+        pressEnter(focusableRow());
+        expect(fired.navigate).to.equal(1);
+      });
+
+      test('a click on the thumbnail in selection mode toggles once', () => {
+        enterSelectionMode();
+        const fired = countEvents();
+        click(thumbnail());
+        expect(fired.selected).to.equal(1);
+      });
+
+      test('the select control still toggles the selection', () => {
+        const fired = countEvents();
+        click(element.shadowRoot.querySelector('.select paper-icon-button'));
+        expect(fired.selected).to.be.greaterThan(0);
+      });
     });
   });
 


### PR DESCRIPTION
## Problem

In the **List view** of the search results, right-clicking an item (over the document title) gives a context menu with no link entries, so there is no way to open the document in a new tab or window from that view. The Grid and Table views do offer them.

JIRA: [WEBUI-1882](https://hyland.atlassian.net/browse/WEBUI-1882)

## Root cause

The title in `nuxeo-document-list-item` was an anchor with no `href`:

```html
<a class="title flex">
  <div class="title">[[doc.title]]</div>
</a>
```

Without an `href` the browser does not treat it as a link, so its context menu has no "Open Link in New Tab" / "Open Link in New Window" entries. The other views already bind the document URL on their title link (`nuxeo-document-grid-thumbnail`, and the `dc:title` column of the search results table).

## Changes

`elements/nuxeo-data-list/nuxeo-document-list-item.js`

- Bind the document URL on the title link, so the browser offers its own link actions. The URL is resolved through a small guarded helper (`_documentUrl`): reverse routing throws for an item that is not a routable document, and the row must still render in that case, so it falls back to `undefined`, which makes Polymer drop the attribute entirely (an empty string would be serialized into `href=""`, a link back to the current page).
- The link is the keyboard stop for the row content: the `tabindex="0"` that was on the div around it has been removed, so the number of stops per row is unchanged, but the stop is now a real link. It announces itself as one, and its context menu can be opened with the context menu key, so opening the document in a new tab works for keyboard users too. Only `Enter` is handled on the link, so `Space` still reaches the results view and (de)selects the row.
- `handleClick` now reads the modifier keys from the tap's source event, because a Polymer `tap` event does not carry them. A plain click still routes in place and now cancels the link's own navigation, so the document is not navigated to twice. `Ctrl`/`Cmd`/`Shift`/middle clicks are left to the browser, which is what opens a new tab or window. In selection mode a click, including a shift-click that extends the selection, still (de)selects the row and never follows the link.
- `_onTitleKeydown` handles `Enter` on the focused link, so the item is activated exactly once instead of being activated by the row handler and the browser both.
- Reset the browser default link colour and underline on the title, so the row looks exactly as before (verified: a bare `<a href>` renders `rgb(0, 0, 238)` and underlined in Chrome).

## Test plan

`npm run lint` and `npm test` are green on both branches (2760 unit tests).

New tests in `test/nuxeo-document-list-item.test.js` dispatch **real** mouse and keyboard events, so the Polymer tap gesture and the `preventDefault` forwarding run as they do in the browser, and assert:

| Interaction | Expected |
| --- | --- |
| Right-click on the title | native menu, no navigation, no selection change |
| Plain click on the title / title text | one `navigate`, link navigation cancelled |
| `Ctrl` / `Cmd` / `Shift` / middle click | left to the browser, no in-place navigation |
| `Enter` on the title | one activation, link not followed |
| `Space` on the title | not taken, still bubbles to the results view |
| Keyboard reachability | link is in the tab order, takes focus, and the div no longer repeats the stop |
| Selection mode: click on the title | selection toggled once, no navigation |
| Selection mode: shift-click on the title | selection still extended (`shiftKey: true`) |
| Rest of the row (thumbnail, row `Enter`, select control) | unchanged |
| Item that is not a routable document | no `href` attribute at all, row still renders |

Manual check in the List view (Default search, Author aggregate): right-click the title and confirm "Open Link in New Tab" / "Open Link in New Window" appear and open the document; plain click still opens it in place; the title colour and hover highlight are unchanged.

## Notes

- One deliberate behaviour change outside the link: a modifier click on the rest of the row (for instance the thumbnail) no longer navigates in place. The modifier guard in `handleClick` always intended to skip navigation for those clicks, but it read the modifiers from the tap event, which never carries them, so it never took effect.
- The Grid view keeps its current behaviour; it already binds the URL and is not part of this ticket.


[WEBUI-1882]: https://hyland.atlassian.net/browse/WEBUI-1882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ