### PR TITLE
WEBUI-2253: Complete an incomplete assertion and make two silent test skips honest [maintenance-3.1.x]

### DIFF
--- a/test/nuxeo-document-tree.test.js
+++ b/test/nuxeo-document-tree.test.js
@@ -341,7 +341,7 @@ suite('nuxeo-document-tree', () => {
       expect(documentTree.parents).to.be.not.empty;
       expect(documentTree.parents).to.have.length(1);
       expect(documentTree.parents[0].uid).to.be.equal(4);
-      isElementVisible(documentTree.shadowRoot.querySelector('.parents'));
+      expect(isElementVisible(documentTree.shadowRoot.querySelector('.parents'))).to.be.true;
     });
 
     test('Tree breadcrumb is present with root document', async () => {
@@ -417,7 +417,7 @@ suite('nuxeo-document-tree', () => {
       expect(documentTree.parents).to.be.not.empty;
       expect(documentTree.parents).to.have.length(1);
       expect(documentTree.parents[0].uid).to.be.equal(4);
-      expect(isElementVisible(documentTree.shadowRoot.querySelector('.parents')));
+      expect(isElementVisible(documentTree.shadowRoot.querySelector('.parents'))).to.be.true;
     });
   });
 

--- a/test/nuxeo-performance.test.js
+++ b/test/nuxeo-performance.test.js
@@ -398,9 +398,9 @@ suite('Performance', () => {
   });
 
   suite('branch coverage: paint and timing fallbacks', () => {
-    test('getFirstPaint returns null when no first-paint entry', () => {
+    test('getFirstPaint returns null when no first-paint entry', function () {
       if (typeof PerformancePaintTiming === 'undefined') {
-        return;
+        this.skip();
       }
       const stub = sinon.stub(performance, 'getEntriesByType').callsFake((type) => {
         if (type === 'paint') {
@@ -468,9 +468,9 @@ suite('Performance', () => {
       }
     });
 
-    test('getFirstContentfulPaint returns null when no fcp entry', () => {
+    test('getFirstContentfulPaint returns null when no fcp entry', function () {
       if (typeof PerformancePaintTiming === 'undefined') {
-        return;
+        this.skip();
       }
       const stub = sinon.stub(performance, 'getEntriesByType').callsFake((type) => {
         if (type === 'paint') {


### PR DESCRIPTION
## Problem

Three SonarCloud maintainability findings, all in test code, all with the same symptom: **a test that reports green without having verified anything.** Jira: [WEBUI-2253](https://hyland.atlassian.net/browse/WEBUI-2253)

| Rule | Severity | File | Line |
| --- | --- | --- | --- |
| `javascript:S2970` | **BLOCKER** | `test/nuxeo-document-tree.test.js` | 420 |
| `javascript:S8968` | HIGH | `test/nuxeo-performance.test.js` | 403 |
| `javascript:S8968` | HIGH | `test/nuxeo-performance.test.js` | 473 |

This is 8 of 9 in the maintainability triage (see WEBUI-2246). It is the smallest ticket in the set but contains the backlog's only maintainability BLOCKER, and it lands first so that [WEBUI-2252](https://hyland.atlassian.net/browse/WEBUI-2252) (the `performance.timing` rewrite) starts from tests that honestly report their own status.

## Root cause

**S2970 — an assertion that can never fail.** `test/nuxeo-document-tree.test.js:420` ended the "Tree should collapse when clicking on a document" test with a chai chain that terminates before it asserts:

```js
expect(isElementVisible(documentTree.shadowRoot.querySelector('.parents')));
```

`expect(value)` with no matcher just constructs an Assertion object and discards it. The line executes and counts toward coverage, but no outcome is ever checked — it is strictly worse than a missing test, because it reads as coverage.

The adjacent "Tree breadcrumb is present" test at `:344` had the **same defect in an even weaker form** — a bare call whose return value is dropped on the floor:

```js
isElementVisible(documentTree.shadowRoot.querySelector('.parents'));
```

Sonar could not see that one because S2970 only matches `expect()` chains, and eslint could not either because `no-unused-expressions` is deliberately off for test files. Both lines sit directly under the comment `// assert that we have one parent only and it is visible`, which states the intent the code failed to implement.

**S8968 — two silent skips.** `test/nuxeo-performance.test.js:403` and `:473` both bail out with a bare `return` when `PerformancePaintTiming` is unavailable. Mocha treats a returning test as a **pass**, so on any engine lacking the paint-timing API these two report green having executed nothing.

## Changes

* **`test/nuxeo-document-tree.test.js`** (lines 344, 420): both `.parents` checks now assert `.to.be.true`, matching the intent stated in their own comment. What they now assert: *after the tree collapses to a single ancestor, the `.parents` breadcrumb container is actually rendered and visible* (non-zero box, non-hidden, opacity > 0). `.parents` is bound to `hidden$="[[_noPermission]]"` in `nuxeo-document-tree.js`, so this is a real guard against the breadcrumb silently disappearing.
* **`test/nuxeo-performance.test.js`** (lines 403, 473): the bare `return` is replaced by `this.skip()`, which reports a skip and makes the condition visible in the CI test report. Both callbacks were converted from arrow functions to `function ()` so that `this` is the Mocha context — `this.skip` is not available on an arrow function's lexical `this`.

Test code only. **No product code is touched**, so there is nothing for QA to exercise — this ticket has no QA sub-task and is verified entirely by CI.

## Test plan

- [x] `npm run lint` — eslint clean on both changed files. (Prettier reports repo-wide differences on this Windows checkout because `core.autocrlf=true` writes CRLF; re-running with `--end-of-line crlf` reports **zero** differences on the changed files, and untouched files such as `webpack.config.js` are flagged identically. CI runs on Linux with LF and is unaffected.)
- [x] `npm test` — **2736 passed, 1 failed**. The single failure is `nuxeo-search-form > gives the saved searches dropdown an always visible label (WEBUI-489)`, which is **pre-existing on `lts-2025` and unrelated**: re-running the full suite with the base versions of both changed files reproduces the identical result (2736 passed, same single failure).
- [x] **The completed S2970 assertion was seen to fail against deliberately broken behaviour** (AC 2). With `_noPermission = true` forced on a real `nuxeo-document-tree` fixture — the actual condition that hides `.parents` — a throwaway probe confirmed all three of:
  - `isElementVisible(parents)` is genuinely `false` (the breadcrumb really is hidden);
  - the **old** form `expect(isElementVisible(parents))` does **not** throw — proving it could never fail;
  - the **new** form `expect(isElementVisible(parents)).to.be.true` **throws** `expected false to be true` — proving the assertion is now real.
- [x] **The S8968 tests report as skipped, not passed** (AC 3). Chromium defines `PerformancePaintTiming`, so the guard is not taken in CI; a throwaway probe replicating both shapes confirmed the runner reports `1 skipped` for the `this.skip()` form while the old `return` form was silently counted among the passes, and that `typeof this.skip === 'function'` inside the non-arrow callback.
- [x] Commits are signed and show **Verified** on GitHub, authored by the CLA-covered identity with no `cursoragent@` co-author trailer.

Both probe files were deleted before committing; the diff is 6 changed lines across the two test files and nothing else.

## Notes

* **Coverage may not move at all**, and that is expected: every one of these lines was already executing. The coverage metric was never wrong — the assertions were.
* Completing the assertions did **not** expose a defect in `nuxeo-document-tree`, so AC 4 does not apply and no follow-up Bug is raised. The breadcrumb genuinely is visible in both scenarios; the assertions pass on their own merits, not because they are trivially true.
* Line 344 is outside the three findings Sonar listed. It is included because it is the identical defect, in the same file, in the test immediately above, and fixing only the line Sonar can see would leave the ticket's own premise — a test that cannot fail — still true one test up.
* Paired PR for the other base is linked below; the two branches carry the same commit.

Paired PR: [#3530](https://github.com/nuxeo/nuxeo-web-ui/pull/3530) (`lts-2025`) - same commit, same diff.


[WEBUI-2253]: https://hyland.atlassian.net/browse/WEBUI-2253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBUI-2252]: https://hyland.atlassian.net/browse/WEBUI-2252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ