### PR TITLE
WEBUI-2254: Quote workflow filename expansions and clear TODO tags [maintenance-3.1.x]

### DIFF
--- a/.github/workflows/veracode-2025.yaml
+++ b/.github/workflows/veracode-2025.yaml
@@ -96,10 +96,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
         run: |
-          npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" nuxeo-elements/core/${ELEMENTS_CORE}
-          npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" nuxeo-elements/ui/${ELEMENTS_UI}
-          npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" nuxeo-elements/dataviz/${ELEMENTS_DATAVIZ}
-          npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" nuxeo-elements/testing-helpers/${ELEMENTS_HELPERS}
+          npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" "nuxeo-elements/core/${ELEMENTS_CORE}"
+          npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" "nuxeo-elements/ui/${ELEMENTS_UI}"
+          npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" "nuxeo-elements/dataviz/${ELEMENTS_DATAVIZ}"
+          npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" "nuxeo-elements/testing-helpers/${ELEMENTS_HELPERS}"
       - name: Delete Node Modules
         run: |
           rm -rf node_modules
@@ -126,7 +126,7 @@ jobs:
       - name: Zip nuxeo-web-ui
         run: |
           echo nuxeo-web-ui-${{ steps.get-tag.outputs.TAG }}.zip
-          zip -r nuxeo-web-ui.zip *
+          zip -r nuxeo-web-ui.zip ./*
 
       - name: Upload ZIP as artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/veracode-3.1.x.yaml
+++ b/.github/workflows/veracode-3.1.x.yaml
@@ -95,10 +95,10 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
       run: |
-          npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" nuxeo-elements/core/${ELEMENTS_CORE}
-          npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" nuxeo-elements/ui/${ELEMENTS_UI}
-          npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" nuxeo-elements/dataviz/${ELEMENTS_DATAVIZ}
-          npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" nuxeo-elements/testing-helpers/${ELEMENTS_HELPERS}
+          npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" "nuxeo-elements/core/${ELEMENTS_CORE}"
+          npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" "nuxeo-elements/ui/${ELEMENTS_UI}"
+          npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" "nuxeo-elements/dataviz/${ELEMENTS_DATAVIZ}"
+          npm install --no-package-lock --@nuxeo:registry="${{ env.NPM_REPOSITORY }}" "nuxeo-elements/testing-helpers/${ELEMENTS_HELPERS}"
     - name: Delete Node Modules
       run: |
         rm -rf node_modules
@@ -125,7 +125,7 @@ jobs:
     - name: Zip nuxeo-web-ui
       run: |
         echo nuxeo-web-ui-${{ steps.get-tag.outputs.TAG }}.zip
-        zip -r nuxeo-web-ui.zip *
+        zip -r nuxeo-web-ui.zip ./*
 
     - name: Upload ZIP as artifact
       uses: actions/upload-artifact@v7

--- a/addons/nuxeo-spreadsheet/app/lib/select2-editor.js
+++ b/addons/nuxeo-spreadsheet/app/lib/select2-editor.js
@@ -42,7 +42,6 @@ Select2Editor.prototype.createElements = function () {
 
   const that = this;
   Handsontable.hooks.add('afterRender', () => {
-    // TODO(nfgs) - was that.instance.registerTimeout
     that.instance._registerTimeout(
       'refresh_editor_dimensions',
       () => {

--- a/addons/nuxeo-spreadsheet/app/nuxeo/widget.js
+++ b/addons/nuxeo-spreadsheet/app/nuxeo/widget.js
@@ -24,7 +24,7 @@ class Widget {
       return;
     }
 
-    // TODO(nfgs): Handle multiple fields
+    // Only the first field of a multi-field widget is bound; see WEBUI-2285.
     this.field = this.widget.fields[0].fieldName;
 
     // Rename data['schema']['property'] to data.schema.property

--- a/elements/nuxeo-admin/nuxeo-search-analytics.js
+++ b/elements/nuxeo-admin/nuxeo-search-analytics.js
@@ -298,13 +298,7 @@ Polymer({
         if (!agg[i] || !agg[i].length) {
           return 0;
         }
-        // TODO: use Array.reduce once prototype.js is removed!
-        // return agg[i].reduce(function(a, b) { return a + b; });
-        let sum = 0;
-        agg[i].forEach((v) => {
-          sum += v;
-        });
-        return sum;
+        return agg[i].reduce((a, b) => a + b, 0);
       }),
     ];
   },

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -119,8 +119,7 @@ sonar.sourceEncoding=UTF-8
 #   Coverage >= 90%, Issues == 0, Hotspots reviewed == 100%, Duplications <= 3%
 # Note: sonar.qualitygate.wait is set via workflow args to ensure it applies in all scan modes.
 
-# Suppress all issues in CI workflow files — npm install with preinstall scripts is intentional.
-# TODO: Remove once sub-packages have package-lock.json and npm ci can be used safely.
-# sonar.issue.ignore.multicriteria=e1
-# sonar.issue.ignore.multicriteria.e1.ruleKey=*
-# sonar.issue.ignore.multicriteria.e1.resourceKey=.github/workflows/**
+# There is deliberately no blanket suppression for .github/workflows/**. A disabled
+# sonar.issue.ignore.multicriteria block used to sit here to hide the npm-install
+# preinstall-script findings; enabling it would also hide every future genuine workflow
+# finding, so workflow issues are fixed in the workflow files instead (see WEBUI-2254).


### PR DESCRIPTION
## Problem

Five SonarCloud maintainability findings are permanently open against `nuxeo-web-ui`, on both bases. Jira: [WEBUI-2254](https://hyland.atlassian.net/browse/WEBUI-2254) (9 of 9 in the [WEBUI-2246](https://hyland.atlassian.net/browse/WEBUI-2246) triage).

| Rule | Count | Location on this base |
| --- | --- | --- |
| `githubactions:S6573` | 2 | `.github/workflows/veracode-2025.yaml:129`, `.github/workflows/veracode-3.1.x.yaml:128` |
| `javascript:S1135` | 3 | `nuxeo-search-analytics.js:301`, `nuxeo-spreadsheet/app/nuxeo/widget.js:27`, `nuxeo-spreadsheet/app/lib/select2-editor.js:45` |

Housekeeping only ΓÇö nothing here is observable in the product.

## Root cause

**S6573.** Both veracode workflows archive the checkout with `zip -r nuxeo-web-ui.zip *`. The glob is neither quoted nor prefixed, so a file whose name begins with `-` is handed to `zip` as an *option* rather than a path. This is a build-correctness rather than a security concern ΓÇö the repository controls its own filenames ΓÇö but it is two permanent findings against the workflow files.

**S1135.** Three `TODO` comments in Nuxeo-authored source record intent that is tracked nowhere but the comment.

## Changes

### `.github/workflows/veracode-2025.yaml`, `.github/workflows/veracode-3.1.x.yaml`

* `zip -r nuxeo-web-ui.zip *` ΓåÆ `zip -r nuxeo-web-ui.zip ./*`, the first remedy Sonar's own message suggests (`Prefix files and paths with "./" or "--" when using glob`).
* Quoted the four sibling `npm install` package-path arguments in the "Link elements to Web UI" step (`"nuxeo-elements/core/${ELEMENTS_CORE}"` and friends). These are the same class of unquoted expansion in the same file; Sonar has not flagged them, but leaving them makes the file half-quoted.

### `elements/nuxeo-admin/nuxeo-search-analytics.js`

The TODO deferred `Array.reduce` *"once prototype.js is removed"*. prototype.js is long gone ΓÇö the comment was its last reference anywhere in the repo ΓÇö so the task is **completed** rather than deleted:

```js
- // TODO: use Array.reduce once prototype.js is removed!
- // return agg[i].reduce(function(a, b) { return a + b; });
- let sum = 0;
- agg[i].forEach((v) => { sum += v; });
- return sum;
+ return agg[i].reduce((a, b) => a + b, 0);
```

The guard above (`if (!agg[i] || !agg[i].length) return 0;`) means the bucket is always a non-empty array of numbers, so this is exactly equivalent.

### `addons/nuxeo-spreadsheet/app/lib/select2-editor.js`

`// TODO(nfgs) - was that.instance.registerTimeout` was a historical annotation from a Handsontable API rename, not a task. The vendored Handsontable (`app/vendor/jquery.handsontable.full.js:2200`) defines only `_registerTimeout`, and every internal editor calls it that way ΓÇö there is no public `registerTimeout` to go back to. **Deleted.**

### `addons/nuxeo-spreadsheet/app/nuxeo/widget.js`

`// TODO(nfgs): Handle multiple fields` is a real, unimplemented capability: a layout widget may declare several `fields`, and the Spreadsheet editor silently binds, shows and saves only the first. **Raised as [WEBUI-2285](https://hyland.atlassian.net/browse/WEBUI-2285)** and the comment now states the limitation and cites the key:

```js
- // TODO(nfgs): Handle multiple fields
+ // Only the first field of a multi-field widget is bound; see WEBUI-2285.
```

### `sonar-project.properties`

Removed the dead commented-out `.github/workflows/**` blanket suppression block and the `TODO` attached to it. Per the ticket it stays disabled ΓÇö the workflow findings are fixed at source instead ΓÇö and the reason it must not be re-enabled is recorded in its place. No open finding under `.github/workflows` depends on it (the only ones there were the two S6573 fixed here plus one out-of-scope item, see Notes).

## Test plan

- [x] `npm run lint` ΓÇö ESLint clean repo-wide. Prettier verified per changed file against LF copies; the local checkout is `core.autocrlf=true`, which makes `prettier --list-different` flag all ~670 files including untouched ones, so the whole-repo Prettier run is not a usable local signal on Windows.
- [x] `npm test` ΓÇö **2737 passed, 0 failed** (173s, coverage 81.21 %), against `@nuxeo/{nuxeo-elements,nuxeo-ui-elements,nuxeo-dataviz-elements,testing-helpers}@3.1.35-rc.15`, resolved with the same "latest common RC" logic `test.yaml` uses, so the local run matches what CI installs.
- [x] **actionlint + shellcheck on both workflows: 26 findings ΓåÆ 16, ten removed, none added.** The ten removed are exactly the two `SC2035` ("Use `./*glob*` or `-- *glob*` so names with dashes won't become options" ΓÇö the shellcheck rule Sonar's S6573 mirrors) and the eight `SC2086` sibling-quoting findings. The 16 that remain are pre-existing and untouched (`always-auth` input, `steps.get-tag` reference, `>> $GITHUB_OUTPUT`/`$GITHUB_ENV` redirects).
- [x] **Archive content proven unchanged.** Ran `zip -r out.zip *` vs `./*` vs `-- *` on a representative tree under `ubuntu:24.04` with Info-ZIP **Zip 3.0**, the version on the GitHub ubuntu runners: all three produce a byte-identical entry listing (`zip` normalises the `./` prefix away), and dotfiles are excluded in all three, as before. So the artifact Veracode ingests does not change.

## Notes

* **Backport of [#3532](https://github.com/nuxeo/nuxeo-web-ui/pull/3532) (`lts-2025`).** Not a straight cherry-pick: the 2025 veracode workflow is `veracode-lts-2025.yaml` there and `veracode-2025.yaml` here, so the workflow hunks were reapplied by hand. The other four files are byte-identical to the `lts-2025` change, except that `sonar-project.properties` ends with a trailing newline on this base and without one on `lts-2025` ΓÇö an existing difference between the two bases, preserved rather than "fixed".
* **The edited workflows do not run on this PR.** Both veracode workflows are `schedule:`-only, so a green tick here comes from unrelated jobs and proves nothing about them ΓÇö the ticket calls this out explicitly. That is why they are validated by actionlint/shellcheck and by the Info-ZIP equivalence test above rather than by CI. First real execution is the next nightly cron.
* **Out of scope, deliberately:** `.github/workflows/sonar.yaml:124` carries a fourth open TODO finding (`githubactions:S1135`, a different rule from the three `javascript:S1135` in this ticket) ΓÇö *"Temporarily non-blocking due to revert PR baseline issue. Revert to exit 1 once SonarCloud new-code baseline resets"*. Resolving it means deciding whether to make the Quality Gate blocking again, which is a real CI-policy change and not 10 minutes of housekeeping. Flagging it rather than folding it in.
* No FIXME work: all nine `javascript:S1134` findings are in the vendored three.js glTF loaders, which are no longer analysed — the vendored-loader Sonar exclusion has already landed on both branches (#3482 and #3483). Cited by PR rather than by Jira key on purpose: the Jira integration turns any issue key in a PR body into a development link on that ticket, which wrongly attached this PR to it.
* No QA sub-task ΓÇö nothing here is observable in the product; verification is CI green plus the Sonar count dropping.


[WEBUI-2254]: https://hyland.atlassian.net/browse/WEBUI-2254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBUI-2246]: https://hyland.atlassian.net/browse/WEBUI-2246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBUI-2285]: https://hyland.atlassian.net/browse/WEBUI-2285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ