### PR TITLE
WEBUI-2027: do not pre-encode the document path when saving column preferences [lts-2025]

### DIFF
--- a/elements/nuxeo-results/nuxeo-results.js
+++ b/elements/nuxeo-results/nuxeo-results.js
@@ -1521,13 +1521,12 @@ Polymer({
   // ------------------------------
 
   // Configures the nuxeo-resource instance to PUT doc-level preferences to /path/<docPath>/@preferences.
+  // The path is left unencoded on purpose: the Nuxeo JS client percent-encodes the whole request path
+  // when it builds the URL, so encoding it here would double-encode names holding a space or any other
+  // reserved character (`My Content` -> `My%2520Content`), which the server resolves to a missing document.
   _configureDocPreferencesResource(docPath) {
     const normalized = docPath.startsWith('/') ? docPath.substring(1) : docPath;
-    const encodedPath = normalized
-      .split('/')
-      .map((segment) => encodeURIComponent(segment))
-      .join('/');
-    this.$.preferences.path = `/path/${encodedPath}/@preferences`;
+    this.$.preferences.path = `/path/${normalized}/@preferences`;
     this.$.preferences.params = null;
     this.$.preferences.enrichers = {};
     this.$.preferences.headers = { accept: 'application/json' };

--- a/test/nuxeo-results.test.js
+++ b/test/nuxeo-results.test.js
@@ -1644,6 +1644,13 @@ suite('nuxeo-results', () => {
       expect(results.$.preferences.headers).to.deep.equal({ accept: 'application/json' });
     });
 
+    test('_configureDocPreferencesResource leaves reserved characters to the client encoder', () => {
+      // The Nuxeo JS client percent-encodes the request path, so encoding it here too would send
+      // `My%2520Content` and make the server report a missing document (WEBUI-2027).
+      results._configureDocPreferencesResource('/default-domain/My Content');
+      expect(results.$.preferences.path).to.equal('/path/default-domain/My Content/@preferences');
+    });
+
     test('_getDocPrefsFromEnricher reads and parses preference payloads', () => {
       const doc = {
         contextParameters: {


### PR DESCRIPTION
## Problem

Changing the visible columns of a content view fails for any document whose path contains a space
(or any other reserved character). The server answers the column-preferences request with
`404 DocumentNotFoundException: /default-domain/workspaces/My%20Content`, so the user's column
choice is never stored on the document — Web UI silently falls back to `localStorage`, and the
server logs a missing-document error for a document that exists.

[WEBUI-2027](https://hyland.atlassian.net/browse/WEBUI-2027)

## Root cause

`nuxeo-results._configureDocPreferencesResource()` percent-encoded every segment of the document
path before assigning it to `<nuxeo-resource>`:

```js
const encodedPath = normalized.split('/').map((segment) => encodeURIComponent(segment)).join('/');
this.$.preferences.path = `/path/${encodedPath}/@preferences`;
```

The Nuxeo JS client already encodes the whole request path when it builds the URL
(`nuxeo/lib/request.js` -> `encodePath()`, which is `encodeURIComponent` with `/`, `:` and `@` put
back). Encoding here as well double-encodes the name:

| stage | value |
| --- | --- |
| document path | `/default-domain/workspaces/My Content` |
| `nuxeo-resource.path` (before this fix) | `/path/default-domain/workspaces/My%20Content/@preferences` |
| URL actually sent | `PUT /nuxeo/api/v1/path/default-domain/workspaces/My%2520Content/@preferences` |
| server decodes once | `/default-domain/workspaces/My%20Content` -> `DocumentNotFoundException` |

Every other resource in the app (`path/${targetPath}/@emptyWithDefault`, `nuxeo-document`'s
`doc-path`, ...) passes the raw path and relies on that single client-side encoding, which is why
only the column preferences broke.

## Changes

- `elements/nuxeo-results/nuxeo-results.js`: pass the raw document path to `<nuxeo-resource>` and let
  the client apply its single encoding. Only the leading `/` is still stripped, as before.
- `test/nuxeo-results.test.js`: regression test asserting the configured resource path keeps the
  space verbatim (`/path/default-domain/My Content/@preferences`).

## Test plan

Verified against a throwaway `nuxeo/nuxeo:2025` container with a `My Content` workspace, running a
dev build of this branch (and of the base branch, for the "before" state), so the two captures differ
only by this commit.

- Before: `PUT .../My%2520Content/@preferences` -> `404`, message `/default-domain/workspaces/My%20Content`
- After: `PUT .../My%20Content/@preferences` -> `201`

Server-side confirmation of the same asymmetry, independent of the UI:

```
GET /nuxeo/api/v1/path/default-domain/workspaces/My%20Content    -> 200
GET /nuxeo/api/v1/path/default-domain/workspaces/My%2520Content  -> 404  /default-domain/workspaces/My%20Content
```

Gating checks locally: `npm run lint` clean, `npm test` 2767 passed / 0 failed.

## Notes

- Backported to both bases: this PR and the companion PR on the other base branch.
- Documents without reserved characters in their path are unaffected: `encodeURIComponent` was a
  no-op for them, which is why this went unnoticed.
- Global (search-provider) preferences are untouched. They key on the page-provider name, a safe
  identifier, so the same pre-encoding there is a no-op.


[WEBUI-2027]: https://hyland.atlassian.net/browse/WEBUI-2027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ