### PR TITLE
WEBUI-1546: reject multi-file drops on a single blob dropzone [LTS-2025]

### DIFF
--- a/elements/nuxeo-dropzone/nuxeo-dropzone.js
+++ b/elements/nuxeo-dropzone/nuxeo-dropzone.js
@@ -621,6 +621,13 @@ Polymer({
     e.preventDefault();
     this._setDraggingFiles(false);
     const droppedFiles = Array.from(e.dataTransfer.files || []);
+    // A single blob dropzone only ever keeps the first file (see `_getFiles`), so accepting the
+    // whole drop would upload every file and then silently discard all but one.
+    if (droppedFiles.length > 1 && !this.multiple && !this.blobList) {
+      this._errorMessage = this.i18n('dropzone.invalid.multipleFiles');
+      this.invalid = true;
+      return;
+    }
     this.files = droppedFiles;
     if (this.validate()) {
       this._upload(e.dataTransfer.files);

--- a/ftest/features/upload.feature
+++ b/ftest/features/upload.feature
@@ -21,3 +21,13 @@ Feature: Upload
     And I upload file "sample.png" as document content
     Then I can see the blob replace button
     And I can see the option to add new attachments
+
+  Scenario: Dropping several files at once on a single file dropzone is rejected
+    Given I have permission WriteProperties for this document
+    When I browse to the document
+    Then I can see the option to add a main blob
+    When I drop 3 files at once as document content
+    Then I can see an error on the document content dropzone
+    And I can't see the blob replace button
+    When I drop 1 file at once as document content
+    Then I can see the blob replace button

--- a/i18n/messages.json
+++ b/i18n/messages.json
@@ -547,7 +547,7 @@
   "dropzone.add": "Upload main file",
   "dropzone.invalid.error": "Invalid content",
   "dropzone.invalid.file": "Only {0} files are allowed",
-  "dropzone.invalid.multipleFiles": "Only one file can be uploaded here",
+  "dropzone.invalid.multipleFiles": "This field accepts only one file. Please drop a single file.",
   "dropzone.invalid.uploading": "File upload pending",
   "dropzone.dropFile": "Drop your file",
   "dropzone.toast.error": "Upload failed: {0}",

--- a/i18n/messages.json
+++ b/i18n/messages.json
@@ -547,6 +547,7 @@
   "dropzone.add": "Upload main file",
   "dropzone.invalid.error": "Invalid content",
   "dropzone.invalid.file": "Only {0} files are allowed",
+  "dropzone.invalid.multipleFiles": "Only one file can be uploaded here",
   "dropzone.invalid.uploading": "File upload pending",
   "dropzone.dropFile": "Drop your file",
   "dropzone.toast.error": "Upload failed: {0}",

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/upload.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/upload.js
@@ -48,9 +48,8 @@ Then("I can't see the blob replace button", async function () {
   await page.waitForVisible();
   const view = await page.view;
   await view.waitForVisible();
-  const ele = await view.el.element('nuxeo-replace-blob-button');
-  const isVisible = await view.isTrulyVisible(ele);
-  isVisible.should.be.false;
+  const result = await view.waitForNotVisible('nuxeo-replace-blob-button');
+  result.should.be.true;
 });
 
 Then('I can see the option to add new attachments', async function () {

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/upload.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/upload.js
@@ -1,8 +1,36 @@
-import { Then } from '@cucumber/cucumber';
+import { Then, When } from '@cucumber/cucumber';
 
 Then(/^I upload file "(.+)" as document content/, async function (file) {
   const element = await this.ui.browser.el.element('nuxeo-dropzone');
   await fixtures.layouts.setValue(element, file);
+});
+
+// `chooseFile` drives the hidden file input, which can only ever carry one file on a single blob
+// dropzone. Dropping is the only way to hand the widget several files at once, so synthesise the
+// drag and drop in the page.
+When(/^I drop (\d+) files? at once as document content$/, async function (count) {
+  const element = await this.ui.browser.el.element('nuxeo-dropzone');
+  await element.waitForVisible();
+  await browser.execute(
+    (dropzone, total) => {
+      const dataTransfer = new DataTransfer();
+      for (let i = 0; i < total; i++) {
+        dataTransfer.items.add(new File([`content ${i}`], `dropped-${i}.txt`, { type: 'text/plain' }));
+      }
+      dropzone.shadowRoot
+        .querySelector('#dropzone')
+        .dispatchEvent(new DragEvent('drop', { dataTransfer, bubbles: true, cancelable: true }));
+    },
+    element,
+    Number(count),
+  );
+});
+
+Then('I can see an error on the document content dropzone', async function () {
+  const element = await this.ui.browser.el.element('nuxeo-dropzone');
+  await element.waitForVisible();
+  const invalid = await browser.execute((dropzone) => dropzone.invalid === true, element);
+  invalid.should.be.true;
 });
 
 Then('I can see the blob replace button', async function () {

--- a/packages/nuxeo-web-ui-ftest/features/step_definitions/upload.js
+++ b/packages/nuxeo-web-ui-ftest/features/step_definitions/upload.js
@@ -48,8 +48,11 @@ Then("I can't see the blob replace button", async function () {
   await page.waitForVisible();
   const view = await page.view;
   await view.waitForVisible();
-  const result = await view.waitForNotVisible('nuxeo-replace-blob-button');
-  result.should.be.true;
+  const ele = await view.el.element('nuxeo-replace-blob-button');
+  // The button is rendered but zero sized when the user cannot write, and absent altogether when
+  // the document has no main blob, so it has to be found before it can be measured.
+  const isVisible = (await ele.isExisting()) && (await view.isTrulyVisible(ele));
+  isVisible.should.be.false;
 });
 
 Then('I can see the option to add new attachments', async function () {

--- a/test/nuxeo-dropzone.test.js
+++ b/test/nuxeo-dropzone.test.js
@@ -214,6 +214,72 @@ suite('nuxeo-dropzone', () => {
       expect(uploadSpy.calledOnceWithExactly(event.dataTransfer.files)).to.eql(true);
     });
 
+    test('drop of several files is rejected when multiple is false', () => {
+      const uploadStub = sinon.stub(element, '_upload');
+      sinon.stub(element, 'validate').returns(true);
+      element.multiple = false;
+      element.files = [{ name: 'kept.txt' }];
+      const event = {
+        preventDefault: sinon.spy(),
+        dataTransfer: { files: [{ name: 'f1.txt' }, { name: 'f2.txt' }] },
+      };
+
+      element._drop(event);
+
+      expect(uploadStub).to.not.have.been.called;
+      expect(element.files).to.eql([{ name: 'kept.txt' }]);
+      expect(element.invalid).to.eql(true);
+      expect(element._errorMessage).to.eql('dropzone.invalid.multipleFiles');
+      element.validate.restore();
+      uploadStub.restore();
+    });
+
+    test('drop of a single file is still accepted when multiple is false', () => {
+      const uploadStub = sinon.stub(element, '_upload');
+      sinon.stub(element, 'validate').returns(true);
+      element.multiple = false;
+      const files = [{ name: 'f1.txt' }];
+      const event = { preventDefault: sinon.spy(), dataTransfer: { files } };
+
+      element._drop(event);
+
+      expect(uploadStub).to.have.been.calledOnceWithExactly(files);
+      expect(element.files).to.eql(files);
+      element.validate.restore();
+      uploadStub.restore();
+    });
+
+    test('drop of several files is accepted when multiple is true', () => {
+      const uploadStub = sinon.stub(element, '_upload');
+      sinon.stub(element, 'validate').returns(true);
+      element.multiple = true;
+      const files = [{ name: 'f1.txt' }, { name: 'f2.txt' }];
+      const event = { preventDefault: sinon.spy(), dataTransfer: { files } };
+
+      element._drop(event);
+
+      expect(uploadStub).to.have.been.calledOnceWithExactly(files);
+      expect(element.files).to.eql(files);
+      element.validate.restore();
+      uploadStub.restore();
+    });
+
+    test('drop of several files is accepted for a legacy blob list', () => {
+      const uploadStub = sinon.stub(element, '_upload');
+      sinon.stub(element, 'validate').returns(true);
+      element.multiple = false;
+      element.blobList = true;
+      const files = [{ name: 'f1.txt' }, { name: 'f2.txt' }];
+      const event = { preventDefault: sinon.spy(), dataTransfer: { files } };
+
+      element._drop(event);
+
+      expect(uploadStub).to.have.been.calledOnceWithExactly(files);
+      expect(element.files).to.eql(files);
+      element.validate.restore();
+      uploadStub.restore();
+    });
+
     test('upload keeps uploaded files for single and multiple mode', () => {
       const uploadFilesSpy = sinon.spy(element, 'uploadFiles');
       const firstFile = { name: 'f1.txt' };


### PR DESCRIPTION
## Problem

On a `nuxeo-dropzone` bound to a single blob (`multiple` defaults to `false`), dropping several
files at once from the file explorer uploads **all** of them and lists them all in the widget as if
they had been accepted. No error is shown.

It is worse than a cosmetic glitch: because `_getFiles` binds only `'upload-fileId': '0'` in single
blob mode, every file after the first is uploaded to the server batch and then **silently discarded**
when the document is saved. The user is given no indication that their files were dropped on the floor.

Reproduced on the `File` creation form (Administrator → personal workspace → **+** → **File** → drop
3 files on *Content*): all 3 appear under *Content*, while the widget value points at file 0 only.

Jira: [WEBUI-1546](https://hyland.atlassian.net/browse/WEBUI-1546)

## Root cause

`elements/nuxeo-dropzone/nuxeo-dropzone.js` — `_drop()` never consults `multiple`:

```js
const droppedFiles = Array.from(e.dataTransfer.files || []);
this.files = droppedFiles;          // every dropped file, unconditionally
if (this.validate()) {
  this._upload(e.dataTransfer.files);
}
```

The file **picker** path is constrained only by the native `multiple$="[[multiple]]"` attribute on
the hidden `<input type="file">`, so the OS dialog enforces the single file limit there. Nothing
enforced it on the **drop** path, and `_getValidity()` had no notion of "too many files" either.

## Changes

- `_drop()` now refuses a multi-file drop on a single blob dropzone (`!multiple && !blobList`):
  nothing is uploaded, `files`/`value` are left untouched, and `dropzone.invalid.multipleFiles` is
  surfaced through the widget's existing `_errorMessage` / `invalid` mechanism (red dashed border +
  inline message, same as an `accept` violation). This mirrors what a non-`multiple`
  `<input type="file">` does with a multi-file drop — refuse it rather than silently keep one.
- A subsequent single file drop passes `validate()`, clears the error and uploads normally, so the
  rejection is fully recoverable without reloading the form.
- New i18n key `dropzone.invalid.multipleFiles` (English only; Crowdin syncs the rest).
- 4 unit tests covering the four branches of `_drop`: reject multi-file in single mode, accept a
  single file in single mode, accept multi-file when `multiple`, accept multi-file for a legacy
  `blob-list`.
- Functional coverage in `ftest/features/upload.feature` plus two steps in `upload.js`. The existing
  ftest harness has no drag-and-drop path (every upload goes through `chooseFile` on the hidden
  input, which cannot carry more than one file here), so the new step synthesises the multi-file
  `DataTransfer` drop in the page.

## Test plan

Local gate (`lint` + unit tests) green on both branches: **2770 passed, 0 failed** (up 4), lint clean,
no `package-lock.json` churn.

Verified end to end against a throwaway Nuxeo 2025 instance, building the branch twice and deploying
each bundle into the same container so the only difference is this commit:

| | multi-file drop (`multiple=false`) | follow-up single file drop |
|---|---|---|
| before | 3 files listed, `invalid=false`, no error, `value` = `upload-fileId: 0` | accepted |
| after | 0 files, `invalid=true`, *"This field accepts only one file. Please drop a single file."*, `value` = `null` | accepted, error cleared |

Before/after screenshots and screen recordings are attached to the Jira ticket.

## Notes

- Legacy `blob-list` dropzones and `multiple` dropzones are deliberately excluded from the guard, so
  attachments (`files:files`) and the Import tab are unaffected.
- The new ftest scenario has **not** been executed locally (the ftest suite needs its own
  server/runner setup); it is expected to be exercised by the branch CI.


[WEBUI-1546]: https://hyland.atlassian.net/browse/WEBUI-1546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ