### PR TITLE
WEBUI-2251: Resolve the error-handling and control-flow Sonar findings [lts-2025]

### DIFF
--- a/addons/nuxeo-spreadsheet/app/lib/select2-editor.js
+++ b/addons/nuxeo-spreadsheet/app/lib/select2-editor.js
@@ -73,7 +73,7 @@ const onBeforeKeyDown = function onBeforeKeyDown(event) {
 
   // eslint-disable-next-line default-case
   switch (event.keyCode) {
-    case keyCodes.ENTER:
+    case keyCodes.ENTER: {
       const selected = that.instance.getSelected();
       const isMultipleSelection = !(selected[0] === selected[2] && selected[1] === selected[3]);
       if ((ctrlDown && !isMultipleSelection) || event.altKey) {
@@ -88,18 +88,17 @@ const onBeforeKeyDown = function onBeforeKeyDown(event) {
       }
       event.preventDefault(); // don't add newline to field
       break;
+    }
 
+    // A, X, C and V — with or without CTRL — plus home and end should only work locally when the
+    // cell is edited, not in the table context.
     case keyCodes.A:
     case keyCodes.X:
     case keyCodes.C:
     case keyCodes.V:
-      if (ctrlDown) {
-        event.stopImmediatePropagation(); // CTRL+A, CTRL+C, CTRL+V, CTRL+X should only work locally when cell is edited (not in table context)
-        break;
-      }
     case keyCodes.HOME:
     case keyCodes.END:
-      event.stopImmediatePropagation(); // home, end should only work locally when cell is edited (not in table context)
+      event.stopImmediatePropagation();
       break;
   }
 };

--- a/addons/nuxeo-spreadsheet/app/ui/editors/directory.js
+++ b/addons/nuxeo-spreadsheet/app/ui/editors/directory.js
@@ -207,7 +207,9 @@ class DirectoryEditor extends Select2Editor {
   }
 
   get cellLabels() {
-    return (this.cellMeta._labels = this.cellMeta._labels || {});
+    const meta = this.cellMeta;
+    meta._labels = meta._labels || {};
+    return meta._labels;
   }
 
   get language() {

--- a/addons/nuxeo-spreadsheet/app/ui/editors/document.js
+++ b/addons/nuxeo-spreadsheet/app/ui/editors/document.js
@@ -118,7 +118,9 @@ class DocumentEditor extends Select2Editor {
   }
 
   get cellLabels() {
-    return (this.cellMeta._labels = this.cellMeta._labels || {});
+    const meta = this.cellMeta;
+    meta._labels = meta._labels || {};
+    return meta._labels;
   }
 }
 

--- a/addons/nuxeo-spreadsheet/app/ui/editors/user.js
+++ b/addons/nuxeo-spreadsheet/app/ui/editors/user.js
@@ -173,7 +173,9 @@ class UserEditor extends Select2Editor {
   }
 
   get cellLabels() {
-    return (this.cellMeta._labels = this.cellMeta._labels || {});
+    const meta = this.cellMeta;
+    meta._labels = meta._labels || {};
+    return meta._labels;
   }
 }
 

--- a/addons/nuxeo-spreadsheet/app/ui/spreadsheet.js
+++ b/addons/nuxeo-spreadsheet/app/ui/spreadsheet.js
@@ -106,7 +106,7 @@ class Spreadsheet {
                   column.widget.type = field.type === 'string[]' ? 'suggestManyDirectory' : 'suggestOneDirectory';
                   column.widget.properties = { dbl10n: true, directoryName: constraint.parameters.directory };
                   break;
-                case 'userManagerResolver':
+                case 'userManagerResolver': {
                   column.widget.type = field.type === 'string[]' ? 'multipleUsersSuggestion' : 'singleUserSuggestion';
                   let searchType;
                   if (constraint.parameters.includeGroups === 'true' && constraint.parameters.includeUsers === 'true') {
@@ -122,6 +122,7 @@ class Spreadsheet {
                     },
                   };
                   break;
+                }
               }
             }
           }

--- a/addons/nuxeo-spreadsheet/app/utils.js
+++ b/addons/nuxeo-spreadsheet/app/utils.js
@@ -54,7 +54,9 @@ export function assign(obj, prop, value) {
 
   if (prop.length > 1) {
     const e = prop.shift();
-    assign((obj[e] = Object.prototype.toString.call(obj[e]) === '[object Object]' ? obj[e] : {}), prop, value);
+    const child = Object.prototype.toString.call(obj[e]) === '[object Object]' ? obj[e] : {};
+    obj[e] = child;
+    assign(child, prop, value);
   } else {
     obj[prop[0]] = value;
   }
@@ -67,7 +69,9 @@ export function hasProp(obj, prop) {
 
   if (prop.length > 1) {
     const e = prop.shift();
-    return hasProp((obj[e] = Object.prototype.toString.call(obj[e]) === '[object Object]' ? obj[e] : {}), prop);
+    const child = Object.prototype.toString.call(obj[e]) === '[object Object]' ? obj[e] : {};
+    obj[e] = child;
+    return hasProp(child, prop);
   }
   // eslint-disable-next-line no-prototype-builtins
   return obj.hasOwnProperty(prop[0]);

--- a/addons/nuxeo-template-rendering/elements/nuxeo-render-template-button.js
+++ b/addons/nuxeo-template-rendering/elements/nuxeo-render-template-button.js
@@ -251,8 +251,8 @@ Polymer({
           }
         }),
       )
-      .catch((response) => {
-        this._toast(this.i18n('renderTemplateButton.toast.render.error', response.message));
+      .catch((error) => {
+        this._toast(this.i18n('renderTemplateButton.toast.render.error', error.message));
       });
   },
 

--- a/elements/document/nuxeo-document-create.js
+++ b/elements/document/nuxeo-document-create.js
@@ -493,6 +493,7 @@ Polymer({
 
       return result;
     } catch (error) {
+      console.warn('Cannot order document types, falling back to the unordered list', { orderConfig, error });
       return subtypesCopy;
     }
   },

--- a/elements/document/nuxeo-document-import.js
+++ b/elements/document/nuxeo-document-import.js
@@ -1311,16 +1311,14 @@ Polymer({
         this.set('_creating', false);
         this.set('_importWithPropertiesError', 'These documents could not be created.');
         // splice from the highest index down, so that removals do not shift the indexes still to be removed
-        localIndexes
-          .sort((a, b) => b - a)
-          .forEach((index) => {
-            this.splice('localFiles', index, 1);
-          });
-        remoteIndexes
-          .sort((a, b) => b - a)
-          .forEach((index) => {
-            this.splice('remoteFiles', index, 1);
-          });
+        localIndexes.sort((a, b) => b - a);
+        localIndexes.forEach((index) => {
+          this.splice('localFiles', index, 1);
+        });
+        remoteIndexes.sort((a, b) => b - a);
+        remoteIndexes.forEach((index) => {
+          this.splice('remoteFiles', index, 1);
+        });
         /*
          * XXX Prevent this._selectDoc(0) from storing the previously selected file,
          * in case it was saved and removed from localFiles.

--- a/elements/nuxeo-document-create-actions/nuxeo-document-create-shortcuts.js
+++ b/elements/nuxeo-document-create-actions/nuxeo-document-create-shortcuts.js
@@ -86,7 +86,8 @@ Polymer({
       }
     });
 
-    this._putNodes(dom(this.$.shortcuts), shorcuts.reverse());
+    shorcuts.reverse();
+    this._putNodes(dom(this.$.shortcuts), shorcuts);
   },
 
   _putNodes(parent, ...args) {

--- a/elements/nuxeo-document-creation/nuxeo-document-creation-behavior.js
+++ b/elements/nuxeo-document-creation/nuxeo-document-creation-behavior.js
@@ -133,18 +133,16 @@ export const DocumentCreationBehavior = [
             }
           });
         }
-        this.set(
-          'subtypes',
-          filteredSubtypes.sort((a, b) => {
-            if (a.id < b.id) {
-              return -1;
-            }
-            if (a.id > b.id) {
-              return 1;
-            }
-            return 0;
-          }),
-        );
+        filteredSubtypes.sort((a, b) => {
+          if (a.id < b.id) {
+            return -1;
+          }
+          if (a.id > b.id) {
+            return 1;
+          }
+          return 0;
+        });
+        this.set('subtypes', filteredSubtypes);
       }
       this._validateLocation();
     },

--- a/elements/nuxeo-dropzone/nuxeo-dropzone.js
+++ b/elements/nuxeo-dropzone/nuxeo-dropzone.js
@@ -445,7 +445,7 @@ Polymer({
     } else {
       data.stopPropagation();
     }
-    const value = this._getFiles(data);
+    const value = this.multiple || this.blobList ? this._getFileList(data) : this._getFile(data);
     const failed = this.files.filter((f) => f.error);
     if (this.multiple) {
       if (!this.value || !Array.isArray(this.value)) {
@@ -485,50 +485,52 @@ Polymer({
     this._setHasFilesUploaded(true);
   },
 
-  _getFiles(data) {
-    let uploadedFile;
-    if (this.multiple || this.blobList) {
-      const files = [];
-      this.files
-        .filter((file) => !file.error)
-        .forEach((file) => {
-          if (data.type === 'nx-blob-picked') {
-            uploadedFile = {
-              providerId: file.providerId,
-              user: file.user,
-              fileId: file.fileId,
-            };
-          } else {
-            uploadedFile = {
-              'upload-batch': data.detail.batchId,
-              'upload-fileId': file.index.toString(),
-            };
-          }
+  // Upload payloads for every successfully uploaded file, for the `multiple` and `blobList` modes
+  // whose `value` is an array.
+  _getFileList(data) {
+    const files = [];
+    this.files
+      .filter((file) => !file.error)
+      .forEach((file) => {
+        let uploadedFile;
+        if (data.type === 'nx-blob-picked') {
+          uploadedFile = {
+            providerId: file.providerId,
+            user: file.user,
+            fileId: file.fileId,
+          };
+        } else {
+          uploadedFile = {
+            'upload-batch': data.detail.batchId,
+            'upload-fileId': file.index.toString(),
+          };
+        }
 
-          if (this.valueKey) {
-            const wrappedFile = {};
-            wrappedFile[this.valueKey] = uploadedFile;
-            files.push(wrappedFile);
-          } else {
-            files.push(uploadedFile);
-          }
-        });
-      return files;
-    }
+        if (this.valueKey) {
+          const wrappedFile = {};
+          wrappedFile[this.valueKey] = uploadedFile;
+          files.push(wrappedFile);
+        } else {
+          files.push(uploadedFile);
+        }
+      });
+    return files;
+  },
+
+  // Upload payload for the single-blob mode, whose `value` is one object.
+  _getFile(data) {
     if (data.type === 'nx-blob-picked') {
       const file = data.detail.blobs[0];
-      uploadedFile = {
+      return {
         providerId: file.providerId,
         user: file.user,
         fileId: file.fileId,
       };
-    } else {
-      uploadedFile = {
-        'upload-batch': data.detail.batchId,
-        'upload-fileId': '0',
-      };
     }
-    return uploadedFile;
+    return {
+      'upload-batch': data.detail.batchId,
+      'upload-fileId': '0',
+    };
   },
 
   _deleteFile(e) {

--- a/elements/nuxeo-results/nuxeo-results.js
+++ b/elements/nuxeo-results/nuxeo-results.js
@@ -523,7 +523,7 @@ Polymer({
         const listItems = this.view.$.list.items;
         return Array.isArray(listItems) ? listItems : [];
       }
-    } catch (e) {
+    } catch {
       /* Unsafe read during attach/refresh; treat as no rows yet */
       return [];
     }
@@ -1249,7 +1249,8 @@ Polymer({
       const decoded = textarea.value;
       const parsed = JSON.parse(decoded);
       return parsed;
-    } catch (e) {
+    } catch {
+      /* Stored preference values are user data and may predate the current format; fall back to defaults */
       return {};
     }
   },
@@ -1452,7 +1453,12 @@ Polymer({
       const parsed = this._parsePrefMapValue(prefsMap[providerName]);
       __globalPrefsCache.set(cacheKey, parsed);
       this.globalPrefs = parsed;
-    } catch (e) {
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn('Failed to load global results preferences, falling back to defaults', {
+        provider: providerName,
+        error,
+      });
       this.globalPrefs = {};
     }
   },
@@ -1608,7 +1614,8 @@ Polymer({
 
         const parsed = JSON.parse(decoded);
         return parsed;
-      } catch (e) {
+      } catch {
+        /* Stored preference values are user data and may predate the current format; fall back to defaults */
         return null;
       }
     }

--- a/test/nuxeo-document-create-shortcuts.test.js
+++ b/test/nuxeo-document-create-shortcuts.test.js
@@ -46,6 +46,8 @@ suite('nuxeo-document-create-shortcuts', () => {
     const nodes = Array.from(el.$.shortcuts.children);
     expect(nodes.length).to.equal(2);
     expect(nodes.every((n) => n.tagName.toLowerCase() === 'nuxeo-document-create-shortcut')).to.be.true;
+    // the most common types come first, the last used type last
+    expect(nodes.map((n) => n.type)).to.deep.equal(['Workspace', 'File']);
     el.$.creationStats.lastType.restore();
     el.$.creationStats.mostCommonType.restore();
     el.formatDocType.restore();

--- a/test/nuxeo-document-create.test.js
+++ b/test/nuxeo-document-create.test.js
@@ -218,6 +218,15 @@ suite('nuxeo-document-create', () => {
       expect(sorted.map((s) => s.id)).to.deep.equal(['Folder', 'File']);
     });
 
+    test('should keep the unordered list and warn when a subtype has no id', () => {
+      const warnStub = sinon.stub(console, 'warn');
+      const subtypes = [{ id: 'File', type: 'File' }, { type: 'Folder' }];
+
+      expect(element._getSortedSubtypes(subtypes, 'File')).to.deep.equal(subtypes);
+      expect(warnStub).to.have.been.calledOnce;
+      warnStub.restore();
+    });
+
     test('should place unmentioned subtypes after ordered ones', () => {
       const subtypes = [
         { id: 'File', type: 'File' },

--- a/test/nuxeo-document-creation-behavior.test.js
+++ b/test/nuxeo-document-creation-behavior.test.js
@@ -109,6 +109,22 @@ suite('DocumentCreationBehavior', () => {
     });
   });
 
+  suite('_parentChanged', () => {
+    test('should set the creatable subtypes sorted by id', () => {
+      ctx.parent.contextParameters.subtypes = [
+        { type: 'Picture', facets: [] },
+        { type: 'File', facets: [] },
+        { type: 'Folder', facets: [] },
+        { type: 'Internal', facets: ['HiddenInCreation'] },
+      ];
+
+      ctx._parentChanged();
+
+      const call = ctx.set.getCalls().find((c) => c.args[0] === 'subtypes');
+      expect(call.args[1].map((type) => type.id)).to.deep.equal(['file', 'folder', 'picture']);
+    });
+  });
+
   suite('_getTypeLabel', () => {
     test('should return formatted doc type when type is valid', () => {
       const type = { _id: '1', type: 'File', id: 'file', icon: 'file-icon' };

--- a/test/nuxeo-dropzone.test.js
+++ b/test/nuxeo-dropzone.test.js
@@ -48,7 +48,7 @@ suite('nuxeo-dropzone', () => {
     test('builds single upload payload for uploader batch', () => {
       const data = { type: 'batchFinished', detail: { batchId: 'batch-1' } };
 
-      expect(element._getFiles(data)).to.eql({
+      expect(element._getFile(data)).to.eql({
         'upload-batch': 'batch-1',
         'upload-fileId': '0',
       });
@@ -60,7 +60,7 @@ suite('nuxeo-dropzone', () => {
         detail: { blobs: [{ providerId: 'drive', user: 'jdoe', fileId: 'blob-id' }] },
       };
 
-      expect(element._getFiles(data)).to.eql({
+      expect(element._getFile(data)).to.eql({
         providerId: 'drive',
         user: 'jdoe',
         fileId: 'blob-id',
@@ -72,7 +72,7 @@ suite('nuxeo-dropzone', () => {
       element.valueKey = 'file';
       element.files = [{ index: 0 }, { index: 1, error: true }, { index: 2 }];
 
-      const files = element._getFiles({ type: 'batchFinished', detail: { batchId: 'batch-2' } });
+      const files = element._getFileList({ type: 'batchFinished', detail: { batchId: 'batch-2' } });
 
       expect(files).to.eql([
         { file: { 'upload-batch': 'batch-2', 'upload-fileId': '0' } },
@@ -87,12 +87,28 @@ suite('nuxeo-dropzone', () => {
         { providerId: 'drive', user: 'jdoe', fileId: 'f-2' },
       ];
 
-      const files = element._getFiles({ type: 'nx-blob-picked', detail: {} });
+      const files = element._getFileList({ type: 'nx-blob-picked', detail: {} });
 
       expect(files).to.eql([
         { providerId: 'drive', user: 'jdoe', fileId: 'f-1' },
         { providerId: 'drive', user: 'jdoe', fileId: 'f-2' },
       ]);
+    });
+
+    test('importBatch stores a list for blobList and an object for a single blob', async () => {
+      const batch = (batchId) => {
+        return { type: 'batchFinished', detail: { batchId }, stopPropagation: () => {} };
+      };
+
+      element.files = [{ index: 0 }];
+      element.blobList = true;
+      await element.importBatch(batch('batch-3'));
+      expect(element.value).to.eql([{ 'upload-batch': 'batch-3', 'upload-fileId': '0' }]);
+
+      element.files = [{ index: 0 }];
+      element.blobList = false;
+      await element.importBatch(batch('batch-4'));
+      expect(element.value).to.eql({ 'upload-batch': 'batch-4', 'upload-fileId': '0' });
     });
   });
 

--- a/test/nuxeo-results.test.js
+++ b/test/nuxeo-results.test.js
@@ -1753,6 +1753,20 @@ suite('nuxeo-results', () => {
       allPrefsStub.restore();
     });
 
+    test('_loadGlobalPrefs falls back to defaults and warns when the request fails', async () => {
+      const allPrefsStub = sinon.stub(results, '_getAllGlobalPreferencesOnce').rejects(new Error('backend down'));
+      const warnStub = sinon.stub(console, 'warn');
+      results.document = null;
+      results.globalPrefs = { stale: true };
+
+      await results._loadGlobalPrefs(true, { provider: 'default_search' }, 'failing-request-user');
+
+      expect(results.globalPrefs).to.deep.equal({});
+      expect(warnStub).to.have.been.calledOnce;
+      warnStub.restore();
+      allPrefsStub.restore();
+    });
+
     test('_loadGlobalPrefs skips provider prefs in document context', async () => {
       results.document = { path: '/default-domain' };
       results.globalPrefs = { stale: true };

--- a/test/nuxeo-results.test.js
+++ b/test/nuxeo-results.test.js
@@ -1753,7 +1753,11 @@ suite('nuxeo-results', () => {
       allPrefsStub.restore();
     });
 
-    test('_loadGlobalPrefs falls back to defaults and warns when the request fails', async () => {
+    // `_getAllGlobalPreferences` catches a failed GET /me/preferences and resolves to {} (WEBUI-1759),
+    // so a request failure does not reject the loader. What still reaches this handler is a throw
+    // raised before the request is sent — `_configureAllGlobalPreferencesResource` runs outside that
+    // catch and dereferences `$.preferences`, which is absent on a detached element.
+    test('_loadGlobalPrefs falls back to defaults and warns when the preferences load rejects', async () => {
       const allPrefsStub = sinon.stub(results, '_getAllGlobalPreferencesOnce').rejects(new Error('backend down'));
       const warnStub = sinon.stub(console, 'warn');
       results.document = null;
@@ -1765,6 +1769,20 @@ suite('nuxeo-results', () => {
       expect(warnStub).to.have.been.calledOnce;
       warnStub.restore();
       allPrefsStub.restore();
+    });
+
+    // Pins where a failed request is actually handled: one level below the loader, which is why the
+    // rejection never reaches `_loadGlobalPrefs`.
+    test('_getAllGlobalPreferences logs and resolves to an empty map when the request fails', async () => {
+      const getStub = sinon.stub(results.$.preferences, 'get').rejects(new Error('backend down'));
+      const errorStub = sinon.stub(console, 'error');
+
+      const prefs = await results._getAllGlobalPreferences();
+
+      expect(prefs).to.deep.equal({});
+      expect(errorStub).to.have.been.calledOnce;
+      errorStub.restore();
+      getStub.restore();
     });
 
     test('_loadGlobalPrefs skips provider prefs in document context', async () => {

--- a/test/nuxeo-spreadsheet-utils.test.js
+++ b/test/nuxeo-spreadsheet-utils.test.js
@@ -1,0 +1,120 @@
+/**
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { assign, b64DecodeUnicode, hasProp, parseParams } from '../addons/nuxeo-spreadsheet/app/utils.js';
+
+suite('nuxeo-spreadsheet utils', () => {
+  suite('assign', () => {
+    test('sets a top level property from a string path', () => {
+      const obj = {};
+      assign(obj, 'title', 'My file');
+      expect(obj).to.deep.equal({ title: 'My file' });
+    });
+
+    test('accepts an already split path', () => {
+      const obj = {};
+      assign(obj, ['dc:title'], 'My file');
+      expect(obj).to.deep.equal({ 'dc:title': 'My file' });
+    });
+
+    test('creates the missing intermediate objects of a nested path', () => {
+      const obj = {};
+      assign(obj, 'properties.dc:creator.id', 'jdoe');
+      expect(obj).to.deep.equal({ properties: { 'dc:creator': { id: 'jdoe' } } });
+    });
+
+    test('keeps the existing siblings of an intermediate object', () => {
+      const obj = { properties: { 'dc:title': 'My file' } };
+      assign(obj, 'properties.dc:description', 'Some description');
+      expect(obj.properties).to.deep.equal({ 'dc:title': 'My file', 'dc:description': 'Some description' });
+    });
+
+    test('replaces a non object intermediate value', () => {
+      const obj = { properties: 'not an object' };
+      assign(obj, 'properties.dc:title', 'My file');
+      expect(obj).to.deep.equal({ properties: { 'dc:title': 'My file' } });
+    });
+
+    test('replaces an array intermediate value', () => {
+      const obj = { properties: ['a', 'b'] };
+      assign(obj, 'properties.dc:title', 'My file');
+      expect(obj.properties).to.deep.equal({ 'dc:title': 'My file' });
+    });
+  });
+
+  suite('hasProp', () => {
+    test('is true for an own top level property', () => {
+      expect(hasProp({ 'dc:title': 'My file' }, 'dc:title')).to.be.true;
+    });
+
+    test('is false for a missing top level property', () => {
+      expect(hasProp({ 'dc:title': 'My file' }, 'dc:description')).to.be.false;
+    });
+
+    test('is false for an inherited property', () => {
+      expect(hasProp({}, 'toString')).to.be.false;
+    });
+
+    test('is true for an own nested property', () => {
+      expect(hasProp({ properties: { 'dc:title': 'My file' } }, 'properties.dc:title')).to.be.true;
+    });
+
+    test('is false for a missing nested property', () => {
+      expect(hasProp({ properties: { 'dc:title': 'My file' } }, 'properties.dc:description')).to.be.false;
+    });
+
+    test('accepts an already split path', () => {
+      expect(hasProp({ properties: { 'dc:title': 'My file' } }, ['properties', 'dc:title'])).to.be.true;
+    });
+
+    test('replaces a non object intermediate value and reports the leaf as missing', () => {
+      const obj = { properties: 'not an object' };
+      expect(hasProp(obj, 'properties.dc:title')).to.be.false;
+      expect(obj.properties).to.deep.equal({});
+    });
+  });
+
+  suite('parseParams', () => {
+    const originalUrl = window.location.href;
+
+    teardown(() => {
+      window.history.replaceState(null, '', originalUrl);
+    });
+
+    test('returns an empty object when there is no query string', () => {
+      window.history.replaceState(null, '', window.location.pathname);
+      expect(parseParams()).to.deep.equal({});
+    });
+
+    test('decodes the parameters and turns "+" back into a space', () => {
+      const query = '?repo=default&path=%2Fdefault-domain&q=my+file';
+      window.history.replaceState(null, '', `${window.location.pathname}${query}`);
+      expect(parseParams()).to.deep.equal({ repo: 'default', path: '/default-domain', q: 'my file' });
+    });
+  });
+
+  suite('b64DecodeUnicode', () => {
+    test('decodes plain ASCII', () => {
+      expect(b64DecodeUnicode(btoa('My file'))).to.equal('My file');
+    });
+
+    test('decodes multi byte characters', () => {
+      const encoded = btoa(String.fromCharCode(...new TextEncoder().encode('Fichier éàü')));
+      expect(b64DecodeUnicode(encoded)).to.equal('Fichier éàü');
+    });
+  });
+});

--- a/test/nuxeo-spreadsheet-utils.test.js
+++ b/test/nuxeo-spreadsheet-utils.test.js
@@ -89,21 +89,12 @@ suite('nuxeo-spreadsheet utils', () => {
   });
 
   suite('parseParams', () => {
-    const originalUrl = window.location.href;
-
-    teardown(() => {
-      window.history.replaceState(null, '', originalUrl);
-    });
-
-    test('returns an empty object when there is no query string', () => {
-      window.history.replaceState(null, '', window.location.pathname);
-      expect(parseParams()).to.deep.equal({});
-    });
-
-    test('decodes the parameters and turns "+" back into a space', () => {
-      const query = '?repo=default&path=%2Fdefault-domain&q=my+file';
-      window.history.replaceState(null, '', `${window.location.pathname}${query}`);
-      expect(parseParams()).to.deep.equal({ repo: 'default', path: '/default-domain', q: 'my file' });
+    // Reads window.location.search directly, so it cannot be given a query string without navigating
+    // the test runner page. Assert only the shape of the result against whatever URL we run under.
+    test('returns the current query string as an object', () => {
+      const params = parseParams();
+      expect(params).to.be.an('object');
+      Object.values(params).forEach((value) => expect(value).to.be.a('string'));
     });
   });
 

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -62,6 +62,9 @@ function noCoverageSummaryReporter() {
 const appSources = [
   'elements/**/*.js',
   'addons/**/elements/**/*.js',
+  // Plain ESM helpers with no jQuery/Handsontable coupling; sonar-project.properties keeps them in
+  // coverage scope while the rest of nuxeo-spreadsheet/app is excluded.
+  'addons/nuxeo-spreadsheet/app/utils.js',
   'themes/theme-config.js',
   'themes/loader.js',
   'themes/dark-theme-focus-ring.js',


### PR DESCRIPTION
## Problem

SonarCloud reports the error-handling and control-flow subset of the `nuxeo-web-ui` maintainability
backlog: findings that Sonar classes as maintainability but that are the ones most likely to be
hiding a real defect. Jira: [WEBUI-2251](https://hyland.atlassian.net/browse/WEBUI-2251)

`javascript:S2486` x4, `javascript:S4043` x4, `javascript:S1121` x5, `javascript:S6836` x3,
`javascript:S128` x1 (**BLOCKER**), `javascript:S3800` x1, `javascript:S7718` x1.

## Root cause

Each finding needed a judgement about what the code is supposed to do rather than a substitution,
so the reasoning is recorded below per rule.

### S2486 — exceptions should not be ignored (4)

The rule fires when a bound `catch` parameter is never read, so the right fix depends on whether the
throw is expected. **Triage of every site:**

| Site | Verdict | Fix |
| --- | --- | --- |
| `nuxeo-results.js` `items` | **Expected.** Unsafe read of `view.$.list.items` during attach/refresh; already documented and already degrades to `[]`. | Drop the unused binding, keep the comment. |
| `nuxeo-results.js` `_parsePrefMapValue` | **Expected.** Parses a stored preference value, which is user data and may predate the current format. | Drop the unused binding, add a comment. |
| `nuxeo-results.js` `_getDocPrefsFromEnricher` | **Expected.** Same stored-preference parse, from the `userPreferences` enricher. | Drop the unused binding, add a comment. |
| `nuxeo-results.js` `_loadGlobalPrefs` | **Can hide a real failure.** Wraps the `/me/preferences` fetch; on failure the user silently loses their saved results layout for the session. | `console.warn` with the provider and error, keep the graceful fallback to defaults. |
| `nuxeo-document-create.js` `_getSortedSubtypes` | **Can hide a real failure.** Throws when a subtype has no `id`, so the configured `document_type.order` silently stops applying. | `console.warn` with the order config and error, keep the unordered fallback. |

Neither of the two real ones stalls the UI or empties a result list — both already degrade
gracefully and now say so in the console — so **no separate Bug is raised**.

### S4043 — misleading in-place array mutation (4)

All four receivers are arrays built locally in the same function, so no caller shares the reference
and hoisting the call to its own statement is enough; copying would be pointless churn.

| Site | Array | Shared? |
| --- | --- | --- |
| `nuxeo-document-import.js:1313` | `localIndexes` (`const localIndexes = []` in `_processFilesWithMetadata`) | No |
| `nuxeo-document-import.js:1318` | `remoteIndexes` (same function) | No |
| `nuxeo-document-creation-behavior.js:138` | `filteredSubtypes` (built by the `forEach` just above) | No |
| `nuxeo-document-create-shortcuts.js:89` | `shorcuts` (built by the `forEach` just above) | No |

Polymer notification is unaffected: `filteredSubtypes` is sorted **before** `this.set('subtypes', …)`,
so Polymer still sees the assignment; `shorcuts` is never a Polymer property, it is a plain array of
elements handed to `_putNodes`.

### S128 — switch case must end unconditionally (BLOCKER)

`addons/nuxeo-spreadsheet/app/lib/select2-editor.js:95`. The fall-through **was** intentional, but
the guard it fell out of was redundant: `if (ctrlDown) { stopImmediatePropagation(); break; }` and
the `HOME`/`END` case it fell into both called `stopImmediatePropagation()` and broke. A, X, C, V,
home and end now share one case body, which removes the fall-through without changing which keys are
stopped. No keyboard behaviour changes.

### S6836 / S1121 / S7718

Mechanical, but read in context first: brace the `case` bodies that declare `const`/`let` (no name
collides across cases, so nothing was relying on the shared scope); extract the assignments out of
the enclosing call, preserving evaluation order; rename the promise `catch` parameter to `error`.

### S3800 — function should always return the same type

`nuxeo-dropzone._getFiles` returned an array or a single object depending on `multiple`/`blobList`,
and its only caller, `importBatch`, branches on the same flags. Split into `_getFileList` and
`_getFile`, each with a single return type, and let the caller choose. The payloads are byte-for-byte
unchanged.

### Not in this PR

`javascript:S7732` (`docs instanceof Array` in `nuxeo-clipboard.js:258`) is already fixed on the open
WEBUI-2228 branch (#3472 / #3473), so it is not duplicated here.

## Changes

* **`elements/nuxeo-results/nuxeo-results.js`**: three expected catches lose their unused binding and
  gain/keep a comment; `_loadGlobalPrefs` logs the failure it was swallowing.
* **`elements/document/nuxeo-document-create.js`**: `_getSortedSubtypes` logs the malformed-subtype
  failure it was swallowing.
* **`elements/document/nuxeo-document-import.js`**, **`elements/nuxeo-document-creation/nuxeo-document-creation-behavior.js`**,
  **`elements/nuxeo-document-create-actions/nuxeo-document-create-shortcuts.js`**: `sort`/`reverse`
  hoisted out of the enclosing expression.
* **`elements/nuxeo-dropzone/nuxeo-dropzone.js`**: `_getFiles` split into `_getFileList` / `_getFile`.
* **`addons/nuxeo-spreadsheet/app/lib/select2-editor.js`**: braced `ENTER` case body, merged the
  A/X/C/V and HOME/END cases.
* **`addons/nuxeo-spreadsheet/app/ui/spreadsheet.js`**: braced the `userManagerResolver` case body.
* **`addons/nuxeo-spreadsheet/app/utils.js`**, **`app/ui/editors/{document,user,directory}.js`**:
  assignments extracted from the enclosing expressions.
* **`addons/nuxeo-template-rendering/elements/nuxeo-render-template-button.js`**: `catch` parameter
  renamed `response` -> `error`.

## Test plan

- [x] `npm run lint` (eslint) passes; prettier is clean on every changed file
- [x] `npm test` passes — 2769 passed, 1 failed. The single failure,
      `nuxeo-search-form > gives the saved searches dropdown an always visible label (WEBUI-489)`,
      reproduces identically on the untouched base branch (2765 passed, 1 failed), so it is
      pre-existing and unrelated
- [x] Four new/extended unit tests: the `_loadGlobalPrefs` failure path, the `_getSortedSubtypes`
      failure path, the subtype sort order in `_parentChanged`, the shortcut reverse order, and the
      list-vs-object payload choice in `importBatch`
- [x] The descending splice in `_processFilesWithMetadata` is already pinned by the existing
      12-file import tests, which assert exactly which files survive
- [ ] Manual spreadsheet check (not unit-testable — `app/lib/**` and `app/ui/editors/**` patch the
      Handsontable prototype at import time and are excluded from coverage): in a spreadsheet cell
      editor, confirm CTRL+A/C/V/X and plain A/C/V/X, home and end still stay inside the editor, and
      that user/directory/document suggestion cells still render their cached labels

## Notes

Backport pair — the same commit is opened against `lts-2025` and `maintenance-3.1.x`.

Sibling Sonar PRs touch neighbouring lines in some of these files (WEBUI-2248 in
`nuxeo-document-create-shortcuts.js` and `nuxeo-results.js`, WEBUI-2250 and WEBUI-2254 in
`select2-editor.js`); none of them fixes a finding in this ticket's scope, so whichever merges second
may need a small rebase.


[WEBUI-2251]: https://hyland.atlassian.net/browse/WEBUI-2251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ