### PR TITLE
WEBUI-2249: Use structuredClone at the six JSON-safe deep-clone sites [lts-2025]

### DIFF
--- a/addons/nuxeo-template-rendering/elements/nuxeo-template-rendering-page.js
+++ b/addons/nuxeo-template-rendering/elements/nuxeo-template-rendering-page.js
@@ -192,8 +192,8 @@ Polymer({
   _documentChanged() {
     if (this.document) {
       this.set('document.properties.tmpl:templateType', this.document.properties['tmpl:templateType'] || 'auto');
-      this.set('editedDocument', this._parseJSON(this.document));
-      if (this.originalDocument === undefined) this.originalDocument = this._parseJSON(this.document);
+      this.set('editedDocument', this._deepClone(this.document));
+      if (this.originalDocument === undefined) this.originalDocument = this._deepClone(this.document);
     }
   },
 
@@ -218,7 +218,7 @@ Polymer({
   },
 
   _resetConfig() {
-    this.set('editedDocument', this._parseJSON(this.document));
+    this.set('editedDocument', this._deepClone(this.document));
   },
 
   _findChangedValues(originalDocument, modifiedDocument) {
@@ -232,18 +232,18 @@ Polymer({
     );
   },
 
-  _parseJSON(obj) {
-    return JSON.parse(JSON.stringify(obj));
+  _deepClone(obj) {
+    return structuredClone(obj);
   },
 
   _save() {
-    const modified = this._parseJSON(this.editedDocument.properties);
-    const originalDocument = this._parseJSON(this.originalDocument.properties);
+    const modified = this._deepClone(this.editedDocument.properties);
+    const originalDocument = this._deepClone(this.originalDocument.properties);
     const changedvalue = this._findChangedValues(originalDocument, modified);
 
     this.editedDocument.properties = changedvalue;
     return this.$.doc.put().then(() => {
-      this.originalDocument = this._parseJSON(this.editedDocument);
+      this.originalDocument = this._deepClone(this.editedDocument);
     });
   },
 

--- a/addons/nuxeo-template-rendering/test/nuxeo-template-rendering-page.test.js
+++ b/addons/nuxeo-template-rendering/test/nuxeo-template-rendering-page.test.js
@@ -65,14 +65,43 @@ suite('nuxeo-template-rendering-page', () => {
     });
   });
 
-  suite('_parseJSON and _findChangedValues', () => {
-    test('_parseJSON deep-clones objects', () => {
+  suite('_deepClone and _findChangedValues', () => {
+    test('_deepClone deep-clones objects', () => {
       const src = { a: 1, nested: { b: 2 } };
-      const copy = el._parseJSON(src);
+      const copy = el._deepClone(src);
       expect(copy).to.deep.equal(src);
       expect(copy).to.not.equal(src);
       copy.nested.b = 3;
       expect(src.nested.b).to.equal(2);
+    });
+
+    test('_deepClone preserves the field types of a template document (WEBUI-2249)', () => {
+      // The template document is REST JSON: tmpl:templateData is a serialized XML string and
+      // dc:modified an ISO string, so the clone must not turn either into another type.
+      const src = {
+        uid: 'doc-1',
+        type: 'TemplateSource',
+        properties: {
+          'dc:modified': '2024-01-31T10:15:00.000Z',
+          'dc:description': null,
+          'tmpl:allowOverride': true,
+          'tmpl:applicableTypes': ['File', 'Note'],
+          'tmpl:templateData': '<nxdt:templateParams xmlns:nxdt="http://www.nuxeo.org/DocumentTemplate"/>',
+        },
+      };
+
+      const copy = el._deepClone(src);
+
+      expect(copy).to.deep.equal(src);
+      expect(copy.properties['dc:modified']).to.be.a('string');
+      expect(copy.properties['dc:description']).to.be.null;
+      expect(copy.properties['tmpl:allowOverride']).to.equal(true);
+      expect(copy.properties['tmpl:applicableTypes']).to.be.an('array');
+      expect(copy.properties['tmpl:templateData']).to.be.a('string');
+      expect(copy.properties).to.not.equal(src.properties);
+
+      copy.properties['tmpl:applicableTypes'].push('Picture');
+      expect(src.properties['tmpl:applicableTypes']).to.deep.equal(['File', 'Note']);
     });
 
     test('_findChangedValues detects scalar and object changes for keys present in original', () => {
@@ -82,6 +111,24 @@ suite('nuxeo-template-rendering-page', () => {
       expect(diff.a).to.equal(2);
       expect(diff.obj).to.deep.equal({ x: 2 });
       expect(diff.extra).to.equal(3);
+    });
+
+    test('_findChangedValues still diffs cloned template properties correctly', () => {
+      const original = el._deepClone({
+        'tmpl:allowOverride': true,
+        'tmpl:applicableTypes': ['File'],
+        'tmpl:templateType': 'Freemarker',
+      });
+      const modified = el._deepClone({
+        'tmpl:allowOverride': false,
+        'tmpl:applicableTypes': ['File'],
+        'tmpl:templateType': 'Freemarker',
+      });
+
+      const diff = el._findChangedValues(original, modified);
+
+      expect(Object.keys(diff)).to.deep.equal(['tmpl:allowOverride']);
+      expect(diff['tmpl:allowOverride']).to.equal(false);
     });
   });
 

--- a/elements/document/nuxeo-document-import.js
+++ b/elements/document/nuxeo-document-import.js
@@ -998,6 +998,10 @@ Polymer({
     let copiedDocData = {};
 
     if (docData && Object.keys(docData).length > 0) {
+      // Deliberately not structuredClone (sonar javascript:S7784): docData.document is mutated in
+      // place by the widgets of the runtime-resolved `nuxeo-<type>-import-layout`, which deployments
+      // may override, so the JSON round-trip's lossy strip is what keeps a non-cloneable property
+      // from aborting the import with a DataCloneError. See WEBUI-2249.
       copiedDocData = JSON.parse(JSON.stringify(docData));
     }
     copiedDocData.document.properties['dc:title'] = destFile.name;
@@ -1015,6 +1019,7 @@ Polymer({
       }
       this.set([propName, pos, 'docData'].join('.'), {
         parent: this.targetPath,
+        // Lossy JSON clone on purpose — see _copyFileData (sonar javascript:S7784, WEBUI-2249).
         document: JSON.parse(JSON.stringify(this.document)),
         type: this.selectedDocType,
       });
@@ -1028,6 +1033,7 @@ Polymer({
     if (docData && Object.keys(docData).length > 0) {
       this.targetPath = docData.parent;
       this.selectedDocType = this._importDocTypes.find((type) => type.id === docData.type.id);
+      // Lossy JSON clone on purpose — see _copyFileData (sonar javascript:S7784, WEBUI-2249).
       ({ properties } = JSON.parse(JSON.stringify(docData.document)));
     }
     if (title) {

--- a/elements/nuxeo-cloud-services/nuxeo-cloud-consumers.js
+++ b/elements/nuxeo-cloud-services/nuxeo-cloud-consumers.js
@@ -200,7 +200,7 @@ class CloudConsumers extends mixinBehaviors([NotifyBehavior, FormatBehavior], Nu
   }
 
   _editEntry(e) {
-    const entry = JSON.parse(JSON.stringify(e.target.parentNode.item));
+    const entry = structuredClone(e.target.parentNode.item);
     if (Array.isArray(entry.redirectURIs)) {
       entry.redirectURIs = entry.redirectURIs.join();
     }

--- a/elements/nuxeo-cloud-services/nuxeo-cloud-providers.js
+++ b/elements/nuxeo-cloud-services/nuxeo-cloud-providers.js
@@ -207,7 +207,7 @@ Polymer({
 
   _editEntry(e) {
     this._isNew = false;
-    this._selectedEntry = JSON.parse(JSON.stringify(e.target.parentNode.item));
+    this._selectedEntry = structuredClone(e.target.parentNode.item);
     this._selectedServiceName = this._selectedEntry.serviceName;
     if (Array.isArray(this._selectedEntry.scopes)) {
       this._selectedEntry.scopes = this._selectedEntry.scopes.join();

--- a/elements/nuxeo-cloud-services/nuxeo-tokens-behavior.js
+++ b/elements/nuxeo-cloud-services/nuxeo-tokens-behavior.js
@@ -68,7 +68,7 @@ export const TokenBehavior = [
     },
 
     _editEntry(e) {
-      this._set_selectedEntry(JSON.parse(JSON.stringify(e.target.parentNode.item)));
+      this._set_selectedEntry(structuredClone(e.target.parentNode.item));
       this.$.dialog.toggle();
     },
 

--- a/elements/nuxeo-results/nuxeo-results.js
+++ b/elements/nuxeo-results/nuxeo-results.js
@@ -1255,6 +1255,9 @@ Polymer({
   },
 
   // Creates a JSON-safe deep copy of an object to avoid mutating cached/shared preference references.
+  // Deliberately not structuredClone (sonar javascript:S7784): the clone is persisted as JSON to the
+  // preference store, and the `{}` fallback below would turn a DataCloneError into a silent write of
+  // empty preferences, discarding the user's saved column layout instead of surfacing an error.
   _deepClone(obj) {
     try {
       return JSON.parse(JSON.stringify(obj || {}));

--- a/elements/search/nuxeo-search-form.js
+++ b/elements/search/nuxeo-search-form.js
@@ -838,7 +838,7 @@ Polymer({
     if (search) {
       this.isSavedSearch = this._isSavedSearch();
       this.selectedSearch = search;
-      const clonedParams = JSON.parse(JSON.stringify(search.params));
+      const clonedParams = structuredClone(search.params);
       this.params = this._mutateParams(clonedParams, true);
       this._navigateToResults();
     } else {
@@ -873,7 +873,7 @@ Polymer({
 
     // Populate params
     const search = this._searches[idx];
-    const clonedParams = JSON.parse(JSON.stringify(search.params));
+    const clonedParams = structuredClone(search.params);
     this.params = this._mutateParams(clonedParams, true);
     this.searchTerm = this.params && this.params.ecm_fulltext ? this.params.ecm_fulltext.replace(/\*/g, '') : '';
 

--- a/test/nuxeo-cloud-consumers.test.js
+++ b/test/nuxeo-cloud-consumers.test.js
@@ -61,6 +61,39 @@ suite('nuxeo-cloud-consumers', () => {
       expect(element._selectedEntry.redirectURIs).to.include('http://localhost:8080/callback');
       expect(element._selectedClientId).to.equal('client1');
     });
+
+    test('should clone the row deeply without altering its field types', () => {
+      const item = {
+        id: 'client1',
+        name: 'My client',
+        secret: null,
+        isEnabled: true,
+        isAutoGrant: false,
+        redirectURIs: ['http://localhost:8080/callback'],
+        metadata: { createdBy: 'Administrator', createdAt: '2024-01-31T10:15:00.000Z' },
+        'entity-type': 'oauth2Client',
+      };
+
+      element._editEntry({ target: { parentNode: { item } } });
+      const entry = element._selectedEntry;
+
+      expect(entry).to.not.equal(item);
+      expect(entry.id).to.be.a('string');
+      expect(entry.secret).to.be.null;
+      expect(entry.isEnabled).to.equal(true);
+      expect(entry.isAutoGrant).to.equal(false);
+      // ISO timestamps stay strings — the entry is REST JSON, never a Date instance
+      expect(entry.metadata.createdAt).to.be.a('string');
+      expect(entry.metadata).to.not.equal(item.metadata);
+      expect(entry.metadata).to.deep.equal(item.metadata);
+
+      // editing the dialog copy must not write through to the row backing the table
+      entry.metadata.createdBy = 'someone-else';
+      entry.isEnabled = false;
+      expect(item.metadata.createdBy).to.equal('Administrator');
+      expect(item.isEnabled).to.equal(true);
+      expect(item.redirectURIs).to.deep.equal(['http://localhost:8080/callback']);
+    });
   });
 
   suite('_save', () => {

--- a/test/nuxeo-cloud-providers.test.js
+++ b/test/nuxeo-cloud-providers.test.js
@@ -56,6 +56,35 @@ suite('nuxeo-cloud-providers', () => {
       expect(element._selectedEntry.scopes).to.equal('email,profile');
       expect(element._selectedServiceName).to.equal('google');
     });
+
+    test('should clone the row deeply without altering its field types', () => {
+      const item = {
+        serviceName: 'google',
+        description: 'Google OAuth2',
+        clientSecret: null,
+        isEnabled: true,
+        scopes: ['email', 'profile'],
+        userAuthorizationURL: 'https://accounts.google.com/o/oauth2/auth',
+        metadata: { registeredAt: '2024-01-31T10:15:00.000Z' },
+        'entity-type': 'nuxeoOAuth2ServiceProvider',
+      };
+
+      element._editEntry({ target: { parentNode: { item } } });
+      const entry = element._selectedEntry;
+
+      expect(entry).to.not.equal(item);
+      expect(entry.serviceName).to.be.a('string');
+      expect(entry.clientSecret).to.be.null;
+      expect(entry.isEnabled).to.equal(true);
+      // ISO timestamps stay strings — the entry is REST JSON, never a Date instance
+      expect(entry.metadata.registeredAt).to.be.a('string');
+      expect(entry.metadata).to.not.equal(item.metadata);
+
+      // _editEntry flattens scopes onto the copy; the row backing the table keeps its array
+      entry.metadata.registeredAt = 'changed';
+      expect(item.scopes).to.deep.equal(['email', 'profile']);
+      expect(item.metadata.registeredAt).to.equal('2024-01-31T10:15:00.000Z');
+    });
   });
 
   suite('_computeDialogHeading', () => {

--- a/test/nuxeo-search-form.test.js
+++ b/test/nuxeo-search-form.test.js
@@ -113,6 +113,74 @@ suite('nuxeo-search-form', () => {
     expect(searchForm.selectedSearchIdx).to.equal(0);
   });
 
+  suite('saved search params are deep-cloned (WEBUI-2249)', () => {
+    // A savedSearch entity is REST JSON: date-range aggregates arrive as ISO strings and
+    // never as Date instances, so the clone must hand the provider back the same field types.
+    const savedSearch = () => {
+      return {
+        id: 'saved-1',
+        title: 'Saved 1',
+        params: {
+          ecm_fulltext: '*report*',
+          dc_created_agg: ['last24h'],
+          dc_modified_min: '2024-01-31T10:15:00.000Z',
+          dc_modified_max: '2024-02-28T10:15:00.000Z',
+          system_primaryType_agg: [],
+          nested: { enabled: true, threshold: 5, label: null },
+        },
+      };
+    };
+
+    ['_selectedSearchIdxChanged', '_selectedSearchChanged'].forEach((method) => {
+      test(`${method} preserves param field types and does not alias the saved search`, () => {
+        const search = savedSearch();
+        searchForm._searches = [search];
+        sinon.stub(searchForm, '_mutateParams').callsFake((p) => p);
+        sinon.stub(searchForm, '_navigateToResults');
+
+        if (method === '_selectedSearchIdxChanged') {
+          searchForm.selectedSearchIdx = 1;
+          searchForm._selectedSearchIdxChanged();
+        } else {
+          searchForm._selectedSearchChanged({ id: 'saved-1' });
+        }
+
+        const { params } = searchForm;
+        expect(params).to.deep.equal(search.params);
+        expect(params).to.not.equal(search.params);
+        expect(params.ecm_fulltext).to.be.a('string');
+        expect(params.dc_modified_min).to.be.a('string');
+        expect(params.dc_created_agg).to.be.an('array');
+        expect(params.system_primaryType_agg).to.deep.equal([]);
+        expect(params.nested.enabled).to.equal(true);
+        expect(params.nested.threshold).to.be.a('number');
+        expect(params.nested.label).to.be.null;
+
+        // the form mutates params as the user edits filters; _searches must stay pristine
+        params.dc_created_agg.push('lastWeek');
+        params.nested.enabled = false;
+        expect(search.params.dc_created_agg).to.deep.equal(['last24h']);
+        expect(search.params.nested.enabled).to.equal(true);
+
+        searchForm._mutateParams.restore();
+        searchForm._navigateToResults.restore();
+      });
+    });
+
+    test('a saved search without params yields undefined params instead of throwing', () => {
+      // JSON.parse(JSON.stringify(undefined)) threw a SyntaxError here; structuredClone returns undefined
+      searchForm._searches = [{ id: 'no-params', title: 'No params' }];
+      sinon.stub(searchForm, '_mutateParams').callsFake((p) => p);
+      sinon.stub(searchForm, '_navigateToResults');
+
+      expect(() => searchForm._selectedSearchChanged({ id: 'no-params' })).to.not.throw();
+      expect(searchForm.params).to.be.undefined;
+
+      searchForm._mutateParams.restore();
+      searchForm._navigateToResults.restore();
+    });
+  });
+
   test('switches between queue and filters', () => {
     const displayFiltersSpy = sinon.spy(searchForm, 'displayFilters');
     const displayQueueSpy = sinon.spy(searchForm, 'displayQueue');

--- a/test/nuxeo-search-form.test.js
+++ b/test/nuxeo-search-form.test.js
@@ -131,12 +131,14 @@ suite('nuxeo-search-form', () => {
       };
     };
 
+    // Spy rather than stub, so paramMutator keeps running: the value handed to _mutateParams is
+    // the structuredClone output itself, which is what this change affects. Asserting on
+    // searchForm.params instead would assert the mutator's filtering, not the clone.
     ['_selectedSearchIdxChanged', '_selectedSearchChanged'].forEach((method) => {
       test(`${method} preserves param field types and does not alias the saved search`, () => {
         const search = savedSearch();
         searchForm._searches = [search];
-        sinon.stub(searchForm, '_mutateParams').callsFake((p) => p);
-        sinon.stub(searchForm, '_navigateToResults');
+        const mutate = sinon.spy(searchForm, '_mutateParams');
 
         if (method === '_selectedSearchIdxChanged') {
           searchForm.selectedSearchIdx = 1;
@@ -145,39 +147,39 @@ suite('nuxeo-search-form', () => {
           searchForm._selectedSearchChanged({ id: 'saved-1' });
         }
 
-        const { params } = searchForm;
-        expect(params).to.deep.equal(search.params);
-        expect(params).to.not.equal(search.params);
-        expect(params.ecm_fulltext).to.be.a('string');
-        expect(params.dc_modified_min).to.be.a('string');
-        expect(params.dc_created_agg).to.be.an('array');
-        expect(params.system_primaryType_agg).to.deep.equal([]);
-        expect(params.nested.enabled).to.equal(true);
-        expect(params.nested.threshold).to.be.a('number');
-        expect(params.nested.label).to.be.null;
+        const clone = mutate.firstCall.args[0];
+        expect(clone).to.deep.equal(search.params);
+        expect(clone).to.not.equal(search.params);
+        expect(clone.ecm_fulltext).to.be.a('string');
+        expect(clone.dc_modified_min).to.be.a('string');
+        expect(clone.dc_created_agg).to.be.an('array');
+        expect(clone.system_primaryType_agg).to.deep.equal([]);
+        expect(clone.nested.enabled).to.equal(true);
+        expect(clone.nested.threshold).to.be.a('number');
+        expect(clone.nested.label).to.be.null;
 
-        // the form mutates params as the user edits filters; _searches must stay pristine
-        params.dc_created_agg.push('lastWeek');
-        params.nested.enabled = false;
+        // the form mutates the clone as the user edits filters; _searches must stay pristine
+        clone.dc_created_agg.push('lastWeek');
+        clone.nested.enabled = false;
         expect(search.params.dc_created_agg).to.deep.equal(['last24h']);
         expect(search.params.nested.enabled).to.equal(true);
 
-        searchForm._mutateParams.restore();
-        searchForm._navigateToResults.restore();
+        mutate.restore();
       });
     });
 
-    test('a saved search without params yields undefined params instead of throwing', () => {
-      // JSON.parse(JSON.stringify(undefined)) threw a SyntaxError here; structuredClone returns undefined
+    test('a saved search without params is handled instead of throwing', () => {
+      // JSON.parse(JSON.stringify(undefined)) threw a SyntaxError before reaching the mutator;
+      // structuredClone yields undefined, which paramMutator turns into an empty param set.
       searchForm._searches = [{ id: 'no-params', title: 'No params' }];
-      sinon.stub(searchForm, '_mutateParams').callsFake((p) => p);
-      sinon.stub(searchForm, '_navigateToResults');
+      const mutate = sinon.spy(searchForm, '_mutateParams');
 
       expect(() => searchForm._selectedSearchChanged({ id: 'no-params' })).to.not.throw();
-      expect(searchForm.params).to.be.undefined;
+      expect(mutate.firstCall.args[0]).to.be.undefined;
+      expect(searchForm.params).to.deep.equal({});
+      expect(searchForm.searchTerm).to.equal('');
 
-      searchForm._mutateParams.restore();
-      searchForm._navigateToResults.restore();
+      mutate.restore();
     });
   });
 

--- a/test/nuxeo-tokens-behavior.test.js
+++ b/test/nuxeo-tokens-behavior.test.js
@@ -75,6 +75,37 @@ suite('TokenBehavior', () => {
       expect(arg).to.not.equal(item);
       expect(dialog.toggle).to.have.been.called;
     });
+
+    test('should clone the row deeply without altering its field types', () => {
+      const item = {
+        nuxeoLogin: 'user1',
+        clientId: 'client-1',
+        serviceName: 'google',
+        // _save() feeds creationDate to formatDate, which expects the REST payload's ISO string
+        creationDate: '2024-01-31T10:15:00.000Z',
+        sharedWith: ['groupA', 'groupB'],
+        clientDetails: { name: 'My client', isAutoGrant: true },
+        'entity-type': 'nuxeoOAuth2Token',
+      };
+      ctx.$ = { dialog: { toggle: sinon.spy() } };
+      ctx._set_selectedEntry = sinon.stub();
+
+      ctx._editEntry({ target: { parentNode: { item } } });
+      const entry = ctx._set_selectedEntry.firstCall.args[0];
+
+      expect(entry).to.not.equal(item);
+      expect(entry.creationDate).to.be.a('string');
+      expect(entry.creationDate).to.equal('2024-01-31T10:15:00.000Z');
+      expect(entry.sharedWith).to.be.an('array');
+      expect(entry.clientDetails.isAutoGrant).to.equal(true);
+      expect(entry.clientDetails).to.not.equal(item.clientDetails);
+
+      // _save() rewrites creationDate on the copy; the row backing the table must be untouched
+      entry.creationDate = '2024-01-31 10:15:00';
+      entry.clientDetails.name = 'renamed';
+      expect(item.creationDate).to.equal('2024-01-31T10:15:00.000Z');
+      expect(item.clientDetails.name).to.equal('My client');
+    });
   });
 
   suite('_deleteEntry', () => {


### PR DESCRIPTION
## Problem

SonarCloud rule `javascript:S7784` flags ten `JSON.parse(JSON.stringify(x))` deep clones in this repo and presents `structuredClone` as a drop-in replacement. It is not a drop-in replacement, so the sweep needed a per-site assessment rather than a find-and-replace.

Jira: [WEBUI-2249](https://hyland.atlassian.net/browse/WEBUI-2249)

## Root cause

The two algorithms disagree in both directions:

* `structuredClone` **throws `DataCloneError`** on functions, DOM nodes, `Symbol`s and class instances with unsupported internals — values the JSON round-trip silently drops or flattens. Converting a site whose payload is not bounded turns a previously-tolerated value into a runtime exception.
* `structuredClone` **preserves** `Date`, `Map`, `Set`, `RegExp`, `undefined` properties, `BigInt`, `NaN`/`Infinity` and circular references, where the JSON round-trip coerces (`Date` → ISO string), empties (`Map` → `{}`) or drops them.

So the question at each site is only ever: *can anything reach this clone that the two algorithms treat differently?*

For six of the ten sites the answer is provably no. The cloned value is always a `JSON.parse` product of a REST response body: `nuxeo-resource` parses the response itself rather than going through the Nuxeo JS client's unmarshallers, so entries are plain objects — never `Nuxeo.Document` instances, never `Date`s, never DOM references. On such a payload the two algorithms are equivalent by construction, and `structuredClone` is the clearer and faster expression of the intent.

For the remaining four the answer is yes, or cannot be established from the code — see below.

## Changes

### Converted to `structuredClone` (6 sites)

| File | Cloned value | Why it is safe |
|---|---|---|
| **`elements/nuxeo-cloud-services/nuxeo-cloud-consumers.js`** | `oauth2Client` row | Row comes straight from `nuxeo-resource` `.get()` → `response.entries`, a parsed JSON array. |
| **`elements/nuxeo-cloud-services/nuxeo-cloud-providers.js`** | `nuxeoOAuth2ServiceProvider` row | Same provenance. |
| **`elements/nuxeo-cloud-services/nuxeo-tokens-behavior.js`** | `nuxeoOAuth2Token` row | Same provenance. `creationDate` is an ISO **string**, not a `Date`, so `_save()`'s `formatDate` call is unaffected. |
| **`elements/search/nuxeo-search-form.js`** (2 sites) | `savedSearch.params` | Params are a `savedSearch` entity's JSON. Date-range aggregates are ISO strings, not `Date`s. Also removes a latent bug: `JSON.parse(JSON.stringify(undefined))` threw `SyntaxError` for a saved search with no `params`; `structuredClone` returns `undefined`. |
| **`addons/nuxeo-template-rendering/elements/nuxeo-template-rendering-page.js`** | template document / its `properties` | Document comes from `nuxeo-document` / `nuxeo-resource`. `tmpl:templateData` is a serialized XML **string**. |

`_parseJSON` is renamed to **`_deepClone`** in the template-rendering page — the old name described a mechanism that no longer parses anything.

### Deliberately left as a JSON round-trip (4 sites)

Both are annotated in-code with the reason, so the next Sonar sweep does not undo this analysis.

| File | Why not converted |
|---|---|
| **`elements/document/nuxeo-document-import.js`** (3 sites) | The cloned `docData.document` is mutated in place by the widgets of a **runtime-resolved** `nuxeo-<type>-import-layout`. Deployments may ship their own import layouts, so the payload cannot be bounded from this repo's code. Here the round-trip's lossy strip is load-bearing: it is what stops a non-cloneable property from aborting the whole import with a `DataCloneError`. |
| **`elements/nuxeo-results/nuxeo-results.js`** (1 site) | `_deepClone` sits on the preference-persistence path behind a `catch` that returns `{}`. A `DataCloneError` would therefore be swallowed and silently persist **empty** preferences, discarding the user's saved column layout instead of surfacing an error. Converting here trades a benign lossy clone for silent data loss. |

### Tests

Each converted site gains a unit test that asserts the **field types** of the cloned payload rather than merely covering the line — ISO timestamps stay strings, booleans stay booleans, `null` survives, nested objects are copied and not aliased, and mutating the copy does not write through to the row backing the table. 8 tests added across 5 suites.

## Test plan

- [x] CI `lint` and `unit-test` green on both PRs.
- [x] Locally, `npm run lint` (`eslint .`) clean on both bases.
- [x] Locally, `npm test` on **lts-2025**: 2785 passed, 1 failed. On **maintenance-3.1.x**: 2785 passed, 1 failed, against a pristine baseline of the same tree at 2777 passed, 1 failed — i.e. **+8 passing tests and no new failure**.
- [x] The one local failure, `nuxeo-search-form > gives the saved searches dropdown an always visible label (WEBUI-489)`, is a **local-environment artifact, not a regression**. It expects `aria-labelledby` on the selectivity input (aligned in `1a5d6ce12`), which the lockfile-pinned `@nuxeo/nuxeo-ui-elements` (`2025.20.0-rc.0` / `3.1.35-rc.0`) does not set — that version still only sets `aria-label`. CI does not hit it because `test.yaml` follows `npm ci` with an *"Ensure latest @nuxeo RC packages"* step that installs the newest common RC over the pin. Confirmed by reproducing the failure on a pristine checkout with no changes applied, and by CI's `unit-test` passing here.
- [ ] Functional smoke (not reachable from unit tests): Cloud Services → edit an OAuth2 consumer / provider / token and save; Search → select a saved search and confirm filters populate; Template rendering → edit and save a template's config and parameters.

## Notes

* Paired PR — the same signed commit is applied to both bases; the branches' diffs are identical apart from the blob hash of `nuxeo-document-import.js`, which differs by one pre-existing comment line between the bases.
* Sonar will keep reporting the four unconverted sites. They are intentional and should be marked *Won't fix* rather than reopened; the reasoning is recorded in-code next to each one.


[WEBUI-2249]: https://hyland.atlassian.net/browse/WEBUI-2249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ