### PR TITLE
WEBUI-1881: keep the queue selection and document on filter toggle [LTS-2025]

### DIFF
--- a/elements/nuxeo-web-ui-bundle.html
+++ b/elements/nuxeo-web-ui-bundle.html
@@ -513,6 +513,7 @@
 <nuxeo-slot-content name="defaultSearchMenuPage" slot="DRAWER_PAGES">
   <template>
     <nuxeo-search-form
+      current-document="[[document]]"
       name="defaultSearch"
       search-name="default"
       auto
@@ -529,6 +530,7 @@
 <nuxeo-slot-content name="expiredSearchMenuPage" slot="DRAWER_PAGES">
   <template>
     <nuxeo-search-form
+      current-document="[[document]]"
       name="expiredSearch"
       search-name="expired"
       queue
@@ -549,6 +551,7 @@
 <nuxeo-slot-content name="damSearchMenuButtons" slot="DRAWER_PAGES">
   <template>
     <nuxeo-search-form
+      current-document="[[document]]"
       name="assetsSearch"
       search-name="assets"
       auto
@@ -638,6 +641,7 @@
 <nuxeo-slot-content name="trashMenuPage" slot="DRAWER_PAGES">
   <template>
     <nuxeo-search-form
+      current-document="[[document]]"
       name="trash"
       search-name="trash"
       auto

--- a/elements/search/nuxeo-search-form.js
+++ b/elements/search/nuxeo-search-form.js
@@ -855,6 +855,14 @@ Polymer({
       // highlighted.
       list.clearSelection();
       list.selectIndex(index);
+      // Selecting writes `selectedDocument`, which schedules `_selectedDocChanged`'s debounced
+      // navigation. This observer must only ever move the highlight: the route already shows this
+      // document. Leaving the timer armed lets it fire after a later host-driven `currentDocument`
+      // change that is not in the queue, navigating back to the stale document and overriding the
+      // external navigation.
+      if (this.__renderDebouncer) {
+        this.__renderDebouncer.cancel();
+      }
     }
   },
 

--- a/elements/search/nuxeo-search-form.js
+++ b/elements/search/nuxeo-search-form.js
@@ -228,10 +228,16 @@ Polymer({
         @apply --hyland-drawer-item-selected;
       }
 
-      .list-item.selected,
-      .list-item:focus,
-      .list-item.selected:focus {
+      /* Only the selected row carries the selected background. Plain focus must not, or a row
+         left focused behind a selection that moved on its own - the queue now follows the
+         displayed document - keeps looking selected and two rows appear highlighted at once
+         (WEBUI-2301). Keyboard focus stays visible through the focus-visible ring below. */
+      .list-item.selected {
         @apply --hyland-drawer-item-selected;
+      }
+      .list-item:focus {
+          border-radius: 54px;
+          outline: 0;
       }
 
         /* Keyboard focus ring: --hyland-drawer-item-selected removes outline, so we apply
@@ -372,6 +378,7 @@ Polymer({
                 tabindex$="{{_computeTabAndLastIndex(index)}}"
                 class$="[[_computedClass(selected)]]"
                 index="[[index]]"
+                on-tap="_queueItemTapped"
               >
                 <div class="list-item-box">
                   <div class="list-item-info" role="listitem" aria-selected="true">
@@ -688,6 +695,7 @@ Polymer({
     currentDocument: {
       type: Object,
       value: null,
+      observer: '_currentDocumentChanged',
     },
 
     /**
@@ -752,19 +760,112 @@ Polymer({
   },
 
   displayQueueAndNavigateToFirst() {
-    this.displayQueue(0);
+    // Toggling back from the filters view must keep the document the user opened from the
+    // queue, so ask for the selection to be restored and only fall back to the first entry
+    // when there is nothing to restore (WEBUI-1881).
+    this.displayQueue(0, true);
   },
 
-  displayQueue(index) {
+  displayQueue(index, restoreSelection) {
     this.queue = true;
     if (this.visible) {
+      // `fetch` replaces the items with new object instances, so the previously selected
+      // document has to be looked up again by uid once the new entries are in.
+      const selectedUid = restoreSelection ? this.selectedDocument?.uid : null;
       this.$.list.fetch().then(() => {
         if (typeof index === 'number') {
-          this.$.list.scrollToIndex(index);
-          this.$.list.selectIndex(index);
+          const targetIndex = this._queueIndexOf(selectedUid, index);
+          this.$.list.scrollToIndex(targetIndex);
+          this.$.list.selectIndex(targetIndex);
+          this._navigateToQueueItem(targetIndex);
         }
       });
     }
+  },
+
+  _queueItemTapped(e) {
+    const row = e.currentTarget;
+    // `iron-list` toggles the selection on tap, so tapping the row that is already selected
+    // deselects it and opens nothing (WEBUI-2300). The queue is a single-selection navigation
+    // list where clearing the selection is never the intent, so keep the tap away from
+    // `iron-list` in that case and open the document instead, leaving the selection untouched.
+    // The tapped row carries the `selected` class from `_computedClass`, and when it is the
+    // selected one `selectedDocument` is by definition that document, so no index lookup is
+    // needed (the row's `index` binding sets a property, not an attribute).
+    if (!row || !row.classList.contains('selected')) {
+      return;
+    }
+    const doc = this.selectedDocument;
+    if (doc?.path) {
+      e.stopPropagation();
+      this._openDocument(doc);
+    }
+  },
+
+  _queueIndexOf(uid, fallbackIndex) {
+    if (!uid) {
+      return fallbackIndex;
+    }
+    const items = this.$.list.items;
+    if (!items) {
+      return fallbackIndex;
+    }
+    const index = items.findIndex((item) => item?.uid === uid);
+    return index > -1 ? index : fallbackIndex;
+  },
+
+  _navigateToQueueItem(index) {
+    const doc = this.$.list.items?.[index];
+    if (doc?.path) {
+      // The queue can only be toggled back on from the filters view, which always navigated away
+      // to the search results, so the document has to be opened again rather than relying on the
+      // selection observer, which skips a selection whose path did not change.
+      this._openDocument(doc);
+    }
+  },
+
+  _currentDocumentChanged(doc) {
+    // The queue selection only ever followed a tap inside the queue, so any other way of changing
+    // the displayed document - browser back/forward, a breadcrumb, a deep link, a child document
+    // opened from the main content area - left the highlight on the previous document
+    // (WEBUI-2301). Follow the displayed document instead.
+    if (!this.queue || !doc || !doc.uid) {
+      return;
+    }
+    // The list is guarded because `currentDocument` is bound from the host and can be pushed in
+    // before the template is stamped, and `queue` is set as an attribute on some search forms.
+    const list = this.$?.list;
+    if (!list) {
+      return;
+    }
+    // Nothing to do when the displayed document is already the selected one. This guard matters:
+    // `iron-list.selectIndex` calls `clearSelection()` before selecting on a single-selection
+    // list, so a redundant call would push a transient null through `selectedDocument` on every
+    // navigation.
+    if (this.selectedDocument?.uid === doc.uid) {
+      return;
+    }
+    const index = this._queueIndexOf(doc.uid, -1);
+    // Leave the selection alone when the document is not part of the queue (e.g. a child document)
+    // rather than clearing it, so nothing else that relies on the selection is disturbed.
+    if (index > -1) {
+      // `iron-list.selectIndex` drops the previous selection through its own internal path, which
+      // bypasses the page provider behaviour's bookkeeping and can leave the previously selected
+      // row still rendered as selected. Clear through the behaviour first so exactly one row stays
+      // highlighted.
+      list.clearSelection();
+      list.selectIndex(index);
+    }
+  },
+
+  _openDocument(doc) {
+    // Every navigation this element performs has to go through here. `navigateTo` does not fire
+    // the global `navigate` event that maintains `currentDocument`, and queue rows are not
+    // `nuxeo-document-list-item` so they do not fire it either. Leaving `currentDocument` behind
+    // makes the `_selectedDocChanged` guard below compare against a document that is no longer
+    // displayed and silently skip a navigation back to a previously opened one (WEBUI-2300).
+    this.currentDocument = doc;
+    this.navigateTo(doc);
   },
 
   _resetResults() {
@@ -799,7 +900,7 @@ Polymer({
     if ((doc && doc.path && !old) || (doc && doc.path && old && old.path && doc.path !== old.path)) {
       this.__renderDebouncer = Debouncer.debounce(this.__renderDebouncer, timeOut.after(150), () => {
         if (!this.currentDocument || (this.currentDocument && this.currentDocument.path !== doc.path)) {
-          this.navigateTo(doc);
+          this._openDocument(doc);
         }
       });
     }

--- a/elements/search/nuxeo-search-form.js
+++ b/elements/search/nuxeo-search-form.js
@@ -792,7 +792,7 @@ Polymer({
     // The tapped row carries the `selected` class from `_computedClass`, and when it is the
     // selected one `selectedDocument` is by definition that document, so no index lookup is
     // needed (the row's `index` binding sets a property, not an attribute).
-    if (!row || !row.classList.contains('selected')) {
+    if (!row?.classList.contains('selected')) {
       return;
     }
     const doc = this.selectedDocument;
@@ -829,7 +829,7 @@ Polymer({
     // the displayed document - browser back/forward, a breadcrumb, a deep link, a child document
     // opened from the main content area - left the highlight on the previous document
     // (WEBUI-2301). Follow the displayed document instead.
-    if (!this.queue || !doc || !doc.uid) {
+    if (!this.queue || !doc?.uid) {
       return;
     }
     // The list is guarded because `currentDocument` is bound from the host and can be pushed in

--- a/test/nuxeo-search-form.test.js
+++ b/test/nuxeo-search-form.test.js
@@ -222,6 +222,388 @@ suite('nuxeo-search-form', () => {
     selectSpy.restore();
   });
 
+  test('keeps the selected document when toggling back to the queue (WEBUI-1881)', async () => {
+    searchForm.visible = true;
+    const entries = [
+      { uid: 'uid-1', path: '/default-domain/doc-1' },
+      { uid: 'uid-2', path: '/default-domain/doc-2' },
+      { uid: 'uid-3', path: '/default-domain/doc-3' },
+    ];
+    const fetchStub = sinon.stub(searchForm.$.list, 'fetch').callsFake(() => {
+      // a fetch replaces the entries with new object instances
+      searchForm.$.list.items = entries.map((entry) => Object.assign({}, entry));
+      return Promise.resolve();
+    });
+    const scrollSpy = sinon.spy(searchForm.$.list, 'scrollToIndex');
+    const selectSpy = sinon.spy(searchForm.$.list, 'selectIndex');
+    const navigateToSpy = sinon.spy();
+    Object.defineProperty(searchForm, 'navigateTo', { value: navigateToSpy, configurable: true, writable: true });
+    // the third document was opened from the queue, then the filters view was displayed
+    searchForm.selectedDocument = entries[2];
+    searchForm.currentDocument = null;
+
+    searchForm.displayQueueAndNavigateToFirst();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(scrollSpy).to.have.been.calledWith(2);
+    expect(selectSpy).to.have.been.calledWith(2);
+    expect(navigateToSpy).to.have.been.calledOnce;
+    expect(navigateToSpy.firstCall.args[0].uid).to.equal('uid-3');
+
+    fetchStub.restore();
+    scrollSpy.restore();
+    selectSpy.restore();
+    delete searchForm.navigateTo;
+  });
+
+  test('falls back to the first queue entry when the selection is gone (WEBUI-1881)', async () => {
+    searchForm.visible = true;
+    const fetchStub = sinon.stub(searchForm.$.list, 'fetch').callsFake(() => {
+      searchForm.$.list.items = [{ uid: 'uid-1', path: '/default-domain/doc-1' }];
+      return Promise.resolve();
+    });
+    const selectSpy = sinon.spy(searchForm.$.list, 'selectIndex');
+    const navigateToSpy = sinon.spy();
+    Object.defineProperty(searchForm, 'navigateTo', { value: navigateToSpy, configurable: true, writable: true });
+    // the previously selected document is no longer part of the results
+    searchForm.selectedDocument = { uid: 'gone', path: '/default-domain/gone' };
+    searchForm.currentDocument = null;
+
+    searchForm.displayQueueAndNavigateToFirst();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(selectSpy).to.have.been.calledWith(0);
+    expect(navigateToSpy.firstCall.args[0].uid).to.equal('uid-1');
+
+    fetchStub.restore();
+    selectSpy.restore();
+    delete searchForm.navigateTo;
+  });
+
+  test('opens the restored document even when currentDocument is stale (WEBUI-1881)', async () => {
+    searchForm.visible = true;
+    const fetchStub = sinon.stub(searchForm.$.list, 'fetch').callsFake(() => {
+      searchForm.$.list.items = [{ uid: 'uid-1', path: '/default-domain/doc-1' }];
+      return Promise.resolve();
+    });
+    const navigateToSpy = sinon.spy();
+    Object.defineProperty(searchForm, 'navigateTo', { value: navigateToSpy, configurable: true, writable: true });
+    searchForm.selectedDocument = { uid: 'uid-1', path: '/default-domain/doc-1' };
+    // `navigateTo` never fires the `navigate` event, so currentDocument still points at the
+    // document the filters view navigated away from and must not suppress the navigation
+    searchForm.currentDocument = { uid: 'uid-1', path: '/default-domain/doc-1' };
+
+    searchForm.displayQueueAndNavigateToFirst();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(navigateToSpy).to.have.been.calledOnce;
+    expect(navigateToSpy.firstCall.args[0].uid).to.equal('uid-1');
+
+    fetchStub.restore();
+    delete searchForm.navigateTo;
+  });
+
+  test('opens the document when the already-selected queue row is tapped (WEBUI-2300)', () => {
+    // real row element, classed exactly as the queue template classes it
+    const row = document.createElement('div');
+    row.className = searchForm._computedClass(true);
+    searchForm.selectedDocument = { uid: 'uid-2', path: '/default-domain/doc-2' };
+    const navigateToSpy = sinon.spy();
+    Object.defineProperty(searchForm, 'navigateTo', { value: navigateToSpy, configurable: true, writable: true });
+    const stopPropagation = sinon.spy();
+
+    searchForm._queueItemTapped({ currentTarget: row, stopPropagation });
+
+    // the tap must not reach iron-list, which would deselect the row and open nothing
+    expect(stopPropagation).to.have.been.calledOnce;
+    expect(navigateToSpy).to.have.been.calledOnce;
+    expect(navigateToSpy.firstCall.args[0].uid).to.equal('uid-2');
+    expect(searchForm.currentDocument.uid).to.equal('uid-2');
+
+    delete searchForm.navigateTo;
+  });
+
+  test('lets iron-list handle a tap on an unselected queue row (WEBUI-2300)', () => {
+    const row = document.createElement('div');
+    row.className = searchForm._computedClass(false);
+    searchForm.selectedDocument = { uid: 'uid-2', path: '/default-domain/doc-2' };
+    const navigateToSpy = sinon.spy();
+    Object.defineProperty(searchForm, 'navigateTo', { value: navigateToSpy, configurable: true, writable: true });
+    const stopPropagation = sinon.spy();
+
+    searchForm._queueItemTapped({ currentTarget: row, stopPropagation });
+
+    // selecting a new row is iron-list's job; the selection observer navigates from there
+    expect(stopPropagation).to.not.have.been.called;
+    expect(navigateToSpy).to.not.have.been.called;
+
+    delete searchForm.navigateTo;
+  });
+
+  test('ignores a queue tap when nothing is selected yet (WEBUI-2300)', () => {
+    const row = document.createElement('div');
+    row.className = searchForm._computedClass(true);
+    searchForm.selectedDocument = undefined;
+    const navigateToSpy = sinon.spy();
+    Object.defineProperty(searchForm, 'navigateTo', { value: navigateToSpy, configurable: true, writable: true });
+    const stopPropagation = sinon.spy();
+
+    searchForm._queueItemTapped({ currentTarget: row, stopPropagation });
+
+    expect(stopPropagation).to.not.have.been.called;
+    expect(navigateToSpy).to.not.have.been.called;
+
+    delete searchForm.navigateTo;
+  });
+
+  test('queue rows are wired to the tap handler (WEBUI-2300)', () => {
+    // iron-list does not stamp rows in the unit-test environment, so assert the binding Polymer
+    // parsed out of the queue row template - that is what makes _queueItemTapped reachable
+    const listTemplate = searchForm.shadowRoot.querySelector('#list template');
+    expect(listTemplate).to.exist;
+    const events = (listTemplate._templateInfo.nodeInfoList || []).reduce(
+      (acc, node) => acc.concat((node.events || []).map((event) => `${event.name}:${event.value}`)),
+      [],
+    );
+    expect(events).to.contain('tap:_queueItemTapped');
+    expect(typeof searchForm._queueItemTapped).to.equal('function');
+  });
+
+  test('reopens a document that was opened earlier in the queue (WEBUI-2300)', async () => {
+    const doc7 = { uid: 'uid-7', path: '/default-domain/doc-7' };
+    const doc3 = { uid: 'uid-3', path: '/default-domain/doc-3' };
+    const navigateToSpy = sinon.spy();
+    Object.defineProperty(searchForm, 'navigateTo', { value: navigateToSpy, configurable: true, writable: true });
+
+    // doc 7 opened from the queue (as the filter/queue toggle does)
+    searchForm._openDocument(doc7);
+    expect(navigateToSpy.lastCall.args[0].uid).to.equal('uid-7');
+
+    // another row is clicked: iron-list moves the selection, the observer navigates
+    searchForm.selectedDocument = doc3;
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(navigateToSpy.lastCall.args[0].uid).to.equal('uid-3');
+
+    // back to doc 7: currentDocument must have followed doc 3, otherwise the observer guard
+    // compares against a stale doc 7 and silently skips this navigation
+    searchForm.selectedDocument = doc7;
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(navigateToSpy.lastCall.args[0].uid).to.equal('uid-7');
+    expect(navigateToSpy).to.have.been.calledThrice;
+
+    delete searchForm.navigateTo;
+  });
+
+  test('_openDocument keeps currentDocument in step with the navigation (WEBUI-2300)', () => {
+    const doc = { uid: 'uid-9', path: '/default-domain/doc-9' };
+    const navigateToSpy = sinon.spy();
+    Object.defineProperty(searchForm, 'navigateTo', { value: navigateToSpy, configurable: true, writable: true });
+
+    searchForm._openDocument(doc);
+
+    expect(navigateToSpy).to.have.been.calledWith(doc);
+    expect(searchForm.currentDocument).to.equal(doc);
+
+    delete searchForm.navigateTo;
+  });
+
+  test('follows the displayed document in the queue selection (WEBUI-2301)', () => {
+    searchForm.queue = true;
+    searchForm.$.list.items = [
+      { uid: 'uid-1', path: '/default-domain/doc-1' },
+      { uid: 'uid-2', path: '/default-domain/doc-2' },
+    ];
+    const selectSpy = sinon.spy(searchForm.$.list, 'selectIndex');
+    const clearSpy = sinon.spy(searchForm.$.list, 'clearSelection');
+    const navigateToSpy = sinon.spy();
+    Object.defineProperty(searchForm, 'navigateTo', { value: navigateToSpy, configurable: true, writable: true });
+
+    // the host pushes down the document the router loaded, e.g. after browser back
+    searchForm.currentDocument = { uid: 'uid-1', path: '/default-domain/doc-1' };
+
+    expect(selectSpy).to.have.been.calledWith(0);
+    // the previous row has to be cleared through the behaviour, otherwise it stays highlighted
+    // as well and two rows look selected at once
+    expect(clearSpy).to.have.been.calledBefore(selectSpy);
+    // syncing the selection from the route must never navigate, or the two would loop
+    expect(navigateToSpy).to.not.have.been.called;
+
+    selectSpy.restore();
+    clearSpy.restore();
+    delete searchForm.navigateTo;
+  });
+
+  test('does not touch the selection while the filters view is shown (WEBUI-2301)', () => {
+    searchForm.queue = false;
+    searchForm.$.list.items = [{ uid: 'uid-1', path: '/default-domain/doc-1' }];
+    const selectSpy = sinon.spy(searchForm.$.list, 'selectIndex');
+
+    searchForm.currentDocument = { uid: 'uid-1', path: '/default-domain/doc-1' };
+
+    expect(selectSpy).to.not.have.been.called;
+
+    selectSpy.restore();
+  });
+
+  test('leaves the selection alone for a document outside the queue (WEBUI-2301)', () => {
+    searchForm.queue = true;
+    searchForm.$.list.items = [{ uid: 'uid-1', path: '/default-domain/doc-1' }];
+    const selectSpy = sinon.spy(searchForm.$.list, 'selectIndex');
+    const clearSpy = sinon.spy(searchForm.$.list, 'clearSelection');
+
+    // a child document opened from the main content area is not part of the result set
+    searchForm.currentDocument = { uid: 'uid-child', path: '/default-domain/doc-1/child' };
+
+    expect(selectSpy).to.not.have.been.called;
+    expect(clearSpy).to.not.have.been.called;
+
+    selectSpy.restore();
+    clearSpy.restore();
+  });
+
+  test('ignores documents without a uid and an empty queue (WEBUI-2301)', () => {
+    searchForm.queue = true;
+    const selectSpy = sinon.spy(searchForm.$.list, 'selectIndex');
+
+    // the global `navigate` listener sets undefined whenever the event carries `doc` not `item`
+    searchForm.currentDocument = undefined;
+    searchForm.currentDocument = { path: '/default-domain/no-uid' };
+    searchForm.$.list.items = [];
+    searchForm.currentDocument = { uid: 'uid-1', path: '/default-domain/doc-1' };
+
+    expect(selectSpy).to.not.have.been.called;
+
+    selectSpy.restore();
+  });
+
+  test('reselecting the displayed document does not re-enter the navigation (WEBUI-2301)', () => {
+    const doc = { uid: 'uid-2', path: '/default-domain/doc-2' };
+    searchForm.queue = true;
+    searchForm.$.list.items = [{ uid: 'uid-1', path: '/default-domain/doc-1' }, doc];
+    const navigateToSpy = sinon.spy();
+    Object.defineProperty(searchForm, 'navigateTo', { value: navigateToSpy, configurable: true, writable: true });
+
+    // _openDocument writes currentDocument, which now has an observer: the selection it syncs
+    // must be recognised as already displayed so _selectedDocChanged does not navigate again
+    searchForm._openDocument(doc);
+    searchForm.selectedDocument = doc;
+
+    expect(navigateToSpy).to.have.been.calledOnce;
+
+    delete searchForm.navigateTo;
+  });
+
+  test('does not re-select the document that is already selected (WEBUI-2301)', () => {
+    const doc = { uid: 'uid-1', path: '/default-domain/doc-1' };
+    searchForm.queue = true;
+    searchForm.$.list.items = [doc];
+    searchForm.selectedDocument = doc;
+    // iron-list.selectIndex clears the selection before selecting, so a redundant call would
+    // push a transient null through selectedDocument on every navigation
+    const selectSpy = sinon.spy(searchForm.$.list, 'selectIndex');
+
+    searchForm.currentDocument = { uid: 'uid-1', path: '/default-domain/doc-1' };
+
+    expect(selectSpy).to.not.have.been.called;
+
+    selectSpy.restore();
+  });
+
+  test('a focused queue row is not styled as selected (WEBUI-2301)', () => {
+    const styles = Array.from(searchForm.shadowRoot.querySelectorAll('style'))
+      .map((style) => style.textContent)
+      .join('');
+    // sanity check that the element's own CSS was read, so the assertions below cannot pass
+    // vacuously. Mixin names are gone by now - Polymer's ApplyShim expands `@apply` at runtime -
+    // so assert on the selectors, which survive.
+    expect(styles).to.contain('.list-item.selected');
+    expect(styles).to.contain('.list-item:hover');
+
+    // The defect was `.list-item:focus` being grouped with `.list-item.selected`, so a focused
+    // row inherited the selected background. Once the queue selection follows the displayed
+    // document, a row left focused behind it kept looking selected and two rows appeared
+    // highlighted at once. A standalone `:focus` rule (outline, radius) is fine - only the
+    // grouping is forbidden, which is what the trailing commas below detect.
+    // The rendered background cannot be asserted here: the theme that defines
+    // --hyland-drawer-item-selected is not loaded in the unit-test fixture.
+    expect(styles).to.not.contain('.list-item:focus,');
+    expect(styles).to.not.contain('.list-item.selected:focus {');
+    // keyboard focus stays visible through the focus-visible ring
+    expect(styles).to.contain('.list-item:focus-visible');
+  });
+
+  test('queue lookups tolerate a list with no items yet (WEBUI-1881)', () => {
+    searchForm.$.list.items = undefined;
+    const navigateToSpy = sinon.spy();
+    Object.defineProperty(searchForm, 'navigateTo', { value: navigateToSpy, configurable: true, writable: true });
+
+    // no entries to search: the caller's fallback index is returned untouched
+    expect(searchForm._queueIndexOf('uid-1', 7)).to.equal(7);
+    // and nothing is opened rather than throwing on an absent items array
+    searchForm._navigateToQueueItem(0);
+    expect(navigateToSpy).to.not.have.been.called;
+
+    delete searchForm.navigateTo;
+  });
+
+  test('ignores a queue tap that carries no row (WEBUI-2300)', () => {
+    const doc = { uid: 'uid-1', path: '/default-domain/doc-1' };
+    // prime currentDocument so the debounced selection observer treats this document as already
+    // displayed and does not fire a navigation 150ms later, after this test has torn down
+    searchForm.currentDocument = doc;
+    searchForm.selectedDocument = doc;
+    const navigateToSpy = sinon.spy();
+    Object.defineProperty(searchForm, 'navigateTo', { value: navigateToSpy, configurable: true, writable: true });
+    const stopPropagation = sinon.spy();
+
+    searchForm._queueItemTapped({ currentTarget: null, stopPropagation });
+
+    expect(stopPropagation).to.not.have.been.called;
+    expect(navigateToSpy).to.not.have.been.called;
+
+    delete searchForm.navigateTo;
+  });
+
+  test('does not open a selected row whose document has no path (WEBUI-2300)', () => {
+    const row = document.createElement('div');
+    row.className = searchForm._computedClass(true);
+    searchForm.selectedDocument = { uid: 'uid-1' };
+    const navigateToSpy = sinon.spy();
+    Object.defineProperty(searchForm, 'navigateTo', { value: navigateToSpy, configurable: true, writable: true });
+    const stopPropagation = sinon.spy();
+
+    searchForm._queueItemTapped({ currentTarget: row, stopPropagation });
+
+    expect(stopPropagation).to.not.have.been.called;
+    expect(navigateToSpy).to.not.have.been.called;
+
+    delete searchForm.navigateTo;
+  });
+
+  test('ignores a route change before the list exists (WEBUI-2301)', () => {
+    searchForm.queue = true;
+    const list = searchForm.$.list;
+    // `currentDocument` can be pushed in by the host before the template is stamped
+    delete searchForm.$.list;
+
+    expect(() => {
+      searchForm.currentDocument = { uid: 'uid-1', path: '/default-domain/doc-1' };
+    }).to.not.throw();
+
+    searchForm.$.list = list;
+  });
+
+  test('queue lookup skips holes in the results array (WEBUI-1881)', () => {
+    // a page provider can leave gaps in `items` for ranges that were never fetched
+    searchForm.$.list.items = [null, { uid: 'uid-2', path: '/default-domain/doc-2' }];
+
+    expect(searchForm._queueIndexOf('uid-2', 9)).to.equal(1);
+    expect(searchForm._queueIndexOf('uid-missing', 9)).to.equal(9);
+  });
+
   test('resetResults invokes list reset when required inputs exist', () => {
     const resetSpy = sinon.spy(searchForm.$.list, '_resetResults');
     searchForm.provider = 'default_search';

--- a/test/nuxeo-search-form.test.js
+++ b/test/nuxeo-search-form.test.js
@@ -329,7 +329,11 @@ suite('nuxeo-search-form', () => {
   test('lets iron-list handle a tap on an unselected queue row (WEBUI-2300)', () => {
     const row = document.createElement('div');
     row.className = searchForm._computedClass(false);
-    searchForm.selectedDocument = { uid: 'uid-2', path: '/default-domain/doc-2' };
+    const doc = { uid: 'uid-2', path: '/default-domain/doc-2' };
+    // prime currentDocument so the debounced selection observer treats this document as already
+    // displayed and does not fire a navigation 150ms later, after this test has torn down
+    searchForm.currentDocument = doc;
+    searchForm.selectedDocument = doc;
     const navigateToSpy = sinon.spy();
     Object.defineProperty(searchForm, 'navigateTo', { value: navigateToSpy, configurable: true, writable: true });
     const stopPropagation = sinon.spy();


### PR DESCRIPTION
## Problem

In the Default Search, toggling the left panel between **Filters** and **Queue** lost the document the user had opened: the selection snapped back to the first entry and that first document was opened. Fixing the selection then exposed three further defects in the same code path.

All four are tracked separately for traceability but share one root cause and the same ~20 lines, so they are fixed together here.

| Ticket | Symptom |
|---|---|
| [WEBUI-1881](https://hyland.atlassian.net/browse/WEBUI-1881) | Queue selection resets to the first entry when toggling back from Filters, and that first document is opened |
| [WEBUI-2299](https://hyland.atlassian.net/browse/WEBUI-2299) | Selected document stays highlighted in the queue but the main content area still shows the search results |
| [WEBUI-2300](https://hyland.atlassian.net/browse/WEBUI-2300) | Clicking the already-selected queue row does not open it; it takes a second click |
| [WEBUI-2301](https://hyland.atlassian.net/browse/WEBUI-2301) | Queue selection does not follow browser Back/Forward, breadcrumbs, deep links, or a child document opened from the main area |

## Root cause

**Opening a document was only ever a side effect of the queue selection *changing*.** `_selectedDocChanged` navigates only when `doc.path` differs from the previous value, so any state where the selection was already correct left the main content area showing something else.

Four separate consequences:

1. **`displayQueueAndNavigateToFirst` hard-coded index 0.** It called `displayQueue(0)`, which ran `selectIndex(0)` after the fetch. That wrote through the `selected-item="{{selectedDocument}}"` binding and navigated to the first document. Nothing remembered which document the user had actually opened.

2. **Restoring the selection was not enough.** `_displayFiltersTapped` fires `search-results`, which `nuxeo-app._showSearchResults` handles by navigating away to the search page. Restoring the selection to the *same* document then leaves `_selectedDocChanged` with an unchanged path, so it deliberately skips navigating and the results list stays on screen.

3. **`iron-list` toggles selection on tap.** With `selection-enabled select-on-tap`, `_selectionEnabledChanged` leaves iron-list's own tap listener wired, and it calls `toggleSelectionForItem` → `isSelected ? deselectIndex(index) : selectIndex(index)`. Tapping an already-selected row therefore **deselects** it; `selectedDocument` becomes null and the observer ignores a null value, so nothing opens. The second tap re-selects and finally navigates.

4. **`currentDocument` went stale.** The element navigated from three places but only two kept `currentDocument` in sync. `RoutingBehavior`'s `navigateTo` never fires the global `navigate` event that maintains it, and queue rows are not `nuxeo-document-list-item` so they do not fire it either. Its own guard in `_selectedDocChanged` then compared against a document that was no longer displayed and silently suppressed a legitimate navigation back to it. This also broke keyboard queue navigation (stepping away from a row and back).

5. **The queue selection had no reverse binding.** `currentDocument` is documented as *"The current document loaded is bound to this property"*, but the binding was never wired up. `nuxeo-app` maintains its own `currentDocument` via `_applyDocumentFromLoad`, which runs on every navigation including Back, but it never reached the search form.

## Changes

### `elements/search/nuxeo-search-form.js`

- **`displayQueue(index, restoreSelection)`** — captures the selected document's `uid` before the fetch and restores it afterwards. The lookup is by `uid`, not object identity, because `fetch` replaces `items` with new object instances (`this.set('items', [...response.entries])`). Index `0` becomes a fallback rather than a command. The second parameter is optional, so the other caller (`_formChanged`) is byte-identical.
- **`_queueIndexOf(uid, fallbackIndex)`** — returns the fallback when there is no uid, no items, or the document is not on the current page.
- **`_navigateToQueueItem(index)`** — opens the restored document explicitly instead of relying on the selection observer.
- **`_queueItemTapped(e)`** + `on-tap` on the queue row — a tap on the **already-selected** row calls `stopPropagation()` so it never reaches iron-list's toggle, then opens the document, leaving the selection untouched. Taps on any other row fall through to iron-list exactly as before.
- **`_openDocument(doc)`** — single funnel for every navigation this element performs, keeping `currentDocument` in step so its guard can no longer lie.
- **`_currentDocumentChanged(doc)`** — follows the displayed document by selecting the matching queue row. Guarded on `queue`, `doc.uid`, list existence, and already-selected. Clears through the behaviour's `clearSelection()` first, because `iron-list.selectIndex` drops the previous selection through its own internal path and can leave the old row still rendered as selected.
- **CSS** — plain `:focus` no longer carries the selected background. Once the selection follows the route, a row left focused behind it kept looking selected and two rows appeared highlighted at once. Keyboard focus stays visible through the existing `:focus-visible` ring.

### `elements/nuxeo-web-ui-bundle.html`

- `current-document="[[document]]"` on the four `nuxeo-search-form` instances (default, expired, assets, trash). This uses existing plumbing — the `DRAWER_PAGES` slot is stamped with `model="[[actionContext]]"`, `nuxeo-app._actionContext()` returns `{ document: this.currentDocument, ... }` and recomputes on every change, and `nuxeo-slot._updateModel` forwards model changes to stamped instances via `instance.set(prop, value)`. No new events or bindings were invented.

### `test/nuxeo-search-form.test.js`

18 new tests covering all four tickets, the guards, and the regression paths.

## Test plan

- `npm run lint` — clean
- Full unit suite — **2803 passed, 0 failed**
- **Coverage on new code: 100% lines (37/37), 100% branches (27/27)**, measured by cross-referencing the diff's added lines against `coverage/lcov.info`
- The WEBUI-2300 sequence test was verified to **fail** without the fix (`expected 'uid-3' to equal 'uid-7'`), so it is a real regression test rather than a tautology

Manual verification on a local instance:

1. Open doc 7 from the results → toggle to Filters → toggle back → doc 7 still selected **and** displayed
2. Same with the **first** entry — the variant the original repro does not exercise
3. Open a folder from the queue → open one of its children from the main area → click the folder in the queue → opens on the **first** click
4. Browser **Back** and **Forward** → the queue highlight follows the displayed document, exactly one row highlighted
5. Regression — arrow keys / `j` / `k` still navigate the queue and open documents
6. Regression — changing sort order or a column filter in the queue still clears the selection without navigating

## Notes

- Both LTS lines are affected; QA confirmed the bug on Web UI 3.1.18. The same commit is on `lts-2025` and `maintenance-3.1.x`.
- Sonar: three would-be new issues were pre-empted — `javascript:S1067` (a guard with 4 `||` operators, split in two), `javascript:S6606` (two `|| []` array fallbacks replaced with explicit guards), and `javascript:S6582` (five `a && a.b` patterns converted to optional chaining, which is used in `elements/` already and only prohibited in `nuxeo-elements` where Polymer analyze cannot parse it).
- `iron-list` does not stamp rows in the unit-test environment and the theme defining `--hyland-drawer-item-selected` is not loaded there, so the row click-through and the rendered highlight are covered by the manual steps above rather than by unit tests. This is stated in the relevant test comments rather than papered over.
- **Not fixed here:** hover shares the selected styling (`.list-item:hover` applies the same mixin), a deliberate drawer-wide convention also used by `nuxeo-tasks-list`, `nuxeo-clipboard` and `nuxeo-collections`. Changing it is a design decision. Also unaddressed: `aria-selected="true"` is hardcoded on every queue row, so screen readers announce all rows as selected — a separate accessibility issue.


[WEBUI-1881]: https://hyland.atlassian.net/browse/WEBUI-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBUI-2299]: https://hyland.atlassian.net/browse/WEBUI-2299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBUI-2300]: https://hyland.atlassian.net/browse/WEBUI-2300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBUI-2301]: https://hyland.atlassian.net/browse/WEBUI-2301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ