### PR TITLE
WEBUI-2246: Convert the falsy guards that are safe to convert to optional chaining [maintenance-3.1.x]

### DIFF
--- a/addons/amazon-s3-online-storage/index.js
+++ b/addons/amazon-s3-online-storage/index.js
@@ -164,7 +164,7 @@ class S3Provider {
   }
 
   _refreshBatchInfo() {
-    if (!this._currentCredentials || !this._currentCredentials.expiration) {
+    if (!this._currentCredentials?.expiration) {
       return Promise.resolve();
     }
     if (new Date() < this._currentCredentials.expiration) {
@@ -274,12 +274,6 @@ UploaderBehavior.registerProvider('s3', S3Provider);
 
 // if S3 direct upload is enabled set it as default upload provider
 // config values from configuration service are strings
-if (
-  Nuxeo &&
-  Nuxeo.UI &&
-  Nuxeo.UI.config &&
-  Nuxeo.UI.config.s3 &&
-  String(Nuxeo.UI.config.s3.useDirectUpload) === 'true'
-) {
+if (Nuxeo?.UI?.config?.s3 && String(Nuxeo.UI.config.s3.useDirectUpload) === 'true') {
   UploaderBehavior.defaultProvider = 's3';
 }

--- a/addons/easyshare/elements/nuxeo-easyshare-share-link.js
+++ b/addons/easyshare/elements/nuxeo-easyshare-share-link.js
@@ -147,7 +147,7 @@ Polymer({
   },
 
   _isEasyshare(document) {
-    return document && document.type === 'EasyShareFolder';
+    return document?.type === 'EasyShareFolder';
   },
 
   _buildPermalink(document) {
@@ -168,12 +168,7 @@ Polymer({
     const link = shareButton.previousElementSibling;
 
     const otherShareButton = shareButton.id === 'easyShareIcon' ? this.$.permalinkIcon : this.$$('#easyShareIcon');
-    if (
-      otherShareButton &&
-      otherShareButton.display !== 'none' &&
-      otherShareButton._debouncer &&
-      otherShareButton._debouncer.isActive()
-    ) {
+    if (otherShareButton && otherShareButton.display !== 'none' && otherShareButton._debouncer?.isActive()) {
       otherShareButton._debouncer = otherShareButton._debouncer.flush();
     }
 

--- a/addons/easyshare/test/nuxeo-easyshare-share-link.test.js
+++ b/addons/easyshare/test/nuxeo-easyshare-share-link.test.js
@@ -1,0 +1,125 @@
+/**
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { fixture, flush, html, login } from '@nuxeo/testing-helpers';
+import '../elements/nuxeo-easyshare-share-link.js';
+
+suite('nuxeo-easyshare-share-link', () => {
+  let server;
+  let element;
+
+  // `_copyLink` only reads `currentTarget`, its previous sibling and a couple of DOM APIs,
+  // so a stand-in avoids stamping the whole dialog.
+  const fakeShareButton = (id) => {
+    return {
+      id,
+      previousElementSibling: {
+        $: {
+          paperInput: {
+            $: { nativeInput: { select: sinon.spy(), setSelectionRange: sinon.spy() } },
+            blur: sinon.spy(),
+          },
+        },
+      },
+      classList: { add: sinon.spy(), remove: sinon.spy() },
+      set: sinon.spy(),
+    };
+  };
+
+  setup(async () => {
+    server = await login();
+    element = await fixture(html`<nuxeo-easyshare-share-link></nuxeo-easyshare-share-link>`);
+    await flush();
+    sinon.stub(element, 'notify');
+  });
+
+  teardown(() => {
+    server.restore();
+  });
+
+  suite('_isEasyshare', () => {
+    test('should return true for an EasyShareFolder', () => {
+      expect(element._isEasyshare({ type: 'EasyShareFolder' })).to.be.true;
+    });
+
+    test('should return false for any other document type', () => {
+      expect(element._isEasyshare({ type: 'File' })).to.be.false;
+    });
+
+    test('should return false when there is no document', () => {
+      expect(element._isEasyshare(null)).to.be.false;
+      expect(element._isEasyshare(undefined)).to.be.false;
+    });
+  });
+
+  suite('_copyLink', () => {
+    setup(() => {
+      sinon.stub(window.document, 'execCommand').returns(true);
+    });
+
+    teardown(() => {
+      window.document.execCommand.restore();
+    });
+
+    test('should select the link and mark the button as copied', () => {
+      const shareButton = fakeShareButton('permalinkIcon');
+      element._copyLink({ currentTarget: shareButton });
+
+      expect(shareButton.previousElementSibling.$.paperInput.$.nativeInput.select).to.have.been.calledOnce;
+      expect(shareButton.set).to.have.been.calledWith('icon', 'check');
+      expect(shareButton.classList.add).to.have.been.calledWith('selected');
+      expect(element.notify).to.have.been.calledOnce;
+
+      shareButton._debouncer.flush();
+    });
+
+    test('should leave the other share button alone when it has no pending debouncer', () => {
+      const other = element.$.permalinkIcon;
+      expect(other._debouncer).to.not.be.ok;
+
+      const shareButton = fakeShareButton('easyShareIcon');
+      element._copyLink({ currentTarget: shareButton });
+
+      expect(other._debouncer).to.not.be.ok;
+      shareButton._debouncer.flush();
+    });
+
+    test('should flush a pending debouncer on the other share button', () => {
+      const other = element.$.permalinkIcon;
+      const flushSpy = sinon.spy();
+      other._debouncer = { isActive: () => true, flush: flushSpy };
+
+      const shareButton = fakeShareButton('easyShareIcon');
+      element._copyLink({ currentTarget: shareButton });
+
+      expect(flushSpy).to.have.been.calledOnce;
+      expect(other._debouncer).to.be.undefined;
+      shareButton._debouncer.flush();
+    });
+
+    test('should bail out when the copy command fails', () => {
+      window.document.execCommand.returns(false);
+      const shareButton = fakeShareButton('permalinkIcon');
+
+      element._copyLink({ currentTarget: shareButton });
+
+      expect(shareButton.set).to.not.have.been.called;
+      expect(element.notify).to.not.have.been.called;
+      expect(shareButton._debouncer).to.be.undefined;
+    });
+  });
+});

--- a/addons/nuxeo-csv/elements/nuxeo-document-import-csv.js
+++ b/addons/nuxeo-csv/elements/nuxeo-document-import-csv.js
@@ -565,7 +565,7 @@ Polymer({
 
   _observeFiles(changeRecord) {
     if (changeRecord) {
-      if (changeRecord.path === 'files.splices' && changeRecord.value && changeRecord.value.indexSplices) {
+      if (changeRecord.path === 'files.splices' && changeRecord.value?.indexSplices) {
         if (this.files && this.files.length > 0) {
           [this.file] = this.files;
           this.hasFile = true;

--- a/addons/nuxeo-platform-3d/elements/nuxeo-3d-viewer.js
+++ b/addons/nuxeo-platform-3d/elements/nuxeo-3d-viewer.js
@@ -319,7 +319,7 @@ Polymer({
   _processLoad(data) {
     const object = data.scene;
 
-    if (data.cameras && data.cameras.length) {
+    if (data.cameras?.length) {
       for (let i = 0; i < data.cameras.length; i++) {
         const dataCamera = data.cameras[i];
         const cameraName = dataCamera.parent.name;
@@ -327,7 +327,7 @@ Polymer({
       }
     }
 
-    if (data.animations && data.animations.length) {
+    if (data.animations?.length) {
       for (let i = 0; i < data.animations.length; i++) {
         const animation = data.animations[i];
         animation.loop = true;
@@ -370,7 +370,7 @@ Polymer({
         obj.geometry.verticesNeedUpdate = true;
         obj.geometry.normalsNeedUpdate = true;
       }
-      if (obj.material && obj.material.bumpMap) {
+      if (obj.material?.bumpMap) {
         obj.material.bumpScale = scale;
       }
     };

--- a/addons/nuxeo-spreadsheet/app/app.js
+++ b/addons/nuxeo-spreadsheet/app/app.js
@@ -39,7 +39,7 @@ function setupUI() {
   log = new Log($('#console'));
 
   $('#close').click(() => {
-    if (window.parent.jQuery && window.parent.jQuery.fancybox) {
+    if (window.parent.jQuery?.fancybox) {
       window.parent.jQuery.fancybox.close();
     }
   });
@@ -100,7 +100,7 @@ function run({ baseURL = '/nuxeo', resultColumns, pageProviderName, queryParamet
 
   return nx.connect().then(() => {
     // Setup the language
-    const language = (navigator.language && navigator.language.slice(0, 2)) || 'en';
+    const language = navigator.language?.slice(0, 2) || 'en';
 
     // default columns
     if (!resultColumns || resultColumns.length === 0) {

--- a/addons/nuxeo-spreadsheet/app/lib/select2-editor.js
+++ b/addons/nuxeo-spreadsheet/app/lib/select2-editor.js
@@ -116,7 +116,7 @@ Select2Editor.prototype.open = function () {
     'min-width': $(this.TD).width(),
   });
 
-  const isMultiple = !!(this.cellProperties && this.cellProperties.multiple);
+  const isMultiple = !!this.cellProperties?.multiple;
 
   this.TEXTAREA.multiple = isMultiple;
 
@@ -185,7 +185,7 @@ Select2Editor.prototype.open = function () {
 };
 
 Select2Editor.prototype.getSelectionText = function (value) {
-  if (this.cellLabels && this.cellLabels[value]) {
+  if (this.cellLabels?.[value]) {
     return this.cellLabels[value];
   }
   return value || '';

--- a/addons/nuxeo-spreadsheet/app/ui/editors/image.js
+++ b/addons/nuxeo-spreadsheet/app/ui/editors/image.js
@@ -18,7 +18,7 @@ All Hyland product names are registered or unregistered trademarks of Hyland Sof
  */
 
 const ImageRenderer = (instance, td, row, col, prop, value, cellProperties) => {
-  if (value && value.data) {
+  if (value?.data) {
     const img = document.createElement('img');
     img.src = value.data;
     if (cellProperties.width) {

--- a/addons/nuxeo-spreadsheet/app/ui/spreadsheet.js
+++ b/addons/nuxeo-spreadsheet/app/ui/spreadsheet.js
@@ -167,8 +167,8 @@ class Spreadsheet {
   createCell(row) {
     const cell = {};
     const doc = this.getDataAtRow(row);
-    const permissions = doc && doc.contextParameters && doc.contextParameters.permissions;
-    if (permissions && permissions.indexOf('Write') === -1) {
+    const permissions = doc?.contextParameters?.permissions;
+    if (permissions?.indexOf('Write') === -1) {
       cell.readOnly = true;
     }
     return cell;
@@ -307,7 +307,7 @@ class Spreadsheet {
         const formattedLabel = editor.formatter(dataEntry);
         if (!formattedLabel) {
           // resolved || unresolved (when just filled in)
-          const id = (dataEntry.properties && dataEntry.properties.id) || dataEntry;
+          const id = dataEntry.properties?.id || dataEntry;
           const cell = ht.getCellMeta(i, j);
           if (!cell._labels) {
             cell._labels = {};

--- a/addons/nuxeo-wopi/elements/nuxeo-wopi-link.js
+++ b/addons/nuxeo-wopi/elements/nuxeo-wopi-link.js
@@ -53,7 +53,7 @@ Polymer({
   },
 
   _appName() {
-    return this.blob && this.blob.wopi && this.blob.wopi.appName && this.blob.wopi.appName.toLowerCase();
+    return this.blob?.wopi?.appName?.toLowerCase();
   },
 
   _isAvailable() {
@@ -69,7 +69,7 @@ Polymer({
   },
 
   _wopiURL() {
-    const blobInfo = this.blob && this.blob.wopi;
+    const blobInfo = this.blob?.wopi;
     if (!blobInfo) {
       return null;
     }

--- a/elements/nuxeo-document-create-button/nuxeo-document-create-button.js
+++ b/elements/nuxeo-document-create-button/nuxeo-document-create-button.js
@@ -161,13 +161,10 @@ Polymer({
       ) {
         this.$.defaultDoc.get();
       } else {
-        const subtypes =
-          this.parent.contextParameters && this.parent.contextParameters.subtypes
-            ? this.parent.contextParameters.subtypes.map((type) => {
-                type.id = type.type.toLowerCase();
-                return type;
-              })
-            : [];
+        const subtypes = this.parent.contextParameters.subtypes.map((type) => {
+          type.id = type.type.toLowerCase();
+          return type;
+        });
         const filteredSubtypes = [];
         if (this._canCreateIn(this.parent)) {
           subtypes.forEach((type) => {


### PR DESCRIPTION
## Problem

SonarCloud reports **206 open `javascript:S6582`** ("Optional chaining should be preferred") findings on this branch. Jira: [WEBUI-2246](https://hyland.atlassian.net/browse/WEBUI-2246)

The ticket plans a full sweep of all 207 findings across four batches. That plan does not survive contact with the Studio Designer catalog: most of these findings **cannot be converted at all** without silently removing elements that customers design against. This PR closes the 19 that are genuinely safe and records why the other 187 are left open.

## Root cause

`packages/nuxeo-designer-catalog` runs **`polymer-analyzer` 3.2.4** over `elements/elements.js`, `elements/nuxeo-app.js` and `addons/nuxeo-spreadsheet/index.js` to generate the catalog. That version predates ES2020 and cannot parse optional chaining: a file containing `?.` fails to parse, and every element or behavior it declares **disappears from the catalog**. The catalog job still succeeds — no build error, no failing check — the elements are simply absent.

So the blocker is not the runtime semantics of `?.`; it is the analyzer that reads the source.

### The rule this PR applies

**No file reachable from a catalog entry point gains a `?.`** — with reachability measured on the *source* import graph, not on what the analyzer currently reports.

That distinction matters, and getting it wrong is easy. `nuxeo-app.js` already contains 19 `?.` of its own, so the analyzer stops at it, and every file reachable only *through* it is missing from the analyzer's file list. Trusting that list makes those files look untouched by the catalog when they are not. Walking the imports directly, ignoring parse failures, gives a true closure of **142 first-party files**; the analyzer reports far fewer.

Thanks to @copilot for catching this on `nuxeo-mobile-banner.js`. Analysed as its own entry point, that file contributes the element `nuxeo-mobile-banner` on the base branch and **nothing** once converted. It, `elements/performance.js` and `elements/select-all-helpers.js` were in the first revision of this PR and have been reverted; all three sit inside the 142-file closure.

**The catalog holds 302 elements and 56 behaviors both before and after this change**, with zero parse errors.

## Changes

19 findings closed across 10 files, all outside the catalog import closure:

* **`addons/easyshare/elements/nuxeo-easyshare-share-link.js`** (2): `document?.type`, and `_debouncer?.isActive()`.
* **`addons/nuxeo-csv/elements/nuxeo-document-import-csv.js`** (1): `changeRecord.value?.indexSplices`.
* **`addons/nuxeo-wopi/elements/nuxeo-wopi-link.js`** (2): `this.blob?.wopi?.appName?.toLowerCase()` — an empty `appName` already yielded a falsy result, so the `''` case is unchanged.
* **`addons/nuxeo-platform-3d/elements/nuxeo-3d-viewer.js`** (3): `data.cameras?.length` and similar; all feed `if` conditions. No file under `loaders/**` or `controls/**` is touched (AC 4).
* **`addons/amazon-s3-online-storage/index.js`** (2): credential-expiry guard and the `Nuxeo?.UI?.config?.s3` bootstrap check.
* **`addons/nuxeo-spreadsheet/app/app.js`** (2), **`app/lib/select2-editor.js`** (2), **`app/ui/editors/image.js`** (1), **`app/ui/spreadsheet.js`** (3): the safe subset of the spreadsheet findings. Each left-hand side is an object or `navigator.language`, never `0`/`''`.

Plus one file that *is* in the closure but gains no `?.`:

* **`elements/nuxeo-document-create-button/nuxeo-document-create-button.js`** (1): **guard deleted rather than converted.** The ternary sits in the `else` of a branch that has already tested `contextParameters.subtypes`, so it could only ever take its truthy arm. Removing the dead guard closes the finding without adding syntax the analyzer chokes on.

Also adds **`addons/easyshare/test/nuxeo-easyshare-share-link.test.js`**, covering `_isEasyshare` and `_copyLink` including the early-return branch, so every instrumented line this PR touches is covered on new code.

### The 187 findings deliberately left open

| Reason | Count |
|---|---|
| File contributes an element/behavior to the catalog today — converting removes it | 96 |
| Reachable from a catalog entry point only through an importer that already fails to parse | 76 |
| No catalog element, but coverage-excluded — no unit test would catch a mistake | 9 |
| Sonar measures the file but the test runner does not instrument it, so edits land at 0% on new code | 4 |
| `&&` and `?.` genuinely differ on a falsy-but-not-nullish left-hand side | 2 |

The sharpest semantic case is `elements/routing.js:48`, `isTrustedDomain`. Converting it would compare `undefined === undefined` and return `true` where the `&&` chain returns `undefined` — a security-relevant change, not a style one. It falls in the second row above as well.

That second row is worth flagging on its own: those elements are **already** absent from the Designer catalog on both LTS lines today, because their importers picked up `?.` at some point in the past. Converting them is inert right now, but it enlarges the repair when that pre-existing regression is fixed. That regression is not caused by this PR and is not addressed here.

## Test plan

- [x] `npm run lint` passes (ESLint + Prettier, all 11 files)
- [x] Designer catalog verified via a full `polymer-analyzer` run over the real entry points: **302 elements / 56 behaviors, identical before and after**, zero parse errors
- [x] Each changed file additionally checked against the 142-file source-import closure: none of them is in it except `nuxeo-document-create-button.js`, which adds no `?.`
- [x] New-code coverage: 8 instrumented lines touched, **0 uncovered** — the 90% gate does not regress
- [x] `npm test` — 2772 pass. One unrelated pre-existing failure locally (`nuxeo-search-form` "always visible label"), caused by a stale local `@nuxeo/nuxeo-ui-elements` in this checkout; CI installs the required version and passes. Untouched by this PR.
- [ ] CI green on lint, unit test, a11y, ftest, sonar and build

## Notes

* **Paired PR.** The same change is opened against the other LTS line; the two diffs are byte-for-byte identical (both branches carry the same 206 findings in the same 73 files at the same line numbers).
* **Deviation from the ticket plan.** The ticket asks for four batches per branch and for all 207 findings to be closed or marked Won't Fix (AC 1). The catalog constraint makes a full sweep impossible without a `polymer-analyzer` upgrade, which is explicitly out of scope here. This PR is deliberately the conservative subset; the 187 remaining findings need a Won't Fix disposition in SonarCloud, which is follow-up work.
* **Unblocking the rest** would mean upgrading `polymer-analyzer` (or replacing it) in `packages/nuxeo-designer-catalog`. That is a separate ticket with its own risk surface, since it changes how the customer-facing catalog is produced.
* Every finding was classified individually against an analyzer run, a coverage report and a read of the left-hand side — not by pattern match.


[WEBUI-2246]: https://hyland.atlassian.net/browse/WEBUI-2246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ