### PR TITLE
chore: recover Jira/PR hygiene guidance from closed PR #3368 [maintenance-3.1.x]

### DIFF
--- a/.agents/skills/fix-nuxeo-web-ui-bug/SKILL.md
+++ b/.agents/skills/fix-nuxeo-web-ui-bug/SKILL.md
@@ -347,6 +347,64 @@ This is the "commit and raise PR" trigger.
   `unknown_key` means the signing key isn't added on GitHub as a **Signing Key** (separate
   from an Authentication key) — fix that, no re-push needed.
 
+## Phase 6.5 — Link every PR on the Jira issue as a remote **web link** (MANDATORY)
+> ### ⛔ NON-NEGOTIABLE — this is a separate action, not a side effect of anything else
+> The moment a PR exists, add it to the ticket as a Jira **remote web link** (what shows under the
+> issue's *Web links* / *Links* section). This is the step that keeps getting skipped; treat it as part
+> of "raise the PR", not as paperwork for later.
+
+**None of these count as done.** If you only did one of them, the step is still outstanding:
+- ❌ pasting the PR URL inside a Jira **comment** (Phase 7.5 does that too — it is *not* a web link);
+- ❌ the **PR title / branch name containing `WEBUI-<id>`** (that is a GitHub-side convention);
+- ❌ a link **on the GitHub side** pointing at the Jira issue, or the Jira dev-panel/Smart-Commit
+  integration picking the key up (it may never fire — do not rely on it);
+- ❌ an **issue link** created with `createIssueLink` (that links Jira issue ↔ Jira issue only and
+  rejects a URL).
+
+**The Atlassian MCP cannot do this — there is no create-remote-link tool.** It exposes only
+`getJiraIssueRemoteIssueLinks` (read) and `createIssueLink` (issue↔issue). Reaching for MCP here finds
+nothing and is exactly the trap that makes this step get dropped. **The Jira REST `remotelink`
+endpoint is the required path**, with the same `~/.jira_email` / `~/.jira_token` credentials used for
+attachments (Phase 7.5).
+
+1. **Create one remote link per PR — including every backport** (so two links for the standard
+   `lts-2025` + `maintenance-3.1.x` pair). `globalId` = the PR URL makes it an **upsert**, so
+   re-running is idempotent and never duplicates:
+   ```bash
+   U="$(cat ~/.jira_email):$(cat ~/.jira_token)"
+   TICKET=WEBUI-<id>
+   SUMMARY="<the ticket summary>"
+   for E in <pr1>:lts-2025 <pr2>:maintenance-3.1.x; do   # one entry per PR opened for this ticket
+     N=${E%%:*}; B=${E##*:}; URL="https://github.com/nuxeo/nuxeo-web-ui/pull/$N"
+     curl -s -u "$U" -H "Content-Type: application/json" -X POST \
+       "https://hyland.atlassian.net/rest/api/3/issue/$TICKET/remotelink" \
+       -d "{\"globalId\":\"$URL\",
+            \"application\":{\"type\":\"com.github\",\"name\":\"GitHub\"},
+            \"relationship\":\"mentioned in\",
+            \"object\":{\"url\":\"$URL\",\"title\":\"PR #$N — $TICKET: $SUMMARY ($B)\",
+              \"icon\":{\"url16x16\":\"https://github.githubassets.com/favicon.ico\",\"title\":\"GitHub\"}}}"
+   done
+   ```
+   Expect `201` (created) or `200` (updated) per PR; anything else means it did **not** land.
+2. **Verify by reading the links back and asserting one per PR.** Do not take the POST response as
+   proof — `GET /remotelink` is the check, and it must list every PR:
+   ```bash
+   curl -s -u "$U" "https://hyland.atlassian.net/rest/api/3/issue/$TICKET/remotelink" \
+     | PRS="<pr1> <pr2>" python3 -c "
+   import json,os,sys
+   links=json.load(sys.stdin)
+   for l in links: print('•', l['object']['title'], '->', l['object']['url'])
+   have={(l.get('globalId') or '').rsplit('/',1)[-1] for l in links}
+   missing=set(os.environ['PRS'].split())-have
+   print('❌ MISSING remote web link for PR(s):', sorted(missing)) if missing else print('✅ one remote web link per PR')
+   sys.exit(1 if missing else 0)"
+   ```
+3. **Print the resulting link titles/URLs** in your summary so the state is on the record. If a PR is
+   opened later (e.g. a second backport), come back and add its link too.
+
+**Exit gate:** the `GET /remotelink` check above exits 0 — one remote web link per PR opened for this
+ticket, backports included.
+
 ## Phase 7 — Watch checks; fix or rerun
 ```bash
 gh pr view <pr> --repo nuxeo/nuxeo-web-ui --json statusCheckRollup \

--- a/.agents/skills/jira/create-qa-subtask/SKILL.md
+++ b/.agents/skills/jira/create-qa-subtask/SKILL.md
@@ -40,6 +40,9 @@ listed, call `mcp_auth` for the Atlassian server first.
   *Issue / Root cause / Fix provided / Steps to reproduce / Steps to verify / Areas affected*
   produced by the `fix-nuxeo-web-ui-bug` skill) and for **PR links**. Also check
   `getJiraIssueRemoteIssueLinks` for linked PRs if the comments don't have them.
+  If the PRs are known but have **no remote web link** on the parent, that's a gap on the parent —
+  add them per [`fix-nuxeo-web-ui-bug` → Phase 6.5](../../fix-nuxeo-web-ui-bug/SKILL.md#phase-65--link-every-pr-on-the-jira-issue-as-a-remote-web-link-mandatory)
+  while you're here, so QA can reach the PRs from the ticket.
 - **Metadata to inherit** — `components` (copy to the sub-task), `fixVersions`, `priority`.
 
 If the fix details are missing (no fix-summary comment, no PRs, ticket not yet resolved), do NOT

--- a/.agents/skills/nuxeo-web-ui-pr-checks/SKILL.md
+++ b/.agents/skills/nuxeo-web-ui-pr-checks/SKILL.md
@@ -21,10 +21,17 @@ run the same checks that gate the PR, and **only push if they pass**.
 | **Lint** (`lint.yaml`) | `npm run lint` (eslint + `prettier --list-different`) | Yes — fast |
 | **Test** (`test.yaml`) | `npm run test` (web-test-runner `--coverage`) | Yes — ~2 min |
 | A11y (`a11y.yaml`) | `mvn -B -ntp install` + `mvn -B -ntp -f plugin/a11y install` | Optional — needs Java + npm token + repo creds |
+| Ftest (`ftest`, cross-repo `web-ui`) | `npm run ftest` (WebdriverIO + a running Nuxeo server) | No — tens of minutes |
 | Sonar / full build | push-only (`main.yaml`) | No — not a PR gate |
 
 `npm run lint` and `npm run test` are the gate developers must reproduce locally.
 A11y/build/sonar need Maven and secrets, so they're not part of the fast pre-push loop.
+
+**Don't wait on the functional tests.** `ftest` (and the cross-repo `web-ui` check) boots a Nuxeo
+server and drives a browser suite, so it runs for tens of minutes — never poll it locally or in CI
+while a task is in flight. Push once lint + unit are green, snapshot the ftest state, and report it as
+"still running, not waited on". Look at it only once it has reported **failed**; if the failure can't
+plausibly come from the change, re-run the job rather than investigating it.
 
 ## Run the gate
 

--- a/.agents/skills/nuxeo-web-ui-pr-checks/scripts/pr-checks.sh
+++ b/.agents/skills/nuxeo-web-ui-pr-checks/scripts/pr-checks.sh
@@ -40,15 +40,20 @@ npm run lint || fail "lint failed - run with --fix (or 'npm run format'), commit
 step "npm test"
 if ! npm test; then
   # Most common local-only cause: npm install replaced the nuxeo-elements symlinks.
-  if [ -e node_modules/@nuxeo/nuxeo-ui-elements ] && [ ! -L node_modules/@nuxeo/nuxeo-ui-elements ] && [ -d ../nuxeo-elements ]; then
-    cat >&2 <<'HINT'
+  if [ -e node_modules/@nuxeo/nuxeo-ui-elements ] && [ ! -L node_modules/@nuxeo/nuxeo-ui-elements ]; then
+    # Prefer this run's own elements clone; fall back to the sibling reference checkout.
+    EL="${NX_ELEMENTS:-$(cd .. 2>/dev/null && pwd)/nuxeo-elements}"
+    if [ -d "$EL" ]; then
+      cat >&2 <<HINT
 
-Hint: @nuxeo packages are not symlinked to ../nuxeo-elements (a prior `npm install`
-likely replaced them). Re-link and retry:
-  rm -rf node_modules/@nuxeo/nuxeo-ui-elements && ln -s ../../../nuxeo-elements/ui node_modules/@nuxeo/nuxeo-ui-elements
-  rm -rf node_modules/@nuxeo/nuxeo-elements && ln -s ../../../nuxeo-elements/core node_modules/@nuxeo/nuxeo-elements
-  rm -rf node_modules/@nuxeo/nuxeo-dataviz-elements && ln -s ../../../nuxeo-elements/dataviz node_modules/@nuxeo/nuxeo-dataviz-elements
+Hint: @nuxeo packages are not symlinked to $EL (a prior \`npm install\`
+likely replaced them). Re-link with ABSOLUTE paths and retry — relative links resolve
+against whatever sits beside the checkout, which cross-wires parallel ticket workspaces:
+  rm -rf node_modules/@nuxeo/nuxeo-ui-elements && ln -s "$EL/ui" node_modules/@nuxeo/nuxeo-ui-elements
+  rm -rf node_modules/@nuxeo/nuxeo-elements && ln -s "$EL/core" node_modules/@nuxeo/nuxeo-elements
+  rm -rf node_modules/@nuxeo/nuxeo-dataviz-elements && ln -s "$EL/dataviz" node_modules/@nuxeo/nuxeo-dataviz-elements
 HINT
+    fi
   fi
   fail "unit tests failed"
 fi

--- a/.agents/skills/nuxeo-web-ui-pr/SKILL.md
+++ b/.agents/skills/nuxeo-web-ui-pr/SKILL.md
@@ -81,6 +81,19 @@ EOF
 )"
 ```
 
+## After opening each PR — link it on the Jira issue (required)
+
+Every PR must also appear on the ticket as a Jira **remote web link** (the issue's *Web links* /
+*Links* section) — one link per PR, backports included. A PR URL pasted in a Jira **comment**, a PR
+**title containing `WEBUI-<id>`**, or a GitHub-side link do **not** satisfy this, and the Atlassian MCP
+has **no** create-remote-link tool (only `getJiraIssueRemoteIssueLinks` to read, and `createIssueLink`
+for issue↔issue links), so it must go through the Jira REST `remotelink` endpoint.
+
+Canonical procedure, with the ready-to-run `curl` (idempotent via `globalId`) and the
+`GET /remotelink` verification:
+[`fix-nuxeo-web-ui-bug` → Phase 6.5](../fix-nuxeo-web-ui-bug/SKILL.md#phase-65--link-every-pr-on-the-jira-issue-as-a-remote-web-link-mandatory).
+Run it as soon as the PR exists, then confirm the link is listed before calling the PR done.
+
 ## Base branches & backports
 
 **Default rule: every fix targets BOTH bases.** For each fix, create a branch off `lts-2025`

--- a/.cursor/skills/fix-nuxeo-web-ui-bug/SKILL.md
+++ b/.cursor/skills/fix-nuxeo-web-ui-bug/SKILL.md
@@ -305,9 +305,6 @@ Tear them down in Phase 10.
   `nuxeo-elements` repo) before editing. **Print the root cause to the user** — a clear,
   explicit statement of what is actually causing the bug (file/function/line and why) — before
   making any change. Then make the **minimal** change in `nuxeo-web-ui`.
-- **When the fix lands in `nuxeo-elements`:** do **not** use optional chaining (`?.`) in
-  `core/`, `ui/`, or `dataviz/` source — Polymer lint/analyze cannot parse it and elements go
-  missing from `analysis.json`. Use explicit `&&` guards instead (see `nuxeo-elements/AGENTS.md`).
 - Keep the diff focused — do not bundle unrelated files. Capture the **after** evidence, including
   the **after video** (Phase 2 recipe) showing the fixed behavior end-to-end.
 - **Extract self-contained/cross-cutting client logic into a Polymer behavior**, don't inline it
@@ -349,6 +346,64 @@ This is the "commit and raise PR" trigger.
   `gh api repos/nuxeo/nuxeo-web-ui/commits/<sha> --jq '.commit.verification'` → `verified:true`.
   `unknown_key` means the signing key isn't added on GitHub as a **Signing Key** (separate
   from an Authentication key) — fix that, no re-push needed.
+
+## Phase 6.5 — Link every PR on the Jira issue as a remote **web link** (MANDATORY)
+> ### ⛔ NON-NEGOTIABLE — this is a separate action, not a side effect of anything else
+> The moment a PR exists, add it to the ticket as a Jira **remote web link** (what shows under the
+> issue's *Web links* / *Links* section). This is the step that keeps getting skipped; treat it as part
+> of "raise the PR", not as paperwork for later.
+
+**None of these count as done.** If you only did one of them, the step is still outstanding:
+- ❌ pasting the PR URL inside a Jira **comment** (Phase 7.5 does that too — it is *not* a web link);
+- ❌ the **PR title / branch name containing `WEBUI-<id>`** (that is a GitHub-side convention);
+- ❌ a link **on the GitHub side** pointing at the Jira issue, or the Jira dev-panel/Smart-Commit
+  integration picking the key up (it may never fire — do not rely on it);
+- ❌ an **issue link** created with `createIssueLink` (that links Jira issue ↔ Jira issue only and
+  rejects a URL).
+
+**The Atlassian MCP cannot do this — there is no create-remote-link tool.** It exposes only
+`getJiraIssueRemoteIssueLinks` (read) and `createIssueLink` (issue↔issue). Reaching for MCP here finds
+nothing and is exactly the trap that makes this step get dropped. **The Jira REST `remotelink`
+endpoint is the required path**, with the same `~/.jira_email` / `~/.jira_token` credentials used for
+attachments (Phase 7.5).
+
+1. **Create one remote link per PR — including every backport** (so two links for the standard
+   `lts-2025` + `maintenance-3.1.x` pair). `globalId` = the PR URL makes it an **upsert**, so
+   re-running is idempotent and never duplicates:
+   ```bash
+   U="$(cat ~/.jira_email):$(cat ~/.jira_token)"
+   TICKET=WEBUI-<id>
+   SUMMARY="<the ticket summary>"
+   for E in <pr1>:lts-2025 <pr2>:maintenance-3.1.x; do   # one entry per PR opened for this ticket
+     N=${E%%:*}; B=${E##*:}; URL="https://github.com/nuxeo/nuxeo-web-ui/pull/$N"
+     curl -s -u "$U" -H "Content-Type: application/json" -X POST \
+       "https://hyland.atlassian.net/rest/api/3/issue/$TICKET/remotelink" \
+       -d "{\"globalId\":\"$URL\",
+            \"application\":{\"type\":\"com.github\",\"name\":\"GitHub\"},
+            \"relationship\":\"mentioned in\",
+            \"object\":{\"url\":\"$URL\",\"title\":\"PR #$N — $TICKET: $SUMMARY ($B)\",
+              \"icon\":{\"url16x16\":\"https://github.githubassets.com/favicon.ico\",\"title\":\"GitHub\"}}}"
+   done
+   ```
+   Expect `201` (created) or `200` (updated) per PR; anything else means it did **not** land.
+2. **Verify by reading the links back and asserting one per PR.** Do not take the POST response as
+   proof — `GET /remotelink` is the check, and it must list every PR:
+   ```bash
+   curl -s -u "$U" "https://hyland.atlassian.net/rest/api/3/issue/$TICKET/remotelink" \
+     | PRS="<pr1> <pr2>" python3 -c "
+   import json,os,sys
+   links=json.load(sys.stdin)
+   for l in links: print('•', l['object']['title'], '->', l['object']['url'])
+   have={(l.get('globalId') or '').rsplit('/',1)[-1] for l in links}
+   missing=set(os.environ['PRS'].split())-have
+   print('❌ MISSING remote web link for PR(s):', sorted(missing)) if missing else print('✅ one remote web link per PR')
+   sys.exit(1 if missing else 0)"
+   ```
+3. **Print the resulting link titles/URLs** in your summary so the state is on the record. If a PR is
+   opened later (e.g. a second backport), come back and add its link too.
+
+**Exit gate:** the `GET /remotelink` check above exits 0 — one remote web link per PR opened for this
+ticket, backports included.
 
 ## Phase 7 — Watch checks; fix or rerun
 ```bash

--- a/.cursor/skills/jira/create-qa-subtask/SKILL.md
+++ b/.cursor/skills/jira/create-qa-subtask/SKILL.md
@@ -40,6 +40,9 @@ listed, call `mcp_auth` for the Atlassian server first.
   *Issue / Root cause / Fix provided / Steps to reproduce / Steps to verify / Areas affected*
   produced by the `fix-nuxeo-web-ui-bug` skill) and for **PR links**. Also check
   `getJiraIssueRemoteIssueLinks` for linked PRs if the comments don't have them.
+  If the PRs are known but have **no remote web link** on the parent, that's a gap on the parent —
+  add them per [`fix-nuxeo-web-ui-bug` → Phase 6.5](../../fix-nuxeo-web-ui-bug/SKILL.md#phase-65--link-every-pr-on-the-jira-issue-as-a-remote-web-link-mandatory)
+  while you're here, so QA can reach the PRs from the ticket.
 - **Metadata to inherit** — `components` (copy to the sub-task), `fixVersions`, `priority`.
 
 If the fix details are missing (no fix-summary comment, no PRs, ticket not yet resolved), do NOT

--- a/.cursor/skills/nuxeo-web-ui-pr-checks/SKILL.md
+++ b/.cursor/skills/nuxeo-web-ui-pr-checks/SKILL.md
@@ -21,10 +21,17 @@ run the same checks that gate the PR, and **only push if they pass**.
 | **Lint** (`lint.yaml`) | `npm run lint` (eslint + `prettier --list-different`) | Yes — fast |
 | **Test** (`test.yaml`) | `npm run test` (web-test-runner `--coverage`) | Yes — ~2 min |
 | A11y (`a11y.yaml`) | `mvn -B -ntp install` + `mvn -B -ntp -f plugin/a11y install` | Optional — needs Java + npm token + repo creds |
+| Ftest (`ftest`, cross-repo `web-ui`) | `npm run ftest` (WebdriverIO + a running Nuxeo server) | No — tens of minutes |
 | Sonar / full build | push-only (`main.yaml`) | No — not a PR gate |
 
 `npm run lint` and `npm run test` are the gate developers must reproduce locally.
 A11y/build/sonar need Maven and secrets, so they're not part of the fast pre-push loop.
+
+**Don't wait on the functional tests.** `ftest` (and the cross-repo `web-ui` check) boots a Nuxeo
+server and drives a browser suite, so it runs for tens of minutes — never poll it locally or in CI
+while a task is in flight. Push once lint + unit are green, snapshot the ftest state, and report it as
+"still running, not waited on". Look at it only once it has reported **failed**; if the failure can't
+plausibly come from the change, re-run the job rather than investigating it.
 
 ## Run the gate
 

--- a/.cursor/skills/nuxeo-web-ui-pr-checks/scripts/pr-checks.sh
+++ b/.cursor/skills/nuxeo-web-ui-pr-checks/scripts/pr-checks.sh
@@ -40,15 +40,20 @@ npm run lint || fail "lint failed - run with --fix (or 'npm run format'), commit
 step "npm test"
 if ! npm test; then
   # Most common local-only cause: npm install replaced the nuxeo-elements symlinks.
-  if [ -e node_modules/@nuxeo/nuxeo-ui-elements ] && [ ! -L node_modules/@nuxeo/nuxeo-ui-elements ] && [ -d ../nuxeo-elements ]; then
-    cat >&2 <<'HINT'
+  if [ -e node_modules/@nuxeo/nuxeo-ui-elements ] && [ ! -L node_modules/@nuxeo/nuxeo-ui-elements ]; then
+    # Prefer this run's own elements clone; fall back to the sibling reference checkout.
+    EL="${NX_ELEMENTS:-$(cd .. 2>/dev/null && pwd)/nuxeo-elements}"
+    if [ -d "$EL" ]; then
+      cat >&2 <<HINT
 
-Hint: @nuxeo packages are not symlinked to ../nuxeo-elements (a prior `npm install`
-likely replaced them). Re-link and retry:
-  rm -rf node_modules/@nuxeo/nuxeo-ui-elements && ln -s ../../../nuxeo-elements/ui node_modules/@nuxeo/nuxeo-ui-elements
-  rm -rf node_modules/@nuxeo/nuxeo-elements && ln -s ../../../nuxeo-elements/core node_modules/@nuxeo/nuxeo-elements
-  rm -rf node_modules/@nuxeo/nuxeo-dataviz-elements && ln -s ../../../nuxeo-elements/dataviz node_modules/@nuxeo/nuxeo-dataviz-elements
+Hint: @nuxeo packages are not symlinked to $EL (a prior \`npm install\`
+likely replaced them). Re-link with ABSOLUTE paths and retry — relative links resolve
+against whatever sits beside the checkout, which cross-wires parallel ticket workspaces:
+  rm -rf node_modules/@nuxeo/nuxeo-ui-elements && ln -s "$EL/ui" node_modules/@nuxeo/nuxeo-ui-elements
+  rm -rf node_modules/@nuxeo/nuxeo-elements && ln -s "$EL/core" node_modules/@nuxeo/nuxeo-elements
+  rm -rf node_modules/@nuxeo/nuxeo-dataviz-elements && ln -s "$EL/dataviz" node_modules/@nuxeo/nuxeo-dataviz-elements
 HINT
+    fi
   fi
   fail "unit tests failed"
 fi

--- a/.cursor/skills/nuxeo-web-ui-pr/SKILL.md
+++ b/.cursor/skills/nuxeo-web-ui-pr/SKILL.md
@@ -81,6 +81,19 @@ EOF
 )"
 ```
 
+## After opening each PR — link it on the Jira issue (required)
+
+Every PR must also appear on the ticket as a Jira **remote web link** (the issue's *Web links* /
+*Links* section) — one link per PR, backports included. A PR URL pasted in a Jira **comment**, a PR
+**title containing `WEBUI-<id>`**, or a GitHub-side link do **not** satisfy this, and the Atlassian MCP
+has **no** create-remote-link tool (only `getJiraIssueRemoteIssueLinks` to read, and `createIssueLink`
+for issue↔issue links), so it must go through the Jira REST `remotelink` endpoint.
+
+Canonical procedure, with the ready-to-run `curl` (idempotent via `globalId`) and the
+`GET /remotelink` verification:
+[`fix-nuxeo-web-ui-bug` → Phase 6.5](../fix-nuxeo-web-ui-bug/SKILL.md#phase-65--link-every-pr-on-the-jira-issue-as-a-remote-web-link-mandatory).
+Run it as soon as the PR exists, then confirm the link is listed before calling the PR done.
+
 ## Base branches & backports
 
 **Default rule: every fix targets BOTH bases.** For each fix, create a branch off `lts-2025`


### PR DESCRIPTION
## Problem

PR #3368 was closed without merging. Most of its content was superseded, but three small,
independently useful skill fixes went with it and exist on no base branch.

## Root cause

#3368 bundled those fixes with a broad `fix-nuxeo-web-ui-bug` rewrite. The pieces that mattered were
re-landed from mainline (WEBUI-2243, WEBUI-1786, and #3553/#3554 for `parallel-bug-fixes`), so when
the PR was finally closed these leftovers had nowhere to go.

## Changes

- **`fix-nuxeo-web-ui-bug` gains Phase 6.5** — adding a Jira **remote web link** per PR is now a
  mandatory, separately verified step. It spells out what does *not* count (a PR URL in a comment, a
  `WEBUI-<id>` in the PR title, a GitHub-side link, an issue link from `createIssueLink`), notes that
  the Atlassian MCP has **no** create-remote-link tool, and gives the idempotent `remotelink` `curl`
  plus a `GET /remotelink` assertion that exits non-zero when a PR is missing its link.
- **`nuxeo-web-ui-pr` and `jira/create-qa-subtask` cross-reference it**, so the step is found from
  wherever you are rather than rediscovered each time.
- **`nuxeo-web-ui-pr-checks` documents `ftest`** as a non-local, tens-of-minutes check: push once
  lint and unit are green, report ftest as "still running, not waited on", and only look once it has
  actually failed.
- **`pr-checks.sh` emits its broken-symlink hint with absolute paths**, preferring `$NX_ELEMENTS`.
  The old hint suggested relative links (`../../../nuxeo-elements/ui`), which resolve against whatever
  sits beside the checkout — in a per-ticket workspace that silently points every parallel run at one
  shared elements clone. The guard also no longer requires a sibling `../nuxeo-elements` to exist
  before it can fire.

## Test plan

- Docs plus one shell script. `lint:prettier` and `lint-staged` cover `**/*.{js,html}`, so neither
  Markdown nor `.sh` is in scope for the gating checks; unit tests are untouched.
- `bash -n pr-checks.sh` passes on both branches, and the rewritten heredoc was rendered with a stubbed
  `$EL` to confirm it interpolates the path and keeps the literal backticks.
- Verified the `#phase-65--…` anchor computed from the new heading matches both cross-references.
- `.agents` and `.cursor` copies are byte-identical, and both base branches carry identical diffs.

## Notes

Completes the recovery of #3368. `verify-run.sh` from that branch is deliberately **not** included —
it is a 282-line per-phase verification harness that needs its own review; it remains available on
`chore-bug-fix-skill-mcp-jira-hygiene-lts-2025` if we want it later.
